### PR TITLE
Legg config.yaml til .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .env
 *.pem
 *.p12
+config.yaml
 
 # Python
 __pycache__/


### PR DESCRIPTION
`config.yaml` inneholder personnummer (fødselsnummer) og org-nummer og skal aldri committes til git.

`config.example.yaml` ligger fortsatt i repoet som mal for nye brukere.