### PR TITLE
Erstatt iXBRL med korrekt BRG XML-format for årsregnskap

### DIFF
--- a/wenche/aarsregnskap.py
+++ b/wenche/aarsregnskap.py
@@ -21,7 +21,7 @@ from wenche.models import (
     Resultatregnskap,
     Selskap,
 )
-from wenche.xbrl import generer_ixbrl
+from wenche.brg_xml import generer_hovedskjema, generer_underskjema
 
 
 def les_config(config_fil: str) -> Aarsregnskap:
@@ -122,7 +122,14 @@ def send_inn(regnskap: Aarsregnskap, klient: AltinnClient, dry_run: bool = False
     """
     Sender inn årsregnskapet til Brønnøysundregistrene via Altinn.
 
-    dry_run=True genererer og validerer iXBRL-dokumentet uten å sende.
+    Flyten er:
+      1. Opprett instans → Altinn oppretter data-elementer automatisk
+      2. PUT Hovedskjema (selskapsinfo, periode, prinsipper)
+      3. PUT Underskjema (resultatregnskap og balanse)
+      4. process/next med action=confirm
+      5. process/next med action=sign
+
+    dry_run=True skriver XML-filene lokalt uten å sende til Altinn.
     """
     feil = valider(regnskap)
     if feil:
@@ -133,25 +140,41 @@ def send_inn(regnskap: Aarsregnskap, klient: AltinnClient, dry_run: bool = False
 
     print("Validering OK.")
 
-    ixbrl = generer_ixbrl(regnskap)
-    print(f"iXBRL-dokument generert ({len(ixbrl):,} bytes).")
+    hovedskjema = generer_hovedskjema(regnskap)
+    underskjema = generer_underskjema(regnskap)
+    org = regnskap.selskap.org_nummer
+    aar = regnskap.regnskapsaar
+    print(f"XML generert: Hovedskjema {len(hovedskjema):,} bytes, Underskjema {len(underskjema):,} bytes.")
 
     if dry_run:
-        utfil = f"aarsregnskap_{regnskap.regnskapsaar}_{regnskap.selskap.org_nummer}.html"
-        with open(utfil, "wb") as f:
-            f.write(ixbrl)
-        print(f"Dry-run: dokument lagret til {utfil} — ingenting sendt til Altinn.")
+        hoved_fil = f"aarsregnskap_{aar}_{org}_hovedskjema.xml"
+        under_fil = f"aarsregnskap_{aar}_{org}_underskjema.xml"
+        with open(hoved_fil, "wb") as f:
+            f.write(hovedskjema)
+        with open(under_fil, "wb") as f:
+            f.write(underskjema)
+        print(f"Dry-run: filer lagret til {hoved_fil} og {under_fil} — ingenting sendt til Altinn.")
         return
 
     print("Sender årsregnskap til Brønnøysundregistrene via Altinn...")
-    instans = klient.opprett_instans("aarsregnskap", regnskap.selskap.org_nummer)
-    klient.last_opp_data(
-        "aarsregnskap",
-        instans,
-        data=ixbrl,
-        content_type="application/xhtml+xml",
-        data_type="aarsregnskap",
+    instans = klient.opprett_instans("aarsregnskap", org)
+
+    klient.oppdater_data_element(
+        "aarsregnskap", instans,
+        data_type="Hovedskjema",
+        data=hovedskjema,
+        content_type="application/xml",
     )
+    print("Hovedskjema lastet opp.")
+
+    klient.oppdater_data_element(
+        "aarsregnskap", instans,
+        data_type="Underskjema",
+        data=underskjema,
+        content_type="application/xml",
+    )
+    print("Underskjema lastet opp.")
+
     klient.fullfoor_instans("aarsregnskap", instans)
 
     status = klient.hent_status("aarsregnskap", instans)

--- a/wenche/altinn_client.py
+++ b/wenche/altinn_client.py
@@ -65,21 +65,23 @@ class AltinnClient:
         print(f"Instans opprettet: {instans['id']}")
         return instans
 
-    def last_opp_data(
+    def oppdater_data_element(
         self,
         app_key: str,
         instans: dict,
+        data_type: str,
         data: bytes,
         content_type: str,
-        data_type: str = "default",
     ) -> dict:
-        """Laster opp skjemadata til en eksisterende instans."""
-        instance_id = instans["id"]          # format: partyId/instanceGuid
-        url = (
-            f"{self._app_base(app_key)}/instances/{instance_id}"
-            f"/data?dataType={data_type}"
-        )
-        resp = self._http.post(
+        """
+        Oppdaterer et eksisterende data-element i instansen med PUT.
+        Altinn oppretter data-elementene automatisk ved instansoppretting;
+        vi finner riktig element via dataType og erstatter innholdet.
+        """
+        instance_id = instans["id"]
+        element_id = self._finn_data_element_id(instans, data_type)
+        url = f"{self._app_base(app_key)}/instances/{instance_id}/data/{element_id}"
+        resp = self._http.put(
             url,
             content=data,
             headers={"Content-Type": content_type},
@@ -87,13 +89,32 @@ class AltinnClient:
         resp.raise_for_status()
         return resp.json()
 
+    def _finn_data_element_id(self, instans: dict, data_type: str) -> str:
+        """Finner data-element ID for gitt dataType i instansens data-array."""
+        for element in instans.get("data", []):
+            if element.get("dataType") == data_type:
+                return element["id"]
+        raise ValueError(
+            f"Fant ikke data-element med dataType='{data_type}' i instansen. "
+            f"Tilgjengelige typer: {[e.get('dataType') for e in instans.get('data', [])]}"
+        )
+
     def fullfoor_instans(self, app_key: str, instans: dict) -> None:
-        """Sender inn instansen (setter prosess til neste steg — 'submit')."""
+        """
+        Fullfører innsending i to steg:
+          1. confirm — bekrefter og flytter instansen til signeringssteg
+          2. sign    — signerer og sender inn
+        """
         instance_id = instans["id"]
         url = f"{self._app_base(app_key)}/instances/{instance_id}/process/next"
-        resp = self._http.put(url)
+
+        resp = self._http.put(url, json={"action": "confirm"})
         resp.raise_for_status()
-        print("Innsending fullfort.")
+        print("Instans bekreftet (confirm).")
+
+        resp = self._http.put(url, json={"action": "sign"})
+        resp.raise_for_status()
+        print("Innsending signert og fullfort.")
 
     def hent_status(self, app_key: str, instans: dict) -> dict:
         """Henter status for en instans."""

--- a/wenche/brg_xml.py
+++ b/wenche/brg_xml.py
@@ -1,0 +1,303 @@
+"""
+Generering av BRG XML-dokumenter for årsregnskap.
+
+Brønnøysundregistrene krever to separate XML-dokumenter ved innsending via Altinn:
+  - Hovedskjema (RR-0002): selskapsinfo, regnskapsperiode, prinsipper, fastsettelse
+  - Underskjema (RR-0002U): selve tallene — resultatregnskap og balanse
+
+Namespace og orid-verdier er hentet fra BRGs offisielle Postman-eksempler:
+https://brreg.github.io/docs/apidokumentasjon/regnskapsregisteret/maskinell-innrapportering/
+"""
+
+import uuid
+from datetime import date
+
+from wenche.models import Aarsregnskap
+
+
+def _row_id() -> str:
+    return str(uuid.uuid4())
+
+
+def generer_hovedskjema(regnskap: Aarsregnskap) -> bytes:
+    """
+    Genererer Hovedskjema XML (dataType=Hovedskjema, dataFormatId=1266).
+    Inneholder selskapsinfo, regnskapsperiode, prinsipper og fastsettelse.
+    """
+    s = regnskap.selskap
+    aar = regnskap.regnskapsaar
+    fastsettelsesdato = regnskap.fastsettelsesdato or date.today()
+    signatar = regnskap.signatar or s.daglig_leder
+    revideres = "nei" if not regnskap.revideres else "ja"
+    ikke_revideres = "ja" if not regnskap.revideres else "nei"
+
+    xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+<melding xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+         xmlns="http://schema.brreg.no/regnsys/aarsregnskap_vanlig"
+         dataFormatId="1266"
+         dataFormatVersion="51820"
+         tjenestehandling="aarsregnskap_vanlig"
+         tjeneste="regnskap">
+  <Innsender>
+    <enhet>
+      <organisasjonsnummer orid="18">{s.org_nummer}</organisasjonsnummer>
+      <organisasjonsform orid="756">AS</organisasjonsform>
+      <navn orid="1">{s.navn}</navn>
+    </enhet>
+  </Innsender>
+  <Skjemainnhold>
+    <regnskapsperiode>
+      <regnskapsaar orid="17102">{aar}</regnskapsaar>
+      <regnskapsstart orid="17103">{aar}-01-01</regnskapsstart>
+      <regnskapsslutt orid="17104">{aar}-12-31</regnskapsslutt>
+    </regnskapsperiode>
+    <konsern>
+      <morselskap orid="4168">nei</morselskap>
+      <konsernregnskap orid="25943">nei</konsernregnskap>
+    </konsern>
+    <regnskapsprinsipper>
+      <smaaForetak orid="8079">ja</smaaForetak>
+      <regnskapsreglerSelskap orid="25021">nei</regnskapsreglerSelskap>
+      <forenkletIFRS orid="36639">nei</forenkletIFRS>
+    </regnskapsprinsipper>
+    <fastsettelse>
+      <fastsettelsedato orid="17105">{fastsettelsesdato.isoformat()}</fastsettelsedato>
+      <bekreftendeSelskapsrepresentant orid="19023">{signatar}</bekreftendeSelskapsrepresentant>
+    </fastsettelse>
+    <revisjonRegnskapsfoerer>
+      <aarsregnskapIkkeRevideres orid="34669">{ikke_revideres}</aarsregnskapIkkeRevideres>
+      <aarsregnskapUtarbeidetAutorisertRegnskapsfoerer orid="34670">nei</aarsregnskapUtarbeidetAutorisertRegnskapsfoerer>
+      <tjenestebistandEksternAutorisertRegnskapsfoerer orid="34671">nei</tjenestebistandEksternAutorisertRegnskapsfoerer>
+    </revisjonRegnskapsfoerer>
+    <aarsberetning/>
+  </Skjemainnhold>
+</melding>"""
+    return xml.encode("utf-8")
+
+
+def generer_underskjema(regnskap: Aarsregnskap) -> bytes:
+    """
+    Genererer Underskjema XML (dataType=Underskjema, dataFormatId=758).
+    Inneholder resultatregnskap og balanse med BRGs orid-verdier.
+    """
+    r = regnskap.resultatregnskap
+    b = regnskap.balanse
+
+    # Hjelpefunksjon: lager linjeelement med altinnRowId kun hvis verdi != 0
+    def linje(tag: str, verdi: int, besk: str, orid_besk: str,
+              orid_aarets: str, orid_fjor: str) -> str:
+        if verdi == 0:
+            return ""
+        return (
+            f'<{tag} altinnRowId="{_row_id()}">'
+            f'<beskrivelse orid="{orid_besk}">{besk}</beskrivelse>'
+            f'<aarets orid="{orid_aarets}">{verdi}</aarets>'
+            f'<fjoraarets orid="{orid_fjor}">0</fjoraarets>'
+            f'</{tag}>'
+        )
+
+    # Beregnede verdier
+    di = r.driftsinntekter
+    dk = r.driftskostnader
+    fp = r.finansposter
+    ei = b.eiendeler
+    am = ei.anleggsmidler
+    om = ei.omloepmidler
+    ek = b.egenkapital_og_gjeld.egenkapital
+    lg = b.egenkapital_og_gjeld.langsiktig_gjeld
+    kg = b.egenkapital_og_gjeld.kortsiktig_gjeld
+
+    netto_finans = fp.sum_inntekter - fp.sum_kostnader
+    sum_gjeld = lg.sum + kg.sum
+    sum_innskutt_ek = ek.aksjekapital + ek.overkursfond
+
+    xml = f"""<?xml version="1.0" encoding="UTF-8"?>
+<melding xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+         xmlns="http://schema.brreg.no/regnsys/aarsregnskap_vanlig/underskjema"
+         dataFormatId="758"
+         dataFormatVersion="51980"
+         tjenestehandling="aarsregnskap_vanlig_underskjema"
+         tjeneste="regnskap">
+  <Rapport-RR0002U>
+    <aarsregnskap>
+      <regnskapstype orid="25942">S</regnskapstype>
+      <valuta orid="34984">NOK</valuta>
+      <valoer orid="28974">H</valoer>
+    </aarsregnskap>
+  </Rapport-RR0002U>
+  <Skjemainnhold-RR0002U>
+
+    <resultatregnskapDriftsresultat>
+      <driftsresultat>
+        <aarets orid="146">{r.driftsresultat}</aarets>
+        <fjoraarets orid="7026">0</fjoraarets>
+      </driftsresultat>
+      <inntekt>
+        {linje("salgsinntekt", di.salgsinntekter, "Salgsinntekter", "28998", "1340", "7965")}
+        {linje("driftsinntekt", di.andre_driftsinntekter, "Andre driftsinntekter", "28999", "7709", "7966")}
+        <driftsinntektSum>
+          <aarets orid="72">{di.sum}</aarets>
+          <fjoraarets orid="6972">0</fjoraarets>
+        </driftsinntektSum>
+      </inntekt>
+      <kostnad>
+        {linje("loennskostnad", dk.loennskostnader, "Lønnskostnader", "29001", "81", "6979")}
+        {linje("avskrivning", dk.avskrivninger, "Avskrivninger", "29002", "2139", "10181")}
+        {linje("annenDriftskostnad", dk.andre_driftskostnader, "Andre driftskostnader", "29003", "82", "7023")}
+        <sumDriftskostnad>
+          <aarets orid="17126">{dk.sum}</aarets>
+          <fjoraarets orid="17127">0</fjoraarets>
+        </sumDriftskostnad>
+      </kostnad>
+    </resultatregnskapDriftsresultat>
+
+    <resultatregnskapFinansinntekt>
+      <nettoFinans>
+        <aarets orid="158">{netto_finans}</aarets>
+        <fjoraarets orid="7999">0</fjoraarets>
+      </nettoFinans>
+      <finansinntekt>
+        {linje("investeringDatterforetakTilknyttetSelskap", fp.utbytte_fra_datterselskap, "Utbytte fra datterselskap", "29004", "27934", "27935")}
+        {linje("annenRenteinntekt", fp.andre_finansinntekter, "Andre finansinntekter", "29006", "152", "7032")}
+        <sumFinansinntekter>
+          <aarets orid="153">{fp.sum_inntekter}</aarets>
+          <fjoraarets orid="7993">0</fjoraarets>
+        </sumFinansinntekter>
+      </finansinntekt>
+      <finanskostnad>
+        {linje("rentekostnad", fp.rentekostnader, "Rentekostnader", "29009", "7037", "7038")}
+        {linje("annenFinanskostnad", fp.andre_finanskostnader, "Andre finanskostnader", "29011", "156", "7041")}
+        <sumFinanskostnader>
+          <aarets orid="17130">{fp.sum_kostnader}</aarets>
+          <fjoraarets orid="17131">0</fjoraarets>
+        </sumFinanskostnader>
+      </finanskostnad>
+    </resultatregnskapFinansinntekt>
+
+    <resultatregnskapResultat>
+      <resultat>
+        <resultatFoerSkattekostnad>
+          <aarets orid="167">{r.resultat_foer_skatt}</aarets>
+          <fjoraarets orid="7042">0</fjoraarets>
+        </resultatFoerSkattekostnad>
+        <aarsresultat>
+          <aarets orid="172">{r.aarsresultat}</aarets>
+          <fjoraarets orid="7054">0</fjoraarets>
+        </aarsresultat>
+      </resultat>
+      <overfoeringer>
+        <sumOverfoeringerOgDisponeringer>
+          <aarets orid="7067">0</aarets>
+          <fjoraarets orid="7068">0</fjoraarets>
+        </sumOverfoeringerOgDisponeringer>
+      </overfoeringer>
+    </resultatregnskapResultat>
+
+    <balanseAnleggsmidlerOmloepsmidler>
+      <sumEiendeler>
+        <aarets orid="219">{ei.sum}</aarets>
+        <fjoraarets orid="7127">0</fjoraarets>
+      </sumEiendeler>
+      <balanseAnleggsmidler>
+        <sumAnleggsmidler>
+          <aarets orid="217">{am.sum}</aarets>
+          <fjoraarets orid="7108">0</fjoraarets>
+        </sumAnleggsmidler>
+        <balanseFinansielleAnleggsmidler>
+          {linje("investeringDatterselskap", am.aksjer_i_datterselskap, "Aksjer i datterselskap", "29017", "9686", "10289")}
+          {linje("investeringAnnetForetakSammeKonsern", am.andre_aksjer, "Andre aksjer", "29018", "7727", "8012")}
+          {linje("laanForetakSammeKonsern", am.langsiktige_fordringer, "Langsiktige fordringer", "29019", "6500", "7093")}
+          <sumFinansielleAnleggsmidler>
+            <aarets orid="5267">{am.sum}</aarets>
+            <fjoraarets orid="8014">0</fjoraarets>
+          </sumFinansielleAnleggsmidler>
+        </balanseFinansielleAnleggsmidler>
+      </balanseAnleggsmidler>
+      <balanseOmloepsmidler>
+        <sumOmloepsmidler>
+          <aarets orid="194">{om.sum}</aarets>
+          <fjoraarets orid="7126">0</fjoraarets>
+        </sumOmloepsmidler>
+        <balanseOmloepsmidlerVarerFordringer>
+          <fordringer>
+            {linje("andreFordringer", om.kortsiktige_fordringer, "Kortsiktige fordringer", "29028", "282", "7112")}
+            <sumFordringer>
+              <aarets orid="80">{om.kortsiktige_fordringer}</aarets>
+              <fjoraarets orid="8015">0</fjoraarets>
+            </sumFordringer>
+          </fordringer>
+        </balanseOmloepsmidlerVarerFordringer>
+        <balanseOmloepsmidlerInvesteringerBankinnskuddKontanter>
+          <bankinnskuddKontanter>
+            {linje("bankinnskuddKontanter", om.bankinnskudd, "Bankinnskudd", "29031", "786", "8019")}
+            <sumBankinnskuddKontanter>
+              <aarets orid="29042">{om.bankinnskudd}</aarets>
+              <fjoraarets orid="29043">0</fjoraarets>
+            </sumBankinnskuddKontanter>
+          </bankinnskuddKontanter>
+        </balanseOmloepsmidlerInvesteringerBankinnskuddKontanter>
+      </balanseOmloepsmidler>
+    </balanseAnleggsmidlerOmloepsmidler>
+
+    <balanseEgenkapitalGjeld>
+      <sumEgenkapitalGjeld>
+        <aarets orid="251">{b.egenkapital_og_gjeld.sum}</aarets>
+        <fjoraarets orid="7185">0</fjoraarets>
+      </sumEgenkapitalGjeld>
+      <balanseEgenkapitalInnskuttOpptjentEgenkapital>
+        <innskuttEgenkapital>
+          {linje("selskapskapital", ek.aksjekapital, "Aksjekapital", "29032", "20488", "20489")}
+          {linje("overkursfond", ek.overkursfond, "Overkursfond", "29033", "2585", "7135")}
+          <sumInnskuttEgenkapital>
+            <aarets orid="3730">{sum_innskutt_ek}</aarets>
+            <fjoraarets orid="9984">0</fjoraarets>
+          </sumInnskuttEgenkapital>
+        </innskuttEgenkapital>
+        <opptjentEgenkaiptal>
+          {linje("annenEgenkapital", ek.annen_egenkapital, "Annen egenkapital", "29034", "3274", "7140")}
+          <sumOpptjentEgenkapital>
+            <aarets orid="9702">{ek.annen_egenkapital}</aarets>
+            <fjoraarets orid="9985">0</fjoraarets>
+          </sumOpptjentEgenkapital>
+          <sumEgenkapital>
+            <aarets orid="250">{ek.sum}</aarets>
+            <fjoraarets orid="7142">0</fjoraarets>
+          </sumEgenkapital>
+        </opptjentEgenkaiptal>
+      </balanseEgenkapitalInnskuttOpptjentEgenkapital>
+      <balanseGjeldOversikt>
+        <sumGjeld>
+          <aarets orid="1119">{sum_gjeld}</aarets>
+          <fjoraarets orid="7184">0</fjoraarets>
+        </sumGjeld>
+        <balanseGjeldAvsetningerForpliktelserAnnenLangsiktigGjeld>
+          <sumLangsiktigGjeld>
+            <aarets orid="86">{lg.sum}</aarets>
+            <fjoraarets orid="7156">0</fjoraarets>
+          </sumLangsiktigGjeld>
+          <annenLangsiktigGjeld>
+            {linje("langsiktigKonserngjeld", lg.laan_fra_aksjonaer, "Lån fra aksjonær", "29035", "2256", "7152")}
+            {linje("oevrigLangsiktigGjeld", lg.andre_langsiktige_laan, "Andre langsiktige lån", "29036", "242", "7155")}
+            <sumAnnenLangsiktigGjeld>
+              <aarets orid="25019">{lg.sum}</aarets>
+              <fjoraarets orid="25020">0</fjoraarets>
+            </sumAnnenLangsiktigGjeld>
+          </annenLangsiktigGjeld>
+        </balanseGjeldAvsetningerForpliktelserAnnenLangsiktigGjeld>
+        <balanseKortsiktigGjeld>
+          {linje("leverandoergjeld", kg.leverandoergjeld, "Leverandørgjeld", "29037", "220", "7162")}
+          {linje("skyldigeOffentligeAvgifter", kg.skyldige_offentlige_avgifter, "Skyldige offentlige avgifter", "29039", "225", "7170")}
+          {linje("annenKortsiktigGjeld", kg.annen_kortsiktig_gjeld, "Annen kortsiktig gjeld", "29040", "236", "7182")}
+          <sumKortsiktigGjeld>
+            <aarets orid="85">{kg.sum}</aarets>
+            <fjoraarets orid="7183">0</fjoraarets>
+          </sumKortsiktigGjeld>
+        </balanseKortsiktigGjeld>
+      </balanseGjeldOversikt>
+    </balanseEgenkapitalGjeld>
+
+  </Skjemainnhold-RR0002U>
+</melding>"""
+    return xml.encode("utf-8")

--- a/wenche/models.py
+++ b/wenche/models.py
@@ -4,6 +4,7 @@ Fylles ut fra config.yaml og valideres før innsending.
 """
 
 from dataclasses import dataclass, field
+from datetime import date
 from typing import Optional
 
 
@@ -194,6 +195,9 @@ class Aarsregnskap:
     regnskapsaar: int
     resultatregnskap: Resultatregnskap
     balanse: Balanse
+    fastsettelsesdato: Optional[date] = None   # Dato styret godkjente regnskapet; standard: i dag
+    signatar: Optional[str] = None              # Navn på den som signerer; standard: daglig_leder
+    revideres: bool = False                     # True hvis regnskapet er revidert
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
BRG krever to proprietary XML-dokumenter, ikke iXBRL:
- Hovedskjema (dataFormatId=1266): selskapsinfo, periode, prinsipper, fastsettelse
- Underskjema (dataFormatId=758): resultatregnskap og balanse med orid-verdier

Altinn-flyten er også oppdatert:
- Bruker PUT til pre-opprettede data-elementer (ikke POST med ?dataType=)
- To-trinns process/next: confirm → sign
- orid-verdier verifisert mot BRGs offisielle Postman-eksempler

Endringer:
- wenche/brg_xml.py: ny fil som erstatter xbrl.py
- wenche/altinn_client.py: ny oppdater_data_element(), oppdatert fullfoor_instans()
- wenche/aarsregnskap.py: oppdatert send_inn() til ny flyt
- wenche/models.py: Aarsregnskap får fastsettelsesdato, signatar og revideres