### PR TITLE
Oppdater bruk.md: innboks-URL og advarsel om aksjonærregister-blokkering

### DIFF
--- a/docs/bruk.md
+++ b/docs/bruk.md
@@ -93,7 +93,7 @@ Sammendraget inneholder:
     wenche logout
     ```
 
-    Wenche skriver ut en Altinn-lenke når opplastingen er ferdig. Åpne lenken i nettleseren og signer med BankID for å fullføre innsendingen.
+    Wenche skriver ut en lenke til Altinn-innboksen når opplastingen er ferdig. Åpne lenken i nettleseren, finn skjemaet i innboksen og signer med BankID for å fullføre innsendingen.
 
 === "Webgrensesnitt"
 
@@ -111,15 +111,18 @@ Sammendraget inneholder:
 
 ## Aksjonærregisteroppgave (frist 31. januar)
 
+!!! warning "Midlertidig utilgjengelig"
+    Digital innsending av aksjonærregisteroppgave (RF-1086) via Wenche er for øyeblikket blokkert fordi Skatteetaten ikke har aktivert systembruker-delegering for sin Altinn-app. Koden er ferdig på Wenche sin side, men innsending er ikke mulig før SKD aktiverer støtten. Vi følger saken og oppdaterer dokumentasjonen så snart det er løst.
+
 === "Kommandolinje"
 
-    Test uten innsending:
+    Test og generer XML lokalt:
 
     ```bash
     wenche send-aksjonaerregister --dry-run
     ```
 
-    Send inn:
+    Innsending (krever at SKD har aktivert systembruker-støtte):
 
     ```bash
     wenche login


### PR DESCRIPTION
## Hva er gjort
- Presiserer at Wenche lenker til Altinn-innboksen (ikke et spesifikt skjema-URL) etter opplasting av årsregnskap
- Legger til advarsel i aksjonærregister-seksjonen om at innsending er midlertidig blokkert fordi Skatteetaten ikke har aktivert systembruker-delegering for RF-1086, ref https://github.com/olefredrik/Wenche/issues/36

## Hvorfor
Dokumentasjonen var upresis om signeringslenken, og ga ingen forvarsel om at `wenche send-aksjonaerregister` ikke kan fullføres ennå. En bruker som fulgte guiden ville møte en vegg uten forklaring.