### PR TITLE
Legg til egenkapitalnote (rskl. § 7-2b)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.4.0"
+version = "0.5.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_skattemelding.py
+++ b/tests/test_skattemelding.py
@@ -120,6 +120,62 @@ def test_advarsel_naar_sammenligningstall_mangler(eksempel_regnskap):
     assert "§ 6-6" in tekst
 
 
+def test_egenkapitalnote_vises_med_fjoraar(eksempel_regnskap):
+    """Egenkapitalnoten skal vises med bevegelsestabel når foregående år er tilgjengelig."""
+    from wenche.models import Balanse, Egenkapital, EgenkapitalOgGjeld, LangsiktigGjeld
+    eksempel_regnskap.foregaaende_aar_balanse = Balanse(
+        egenkapital_og_gjeld=EgenkapitalOgGjeld(
+            egenkapital=Egenkapital(aksjekapital=30000, annen_egenkapital=-28800),
+            langsiktig_gjeld=LangsiktigGjeld(laan_fra_aksjonaer=100000),
+        ),
+    )
+    konfig = SkattemeldingKonfig()
+    tekst = generer(eksempel_regnskap, konfig)
+    assert "NOTE: EGENKAPITAL" in tekst
+    assert "§ 7-2b" in tekst
+    assert "EK 01.01.2025" in tekst
+    assert "EK 31.12.2025" in tekst
+    assert "Årsresultat" in tekst
+
+
+def test_egenkapitalnote_advarsel_uten_fjoraar(eksempel_regnskap):
+    """Uten foregående år skal noten advare om manglende egenkapitalbevegelse."""
+    konfig = SkattemeldingKonfig()
+    tekst = generer(eksempel_regnskap, konfig)
+    assert "NOTE: EGENKAPITAL" in tekst
+    assert "foregaaende_aar" in tekst
+
+
+def test_egenkapitalnote_utbytte_vises(eksempel_regnskap):
+    """Utbytte utbetalt skal vises som egen linje i egenkapitalnoten."""
+    from wenche.models import Balanse, Egenkapital, EgenkapitalOgGjeld, LangsiktigGjeld
+    eksempel_regnskap.utbytte_utbetalt = 50000
+    eksempel_regnskap.foregaaende_aar_balanse = Balanse(
+        egenkapital_og_gjeld=EgenkapitalOgGjeld(
+            egenkapital=Egenkapital(aksjekapital=30000, annen_egenkapital=20000),
+            langsiktig_gjeld=LangsiktigGjeld(laan_fra_aksjonaer=0),
+        ),
+    )
+    konfig = SkattemeldingKonfig()
+    tekst = generer(eksempel_regnskap, konfig)
+    assert "Utbytte utbetalt" in tekst
+    assert "-50 000" in tekst
+
+
+def test_egenkapitalnote_ingen_utbytte_linje_naar_null(eksempel_regnskap):
+    """Utbytte-linjen skal ikke vises når utbytte er 0."""
+    from wenche.models import Balanse, Egenkapital, EgenkapitalOgGjeld, LangsiktigGjeld
+    eksempel_regnskap.foregaaende_aar_balanse = Balanse(
+        egenkapital_og_gjeld=EgenkapitalOgGjeld(
+            egenkapital=Egenkapital(aksjekapital=30000, annen_egenkapital=-28800),
+            langsiktig_gjeld=LangsiktigGjeld(laan_fra_aksjonaer=100000),
+        ),
+    )
+    konfig = SkattemeldingKonfig()
+    tekst = generer(eksempel_regnskap, konfig)
+    assert "Utbytte utbetalt" not in tekst
+
+
 def test_balansekontroll_advarsel():
     """Ubalansert balanse skal gi advarsel i rapporten."""
     from wenche.models import (

--- a/wenche/aarsregnskap.py
+++ b/wenche/aarsregnskap.py
@@ -99,6 +99,10 @@ def les_config(config_fil: str) -> Aarsregnskap:
     foregaaende_resultat = _les_resultat(fa["resultatregnskap"]) if "resultatregnskap" in fa else Resultatregnskap()
     foregaaende_balanse = _les_balanse(fa["balanse"]) if "balanse" in fa else Balanse()
 
+    utbytte_utbetalt = sum(
+        int(a.get("utbytte_utbetalt", 0)) for a in cfg.get("aksjonaerer", [])
+    )
+
     return Aarsregnskap(
         selskap=selskap,
         regnskapsaar=cfg["regnskapsaar"],
@@ -106,6 +110,7 @@ def les_config(config_fil: str) -> Aarsregnskap:
         balanse=balanse,
         foregaaende_aar_resultat=foregaaende_resultat,
         foregaaende_aar_balanse=foregaaende_balanse,
+        utbytte_utbetalt=utbytte_utbetalt,
     )
 
 

--- a/wenche/models.py
+++ b/wenche/models.py
@@ -200,6 +200,7 @@ class Aarsregnskap:
     revideres: bool = False                     # True hvis regnskapet er revidert
     foregaaende_aar_resultat: Resultatregnskap = field(default_factory=Resultatregnskap)
     foregaaende_aar_balanse: Balanse = field(default_factory=Balanse)
+    utbytte_utbetalt: int = 0                  # Totalt utbytte utbetalt til aksjonærer i løpet av året
 
 
 # ---------------------------------------------------------------------------

--- a/wenche/skattemelding.py
+++ b/wenche/skattemelding.py
@@ -57,6 +57,10 @@ def les_config(config_fil: str) -> tuple[Aarsregnskap, SkattemeldingKonfig]:
     foregaaende_resultat = _les_resultat(fa["resultatregnskap"]) if "resultatregnskap" in fa else Resultatregnskap()
     foregaaende_balanse = _les_balanse(fa["balanse"]) if "balanse" in fa else Balanse()
 
+    utbytte_utbetalt = sum(
+        int(a.get("utbytte_utbetalt", 0)) for a in raw.get("aksjonaerer", [])
+    )
+
     regnskap = Aarsregnskap(
         selskap=selskap,
         regnskapsaar=int(raw["regnskapsaar"]),
@@ -64,6 +68,7 @@ def les_config(config_fil: str) -> tuple[Aarsregnskap, SkattemeldingKonfig]:
         balanse=balanse,
         foregaaende_aar_resultat=foregaaende_resultat,
         foregaaende_aar_balanse=foregaaende_balanse,
+        utbytte_utbetalt=utbytte_utbetalt,
     )
 
     sm_raw = raw.get("skattemelding", {})
@@ -314,6 +319,49 @@ def generer(regnskap: Aarsregnskap, konfig: SkattemeldingKonfig) -> str:
             f"  Legg til 'foregaaende_aar' i config.yaml (påkrevd, jf. rskl. § 6-6).",
             "",
         ]
+
+    # --- Egenkapitalnote (rskl. § 7-2b) ---
+
+    def _ekk(v: int) -> str:
+        return f"{v:>12,}".replace(",", " ")
+
+    def _ek_rad(label: str, ak: int, ok: int, aek: int) -> str:
+        s = ak + ok + aek
+        return f"  {label:<20}{_ekk(ak)}{_ekk(ok)}{_ekk(aek)}{_ekk(s)}"
+
+    aarsresultat = resultat_foer_skatt - beregnet_skatt
+    ek_ub = b.egenkapital_og_gjeld.egenkapital
+
+    linjer += [
+        "",
+        linje,
+        "  NOTE: EGENKAPITAL  (rskl. § 7-2b)",
+        linje,
+        f"  {'':20}{'AK-kapital':>12}{'Overkursfond':>12}{'Annen EK':>12}{'Sum':>12}",
+    ]
+
+    if har_fjoraar:
+        ek_ib = fb.egenkapital_og_gjeld.egenkapital
+        delta_ak = ek_ub.aksjekapital - ek_ib.aksjekapital
+        delta_ok = ek_ub.overkursfond - ek_ib.overkursfond
+        forklart_aek = ek_ib.annen_egenkapital + aarsresultat - regnskap.utbytte_utbetalt
+        andre_aek = ek_ub.annen_egenkapital - forklart_aek
+
+        linjer.append(_ek_rad(f"EK 01.01.{år}", ek_ib.aksjekapital, ek_ib.overkursfond, ek_ib.annen_egenkapital))
+        linjer.append(_ek_rad("Årsresultat", 0, 0, aarsresultat))
+        if regnskap.utbytte_utbetalt != 0:
+            linjer.append(_ek_rad("Utbytte utbetalt", 0, 0, -regnskap.utbytte_utbetalt))
+        if delta_ak != 0 or delta_ok != 0 or andre_aek != 0:
+            linjer.append(_ek_rad("Andre endringer", delta_ak, delta_ok, andre_aek))
+        linjer.append(_ek_rad(f"EK 31.12.{år}", ek_ub.aksjekapital, ek_ub.overkursfond, ek_ub.annen_egenkapital))
+    else:
+        linjer += [
+            f"  NB: Egenkapitalbevegelse krever foregaaende_aar (rskl. § 7-2b).",
+            _ek_rad(f"EK 31.12.{år}", ek_ub.aksjekapital, ek_ub.overkursfond, ek_ub.annen_egenkapital),
+        ]
+
+    linjer.append("  (beløp i hele kroner, NOK)")
+    linjer.append("")
 
     if i_balanse:
         linjer.append("  Balansekontroll: OK")

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -861,7 +861,12 @@ with fane_dokumenter:
     st.divider()
 
     def bygg_regnskap() -> Aarsregnskap:
+        antall_aksjona = int(st.session_state.get("antall_aksjonaerer", 1))
+        utbytte_utbetalt = sum(
+            int(st.session_state.get(f"a_utbytte_{i}", 0)) for i in range(antall_aksjona)
+        )
         return Aarsregnskap(
+            utbytte_utbetalt=utbytte_utbetalt,
             selskap=Selskap(
                 navn=st.session_state["navn"],
                 org_nummer=st.session_state["org_nummer"],


### PR DESCRIPTION
## Hva er endret

Implementerer egenkapitalnote som krevd av regnskapslovens § 7-2b for
små foretak.

**Ny seksjon i skattemeldingsrapporten:**

NOTE: EGENKAPITAL  (rskl. § 7-2b)
────────────────────────────────────────────────────────────
AK-kapital  Overkursfond     Annen EK          Sum
EK 01.01.2024            30 000             0      -28 800        1 200
Årsresultat                   0             0       -5 500       -5 500
Utbytte utbetalt              0             0      -50 000      -50 000
EK 31.12.2025            30 000             0      -84 300      -54 300
(beløp i hele kroner, NOK)



- Viser bevegelsestabel med kolonner for aksjekapital, overkursfond, annen EK og sum
- Utbytte utbetalt avledes automatisk fra summen av aksjonærenes `utbytte_utbetalt`-felt — ingen ny datafeltinntasting kreves
- Skjuler utbytte-linjen hvis ingen utbytte er utbetalt
- Viser "Andre endringer"-linje kun hvis det er en residual (f.eks. ved kapitalforhøyelse)
- Advarer om manglende `foregaaende_aar`-tall hvis bevegelsestabellen ikke kan vises

## Filer

- `wenche/models.py` — nytt felt `utbytte_utbetalt: int = 0` på `Aarsregnskap`
- `wenche/skattemelding.py` — egenkapitalnote i `generer()`, utbytte lest fra aksjonærconfig
- `wenche/aarsregnskap.py` — utbytte lest fra aksjonærconfig i `les_config()`
- `wenche/ui.py` — `bygg_regnskap()` beregner `utbytte_utbetalt` fra aksjonærfeltene automatisk
- `tests/test_skattemelding.py` — 4 nye tester (55 totalt, alle grønne)

## Versjon

`0.4.0` → `0.5.0` (ny funksjonalitet)

## Test plan

- [x] 55 tester, alle grønne (`pytest`)
- [x] Generer skattemelding med og uten `foregaaende_aar` — sjekk at noten vises korrekt
- [x] Sett `utbytte_utbetalt` på en aksjonær — sjekk at linjen dukker opp i noten