### PR TITLE
Dokumenter omfang og endringslogg etter regnskapsfører-tilbakemeldinger

### DIFF
--- a/docs/bruk.md
+++ b/docs/bruk.md
@@ -50,7 +50,18 @@ Sammendraget inneholder:
 - Alle felt i næringsoppgaven (RF-1167) ferdig utfylt
 - Skatteberegning med fritaksmetoden der det er aktuelt
 - Beregnet skatt (22 %)
+- Skattekostnad ført i resultatregnskapet
 - Fremførbart underskudd hvis selskapet gikk med tap
+- **Egenkapitalnote** (rskl. § 7-2b) med bevegelse per egenkapitalpost (inngående balanse, årsresultat, utbytte og utgående balanse)
+
+!!! info "Fritaksmetoden og sjablonregelen"
+    Wenche håndterer **to tilfeller** avhengig av eierandel i datterselskapet (`eierandel_datterselskap` i config.yaml):
+
+    - **Eierandel ≥ 90 %:** Hele utbyttet er skattefritt (fritaksmetoden, sktl. § 2-38).
+    - **Eierandel < 90 %:** 3 % av utbyttet er skattepliktig (sjablonregelen, sktl. § 2-38 sjette ledd). Skatteberegningen justeres automatisk.
+
+!!! info "Egenkapitalnote"
+    Egenkapitalnoten (rskl. § 7-2b) vises automatisk når `foregaaende_aar` er utfylt i `config.yaml`. Uten sammenligningstall vises kun utgående balanse med en advarsel om at inngående tall mangler.
 
 **Send inn manuelt:**
 
@@ -92,6 +103,9 @@ Sammendraget inneholder:
 
 !!! note "Signering skjer i Altinn, ikke i Wenche"
     Wenche laster opp regnskapet og klargjør det for signering. Selve signeringen må gjøres av daglig leder eller styreleder i Altinn med BankID — dette er et juridisk krav og kan ikke gjøres maskinelt.
+
+!!! info "Sammenligningstall (rskl. § 6-6)"
+    Årsregnskapet inkluderer automatisk sammenligningstall fra foregående år når `foregaaende_aar` er utfylt i `config.yaml`. Dette er obligatorisk etter regnskapsloven § 6-6. For selskaper stiftet i inneværende regnskapsår kan seksjonen utelates.
 
 ---
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -24,6 +24,27 @@ Alle AS plikter å levere tre ting hvert år:
 - **Næringsoppgaven (RF-1167)** er en detaljert oppstilling av selskapets inntekter og kostnader for skatteformål, og er grunnlaget for skatteberegningen.
 - **Skattemeldingen for AS (RF-1028)** er selve skattemeldingen. For holdingselskaper gjelder **fritaksmetoden**: utbytte fra datterselskaper er i praksis 97 % skattefritt.
 
+## Hvem passer Wenche for?
+
+Wenche er laget for **enkle holdingselskaper og småaksjeselskaper** — typisk et personlig investeringsselskap uten ansatte som eier aksjer i ett eller flere datterselskaper.
+
+**Passer godt for selskaper som:**
+
+- Ikke har ansatte (eller har én daglig leder uten komplekse lønnsforhold)
+- Kun eier aksjer og finansielle instrumenter — ingen varelager eller produksjonsmidler
+- Er alene i strukturen, dvs. ikke morselskap med plikt til konsernregnskap
+- Har et enkelt noteapparat (aksjenote og egenkapitalbevegelse dekkes av Wenche)
+
+**Passer ikke for selskaper som:**
+
+- Er morselskap og har plikt til å avlegge konsernregnskap
+- Har varelager, produksjonsutstyr eller mange anleggsmidler med avskrivningsplan
+- Krever revisor (Wenche støtter reviderte regnskap, men genererer ikke revisjonsberetning)
+- Har mange ansatte med komplekse lønns- og pensjonsforhold
+
+!!! warning "Wenche er ikke et fullverdig regnskapssystem"
+    Wenche er et **innsendingsverktøy** — det hjelper deg å fylle ut og sende inn dokumenter du allerede har tallene til. Det erstatter ikke en autorisert regnskapsfører eller et fullstendig regnskapsprogram. Skatteberegningene bør alltid verifiseres mot gjeldende regelverk, og regelverket endres jevnlig.
+
 ## Kom i gang
 
 [Installasjon →](installasjon.md){ .md-button .md-button--primary }


### PR DESCRIPTION
## Sammendrag

Dokumenterer nye funksjoner og avklarer omfanget av Wenche, som oppfølging av tilbakemeldinger fra regnskapsfaglig gjennomgang.

### docs/index.md
- Ny seksjon «Hvem passer Wenche for?» med tydelige inkluderings- og ekskluderingskriterier
- Advarselsboks som presiserer at Wenche er et innsendingsverktøy, ikke et fullverdig regnskapssystem

### docs/bruk.md
- **Egenkapitalnote (rskl. § 7-2b):** Automatisk generert bevegelsesoppstilling per egenkapitalpost — vises i skattemelding-sammendraget når foregaaende_aar er utfylt
- **Skattekostnad:** Beregnet skatt føres nå i resultatregnskapet
- **Fritaksmetoden og sjablonregelen:** Forklarer de to tilfellene (eierandel ≥/< 90 %, sktl. § 2-38 sjette ledd)
- **Sammenligningstall (rskl. § 6-6):** Dokumenterer at foregaaende_aar i config.yaml aktiverer sammenligningstall i årsregnskapet