### PR TITLE
Legg site/ til .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ venv/
 .claude/
 
 # Genererte filer
+site/
 *.xml
 *.xbrl
 *.html


### PR DESCRIPTION
`site/`-mappen genereres lokalt av MkDocs ved `mkdocs build` og skal ikke ligge i git.
