### PR TITLE
Publiser Wenche til PyPI og oppdater installasjonsinstruksjoner

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,29 @@ Har du aldri hørt om disse skjemaene? Her er en kort forklaring:
 ## Installasjon
 
 ```bash
-git clone https://github.com/ditt-brukernavn/wenche.git
+pip install wenche
+```
+
+Det er alt. Wenche er nå tilgjengelig som kommandoen `wenche` i terminalen din.
+
+> **Merk:** Det anbefales å installere i et virtuelt miljø for å unngå konflikter med andre Python-pakker:
+> ```bash
+> python3 -m venv .venv
+> source .venv/bin/activate
+> pip install wenche
+> ```
+> Husk å aktivere miljøet (`source .venv/bin/activate`) i nye terminalvinduer.
+
+### For utviklere
+
+Vil du bidra til koden eller kjøre siste versjon fra GitHub?
+
+```bash
+git clone https://github.com/olefredrik/wenche.git
 cd wenche
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -e .
-```
-
-Husk å aktivere det virtuelle miljøet hver gang du åpner en ny terminal:
-
-```bash
-source .venv/bin/activate
 ```
 
 ## Oppsett

--- a/cspell.json
+++ b/cspell.json
@@ -7,5 +7,9 @@
       "name": "nb-no",
       "path": "./node_modules/@cspell/dict-nb-no/cspell-ext.json"
     }
+  ],
+  "ignorePaths": [
+    "**/*.md",
+    "**/*.toml"
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,19 @@ description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregis
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"
+keywords = ["altinn", "skatt", "regnskap", "aksjonaerregister", "skattemelding", "holdingselskap", "norge"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: End Users/Desktop",
+    "License :: OSI Approved :: MIT License",
+    "Natural Language :: Norwegian",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Office/Business :: Financial :: Accounting",
+]
 dependencies = [
     "click>=8.1",
     "httpx>=0.27",
@@ -16,6 +29,11 @@ dependencies = [
     "python-dotenv>=1.0",
     "authlib>=1.3",
 ]
+
+[project.urls]
+Homepage = "https://github.com/olefredrik/wenche"
+Repository = "https://github.com/olefredrik/wenche"
+Issues = "https://github.com/olefredrik/wenche/issues"
 
 [project.scripts]
 wenche = "wenche.cli:main"


### PR DESCRIPTION
- Legg til keywords, classifiers og project.urls i pyproject.toml
- Oppdater README: pip install wenche er nå primær installasjonsmåte
- git clone-instruksjoner flyttes til "For utviklere"-seksjon
- Legg til *.toml i cspell.json ignorePaths