### PR TITLE
Legg til MkDocs-dokumentasjon med GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,36 @@
+name: Dokumentasjon
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Installer MkDocs
+        run: pip install mkdocs-material
+      - name: Bygg dokumentasjon
+        run: mkdocs build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+      - uses: actions/deploy-pages@v4
+        id: deployment

--- a/docs/bruk.md
+++ b/docs/bruk.md
@@ -1,0 +1,133 @@
+# Bruk
+
+Wenche kan brukes enten via **kommandolinjen** eller via **webgrensesnittet** (`wenche ui`). Begge gir tilgang til de samme funksjonene.
+
+---
+
+## Skattemelding (frist 31. mai)
+
+Wenche genererer et ferdig utfylt sammendrag av RF-1167 (næringsoppgaven) og RF-1028 (skattemeldingen) basert på tallene i `config.yaml`.
+
+=== "Kommandolinje"
+
+    ```bash
+    wenche generer-skattemelding
+    ```
+
+    Lagre til fil:
+
+    ```bash
+    wenche generer-skattemelding --ut skattemelding.txt
+    ```
+
+=== "Webgrensesnitt"
+
+    Gå til fanen **Dokumenter** og klikk **Last ned skattemelding**.
+
+Sammendraget inneholder:
+
+- Alle felt i næringsoppgaven (RF-1167) ferdig utfylt
+- Skatteberegning med fritaksmetoden der det er aktuelt
+- Beregnet skatt (22 %)
+- Fremførbart underskudd hvis selskapet gikk med tap
+
+**Send inn manuelt:**
+
+1. Gå til [skatteetaten.no](https://www.skatteetaten.no/) og logg inn med BankID
+2. Åpne skattemeldingen for AS for gjeldende regnskapsår
+3. Fyll inn tallene fra sammendraget Wenche har generert
+4. Kontroller at Skatteetaten beregner samme skatt
+5. Send inn
+
+---
+
+## Årsregnskap (frist 31. juli)
+
+=== "Kommandolinje"
+
+    Test uten innsending (anbefalt første gang):
+
+    ```bash
+    wenche send-aarsregnskap --dry-run
+    ```
+
+    `--dry-run` lagrer de genererte XML-dokumentene lokalt slik at du kan inspisere dem.
+
+    Send inn:
+
+    ```bash
+    wenche login
+    wenche send-aarsregnskap
+    wenche logout
+    ```
+
+=== "Webgrensesnitt"
+
+    Gå til fanen **Send til Altinn** og klikk **Send årsregnskap**.
+
+---
+
+## Aksjonærregisteroppgave (frist 31. januar)
+
+=== "Kommandolinje"
+
+    Test uten innsending:
+
+    ```bash
+    wenche send-aksjonaerregister --dry-run
+    ```
+
+    Send inn:
+
+    ```bash
+    wenche login
+    wenche send-aksjonaerregister
+    wenche logout
+    ```
+
+=== "Webgrensesnitt"
+
+    Gå til fanen **Send til Altinn** og klikk **Send aksjonærregisteroppgave**.
+
+---
+
+## Autentisering
+
+`wenche login` autentiserer mot Maskinporten med din private RSA-nøkkel og lagrer et token lokalt i `~/.wenche/token.json`. Tokenet gjenbrukes automatisk for påfølgende kommandoer i samme sesjon.
+
+```bash
+wenche login     # Henter og lagrer token
+wenche logout    # Sletter lagret token
+```
+
+---
+
+## Alle kommandoer
+
+```
+wenche --help
+
+Kommandoer:
+  login                    Autentiser mot Maskinporten med RSA-nokkel
+  logout                   Logg ut og slett lagret token
+  generer-skattemelding    Generer ferdig utfylt RF-1167 og RF-1028 fra config.yaml
+  send-aarsregnskap        Send inn arsregnskap til Bronnoysundregistrene
+  send-aksjonaerregister   Send inn aksjonaerregisteroppgave (RF-1086)
+  ui                       Start webgrensesnittet i nettleseren
+
+Alternativer (send-aarsregnskap og send-aksjonaerregister):
+  --config TEXT            Sti til konfigurasjonsfil [standard: config.yaml]
+  --dry-run                Generer dokument lokalt uten a sende til Altinn
+
+Alternativer (generer-skattemelding):
+  --config TEXT            Sti til konfigurasjonsfil [standard: config.yaml]
+  --ut TEXT                Lagre sammendrag til fil
+```
+
+---
+
+## Sikkerhet
+
+- `.env` og `config.yaml` skal aldri legges i git (de er lagt til i `.gitignore`)
+- Innloggingstokenet lagres i `~/.wenche/token.json` med rettigheter begrenset til din bruker
+- Wenche sender aldri data andre steder enn til Maskinporten og Altinn

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,40 @@
+# Wenche
+
+Wenche er et verktøy for holdingselskaper og småaksjeselskaper som må levere regnskap og skattedokumenter til norske myndigheter. Det kan brukes både fra kommandolinjen og via et grafisk webgrensesnitt — uten behov for et fullverdig regnskapsprogram.
+
+Autentisering skjer via Maskinporten med et selvgenerert RSA-nøkkelpar. Ingen virksomhetssertifikat eller BankID-innlogging nødvendig.
+
+## Hva hjelper Wenche med?
+
+Alle AS plikter å levere tre ting hvert år:
+
+| Hva | Til hvem | Frist | Status |
+|---|---|---|---|
+| **Årsregnskap** | Brønnøysundregistrene | 31. juli | Automatisk innsending |
+| **Aksjonærregisteroppgave** (RF-1086) | Skatteetaten via Altinn | 31. januar | Automatisk innsending |
+| **Skattemelding for AS** (RF-1028 + RF-1167) | Skatteetaten | 31. mai | Genereres lokalt — sendes inn manuelt |
+
+!!! info "Om skattemeldingen"
+    Automatisk innsending av skattemelding krever registrering som systemleverandør hos Skatteetaten. Wenche genererer i stedet et ferdig utfylt sammendrag som du raskt kopierer inn på skatteetaten.no.
+
+## Hva er de ulike skjemaene?
+
+Har du aldri hørt om disse skjemaene? Her er en kort forklaring:
+
+- **Årsregnskapet** er en oppsummering av selskapets økonomi — hva selskapet eier, hva det skylder, og hva det tjente eller tapte i løpet av året. Dette er offentlig informasjon.
+- **Aksjonærregisteroppgaven (RF-1086)** forteller Skatteetaten hvem som eier aksjer i selskapet og om det er utbetalt utbytte. Brukes blant annet til å forhåndsutfylle aksjonærenes personlige skattemelding.
+- **Næringsoppgaven (RF-1167)** er en detaljert oppstilling av selskapets inntekter og kostnader for skatteformål. Grunnlaget for skatteberegningen.
+- **Skattemeldingen for AS (RF-1028)** er selve skattemeldingen. For holdingselskaper som eier aksjer i andre selskaper gjelder **fritaksmetoden**: utbytte fra datterselskaper er i praksis 97 % skattefritt.
+
+## Frister
+
+| Innsending | Frist |
+|---|---|
+| Aksjonærregisteroppgave | 31. januar |
+| Skattemelding for AS | 31. mai |
+| Årsregnskap | 31. juli |
+
+## Kom i gang
+
+[Installasjon →](installasjon.md){ .md-button .md-button--primary }
+[Oppsett →](oppsett.md){ .md-button }

--- a/docs/installasjon.md
+++ b/docs/installasjon.md
@@ -1,0 +1,88 @@
+# Installasjon
+
+## Krav
+
+- Python 3.11 eller nyere
+- OpenSSL (følger med macOS og de fleste Linux-distribusjoner)
+
+Sjekk Python-versjonen din:
+
+```bash
+python3 --version
+```
+
+Viser den 3.10 eller eldre, installer en nyere versjon:
+
+=== "macOS"
+
+    ```bash
+    brew install python@3.11
+    ```
+
+=== "Linux (Ubuntu/Debian)"
+
+    ```bash
+    sudo apt install python3.11 python3.11-venv
+    ```
+
+=== "Windows"
+
+    Last ned og installer fra [python.org](https://www.python.org/downloads/).
+
+## Installer Wenche
+
+Det anbefales å installere Wenche i et virtuelt miljø for å unngå konflikter med andre Python-pakker.
+
+```bash
+python3.11 -m venv .venv
+source .venv/bin/activate   # Windows: .venv\Scripts\activate
+pip install wenche
+```
+
+Wenche er nå tilgjengelig som kommandoen `wenche` i terminalen:
+
+```bash
+wenche --help
+```
+
+!!! tip "Husk å aktivere miljøet"
+    Neste gang du åpner et nytt terminalvindu må du aktivere det virtuelle miljøet på nytt:
+    ```bash
+    source .venv/bin/activate
+    ```
+
+## Webgrensesnitt (valgfritt)
+
+Foretrekker du å fylle ut skjemaer i nettleseren fremfor terminalen? Installer Wenche med UI-støtte:
+
+```bash
+pip install "wenche[ui]"
+```
+
+Start webgrensesnittet:
+
+```bash
+wenche ui
+```
+
+En nettleser åpner seg automatisk på `http://localhost:8501`. Du kan fylle inn selskapsinformasjon og regnskapstall i skjemaene, laste ned dokumenter og sende inn direkte fra grensesnittet.
+
+## For utviklere
+
+Vil du bidra til koden eller kjøre siste versjon fra GitHub?
+
+```bash
+git clone https://github.com/olefredrik/wenche.git
+cd wenche
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -e ".[dev]"
+```
+
+Kjør testsuiten:
+
+```bash
+pytest tests/ -v
+```
+
+[Gå videre til oppsett →](oppsett.md){ .md-button .md-button--primary }

--- a/docs/oppsett.md
+++ b/docs/oppsett.md
@@ -1,0 +1,122 @@
+# Oppsett
+
+Wenche bruker Maskinporten for å autentisere deg som konsument overfor Altinn — uten nettleserinnlogging. Du trenger:
+
+1. Et RSA-nøkkelpar (genereres lokalt)
+2. En Maskinporten-klient registrert hos Digdir
+3. En `.env`-fil med klient-ID og nøkkelinformasjon
+
+!!! note "Webgrensesnittet hjelper deg"
+    Har du installert Wenche med UI-støtte? Start `wenche ui` og gå til fanen **Oppsett** — der kan du fylle inn konfigurasjonen direkte i nettleseren uten å redigere filer manuelt.
+
+---
+
+## Steg 1 — Generer RSA-nøkkelpar
+
+Nøklene brukes til å identifisere deg overfor Maskinporten. Den private nøkkelen beholdes lokalt; den offentlige lastes opp til Digdir.
+
+```bash
+openssl genrsa -out maskinporten_privat.pem 2048
+openssl rsa -in maskinporten_privat.pem -pubout -out maskinporten_offentlig.pem
+```
+
+!!! warning "Ikke del den private nøkkelen"
+    `maskinporten_privat.pem` skal aldri deles med andre eller legges i git. Filen er lagt til i `.gitignore`.
+
+---
+
+## Steg 2 — Registrer Maskinporten-klient hos Digdir
+
+Registrering er gratis og tar ca. 15 minutter.
+
+### 2a. Søk om tilgang
+
+Gå til [samarbeid.digdir.no](https://samarbeid.digdir.no) og søk om tilgang som **Maskinporten-konsument**. Du vil motta en e-post med bekreftelse og lenke til selvbetjeningsportalen.
+
+### 2b. Opprett integrasjon
+
+Logg inn på [selvbetjeningsportalen.digdir.no](https://selvbetjeningsportalen.digdir.no):
+
+1. Velg **Produksjon** (eller **Test** for testmiljø)
+2. Velg **Klienter** → **Maskinporten & KRR**
+3. Klikk **Ny integrasjon** og fyll ut:
+    - Visningsnavn: `wenche`
+    - Access token levetid: `120`
+4. Legg til scopes: `altinn:instances.read` og `altinn:instances.write`
+5. Kopier **klient-ID** — du trenger den i neste steg
+
+### 2c. Last opp offentlig nøkkel
+
+Under klienten, klikk **Legg til nøkkel** og lim inn innholdet i `maskinporten_offentlig.pem`. Lagre klienten.
+
+Nøkkelen vil vises i listen med en UUID (f.eks. `9bc5078c-...`). Kopier denne UUID-en — dette er din **KID**.
+
+!!! info "Synkroniseringstid"
+    Endringer i testmiljøet kan ta noen minutter å synkronisere.
+
+---
+
+## Steg 3 — Konfigurer miljøvariabler
+
+Kopier eksempelfilen:
+
+```bash
+cp .env.example .env
+```
+
+Åpne `.env` og fyll inn verdiene fra portalen:
+
+```
+MASKINPORTEN_CLIENT_ID=din-klient-id-her
+MASKINPORTEN_KID=uuid-fra-portalen-her
+MASKINPORTEN_PRIVAT_NOKKEL=maskinporten_privat.pem
+WENCHE_ENV=prod
+```
+
+| Variabel | Hva det er |
+|---|---|
+| `MASKINPORTEN_CLIENT_ID` | Klient-ID fra selvbetjeningsportalen |
+| `MASKINPORTEN_KID` | UUID som portalen tildelte nøkkelen din |
+| `MASKINPORTEN_PRIVAT_NOKKEL` | Sti til din private nøkkelfil (standard: `maskinporten_privat.pem`) |
+| `WENCHE_ENV` | `prod` for produksjon, `test` for Altinn tt02-testmiljø |
+
+---
+
+## Steg 4 — Fyll ut config.yaml
+
+Kopier eksempelfilen:
+
+```bash
+cp config.example.yaml config.yaml
+```
+
+Åpne `config.yaml` og fyll inn selskapets opplysninger, regnskapstall og aksjonærdata. Filen er kommentert og selvforklarende. Alle beløp oppgis i hele kroner (NOK).
+
+!!! tip "Webgrensesnittet"
+    Bruker du `wenche ui` kan du fylle ut all informasjon om selskapet, regnskapet og aksjonærene direkte i nettleseren — ingen manuell filredigering nødvendig.
+
+---
+
+## Verifiser oppsett
+
+Test at alt er konfigurert riktig:
+
+```bash
+wenche login
+```
+
+Vellykket utskrift:
+
+```
+Autentiserer mot Maskinporten...
+Maskinporten-token mottatt. Henter Altinn-token...
+Autentisering vellykket.
+```
+
+Logg deretter ut igjen:
+
+```bash
+wenche logout
+```
+
+[Gå videre til bruk →](bruk.md){ .md-button .md-button--primary }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,48 @@
+site_name: Wenche
+site_description: Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn
+site_url: https://olefredrik.github.io/Wenche/
+repo_url: https://github.com/olefredrik/Wenche
+repo_name: olefredrik/Wenche
+
+theme:
+  name: material
+  language: no
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Bytt til mørk modus
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Bytt til lys modus
+  features:
+    - navigation.instant
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - toc.integrate
+
+nav:
+  - Hjem: index.md
+  - Installasjon: installasjon.md
+  - Oppsett: oppsett.md
+  - Bruk: bruk.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tabbed:
+      alternate_style: true
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
 
 [project.optional-dependencies]
 ui = ["streamlit>=1.30"]
-dev = ["pytest>=8.0"]
+dev = ["pytest>=8.0", "mkdocs-material>=9.5"]
 
 [project.urls]
 Homepage = "https://github.com/olefredrik/wenche"


### PR DESCRIPTION
Oppretter docs/ med fire sider (hjem, installasjon, oppsett, bruk) og GitHub Actions-workflow som publiserer automatisk ved push til main.