### PR TITLE
Utvid Windows-installasjonsveiledning

### DIFF
--- a/docs/installasjon.md
+++ b/docs/installasjon.md
@@ -2,16 +2,30 @@
 
 ## Krav
 
-- Python 3.11 eller nyere
-- OpenSSL (følger med macOS og de fleste Linux-distribusjoner)
+- Python **3.11 eller nyere**
+- OpenSSL (følger med macOS og de fleste Linux-distribusjoner; Python på Windows inkluderer dette automatisk)
 
-Sjekk Python-versjonen din:
+### Sjekk Python-versjonen din
 
-```bash
-python3 --version
-```
+=== "macOS / Linux"
 
-Viser den 3.10 eller lavere, installer en nyere versjon:
+    ```bash
+    python3 --version
+    ```
+
+=== "Windows (PowerShell)"
+
+    ```powershell
+    python --version
+    ```
+
+    Har du flere Python-versjoner installert, bruk `py`-launcheren for å se alle:
+
+    ```powershell
+    py --list
+    ```
+
+Viser kommandoen 3.10 eller lavere (eller du får feilmeldingen `command not found`), installer en nyere versjon:
 
 === "macOS"
 
@@ -27,27 +41,61 @@ Viser den 3.10 eller lavere, installer en nyere versjon:
 
 === "Windows"
 
-    Last ned og installer fra [python.org](https://www.python.org/downloads/).
+    Last ned **Python 3.11** eller nyere fra [python.org](https://www.python.org/downloads/).
+
+    !!! warning "Viktig under installasjonen"
+        Huk av **«Add Python to PATH»** nederst i installasjonsvinduet før du klikker *Install Now*.
+        Uten dette finner ikke terminalen `python`-kommandoen.
+
+    !!! tip "Unngå Microsoft Store-versjonen"
+        Windows kan ha en stubb-versjon av Python installert som åpner Microsoft Store i stedet for å kjøre Python.
+        Hvis `python --version` åpner Store, deaktiver dette under **Innstillinger → Apper → Appkjøringsaliaser** og slå av begge Python-oppføringene.
 
 ## Installer Wenche
 
 Det anbefales å installere Wenche i et virtuelt miljø for å unngå konflikter med andre Python-pakker.
 
-=== "Kommandolinje"
+=== "macOS / Linux — kommandolinje"
 
     ```bash
     python3.11 -m venv .venv
-    source .venv/bin/activate   # Windows: .venv\Scripts\activate
+    source .venv/bin/activate
     pip install wenche
     ```
 
-=== "Webgrensesnitt"
+=== "macOS / Linux — webgrensesnitt"
 
     ```bash
     python3.11 -m venv .venv
-    source .venv/bin/activate   # Windows: .venv\Scripts\activate
+    source .venv/bin/activate
     pip install "wenche[ui]"
     ```
+
+=== "Windows — kommandolinje"
+
+    ```powershell
+    py -3.11 -m venv .venv
+    .venv\Scripts\Activate.ps1
+    pip install wenche
+    ```
+
+=== "Windows — webgrensesnitt"
+
+    ```powershell
+    py -3.11 -m venv .venv
+    .venv\Scripts\Activate.ps1
+    pip install "wenche[ui]"
+    ```
+
+!!! warning "Windows: PowerShell execution policy"
+    Får du feilmeldingen `running scripts is disabled on this system` når du kjører `Activate.ps1`,
+    må du tillate kjøring av lokale scripts:
+
+    ```powershell
+    Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
+    ```
+
+    Kjør så `.venv\Scripts\Activate.ps1` på nytt.
 
 Wenche er nå tilgjengelig som kommandoen `wenche` i terminalen:
 
@@ -57,9 +105,16 @@ wenche --help
 
 !!! tip "Husk å aktivere miljøet"
     Neste gang du åpner et nytt terminalvindu må du aktivere det virtuelle miljøet på nytt:
-    ```bash
-    source .venv/bin/activate
-    ```
+
+    === "macOS / Linux"
+        ```bash
+        source .venv/bin/activate
+        ```
+
+    === "Windows"
+        ```powershell
+        .venv\Scripts\Activate.ps1
+        ```
 
 ## Start webgrensesnittet
 


### PR DESCRIPTION
Basert på tilbakemelding fra Windows-bruker som hadde problemer med Python-oppsett.

## Endringer
- Separate installasjonsfaner for macOS/Linux og Windows gjennom hele siden
- Bruker `py`-launcheren (`py -3.11`) på Windows for korrekt versjonshåndtering
- Advarsel om PowerShell execution policy med klar fix (`Set-ExecutionPolicy`)
- Advarsel om Microsoft Store Python-stubber og hvordan deaktivere dem
- Presiserer at «Add Python to PATH» må hukes av under installasjonen
- `source .venv/bin/activate`-tipset viser nå separat kommando for Windows