### PR TITLE
Dokumenter signeringssteget i Altinn for årsregnskap

### DIFF
--- a/docs/bruk.md
+++ b/docs/bruk.md
@@ -82,9 +82,16 @@ Sammendraget inneholder:
     wenche logout
     ```
 
+    Wenche skriver ut en Altinn-lenke når opplastingen er ferdig. Åpne lenken i nettleseren og signer med BankID for å fullføre innsendingen.
+
 === "Webgrensesnitt"
 
     Gå til fanen **Send til Altinn** og klikk **Send årsregnskap**.
+
+    Når opplastingen er ferdig vises en knapp **Signer i Altinn**. Klikk den og signer med BankID for å fullføre innsendingen.
+
+!!! note "Signering skjer i Altinn, ikke i Wenche"
+    Wenche laster opp regnskapet og klargjør det for signering. Selve signeringen må gjøres av daglig leder eller styreleder i Altinn med BankID — dette er et juridisk krav og kan ikke gjøres maskinelt.
 
 ---
 


### PR DESCRIPTION
## Sammendrag

- Forklarer at Wenche laster opp regnskapet og klargjør for signering,
  men at selve signeringen gjøres av bruker i Altinn med BankID
- Legger til instruksjon om signeringslenke i kommandolinje-flyten
- Legger til instruksjon om «Signer i Altinn»-knapp i webgrensesnitt-flyten
- Legger til advarselsboks som tydeliggjør ansvarsdelingen mellom Wenche og Altinn

## Bakgrunn

Basert på verifisert end-to-end-test i tt02: Wenche leverer instansen
til Signeringssteget og returnerer Altinn-lenke. Signeringen er et
juridisk krav og kan ikke gjøres maskinelt (krever ID-Porten/BankID).