### PR TITLE
Oppdater README: fjern utdatert iXBRL-referanse

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Test uten innsending først (anbefalt):
 wenche send-aarsregnskap --dry-run
 ```
 
-`--dry-run` lagrer det genererte iXBRL-dokumentet lokalt slik at du kan inspisere det.
+`--dry-run` lagrer de genererte XML-dokumentene lokalt slik at du kan inspisere dem.
 
 Send inn til Brønnøysundregistrene:
 
@@ -250,7 +250,6 @@ Alternativer (generer-skattemelding):
 
 Bidrag er velkomne. Åpne gjerne en issue eller pull request. Særlig nyttig:
 
-- Verifisering av iXBRL-format mot Brønnøysundregistrenes gjeldende taksonomi
 - Implementasjon av automatisk skattemeldingsinnsending (krever systemleverandør-registrering hos Skatteetaten)
 - Testing mot Altinn testmiljø (tt02)
 


### PR DESCRIPTION
Fjern utdatert iXBRL-referanse fra Bidra-seksjonen

iXBRL er erstattet med korrekt BRG XML-format i v0.1.5. Oppdaterer også beskrivelsen av --dry-run til å reflektere at det nå genereres to XML-filer.