### PR TITLE
Fiks MkDocs: språkkode nb og pin mkdocs<2.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: "3.11"
       - name: Installer MkDocs
-        run: pip install mkdocs-material
+        run: pip install "mkdocs-material>=9.5" "mkdocs>=1.6,<2.0"
       - name: Bygg dokumentasjon
         run: mkdocs build
       - uses: actions/upload-pages-artifact@v3

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ repo_name: olefredrik/Wenche
 
 theme:
   name: material
-  language: no
+  language: nb
   palette:
     - scheme: default
       primary: indigo


### PR DESCRIPTION
- language: no tolkes som boolsk false i YAML — endret til nb (norsk bokmål)
- Pinner mkdocs<2.0 siden MkDocs 2.0 er inkompatibel med Material-temaet