### PR TITLE
Forklar test vs. prod i Maskinporten-oppsett

### DIFF
--- a/docs/oppsett.md
+++ b/docs/oppsett.md
@@ -41,12 +41,15 @@ Gå til [samarbeid.digdir.no](https://samarbeid.digdir.no) og søk om tilgang so
 
 ### 2b. Opprett integrasjon
 
-Logg inn på [selvbetjeningsportalen.digdir.no](https://selvbetjeningsportalen.digdir.no):
-
 !!! info "Produksjon eller test?"
-    De fleste trenger kun å sette opp **Produksjon**. Test-miljøet (Altinn tt02) er for utviklere som vil teste innsending uten å sende ekte data til myndighetene. Du oppretter én klient per miljø, men tilgangen til selvbetjeningsportalen er felles — du velger miljø øverst i portalen.
+    De fleste trenger kun å sette opp **Produksjon**. Test-miljøet (Altinn tt02) er for utviklere som vil teste innsending uten å sende ekte data til myndighetene. De to miljøene har hver sin portal:
 
-1. Velg **Produksjon** øverst i portalen (eller **Test** hvis du skal sette opp testmiljøet)
+    - **Produksjon:** [selvbetjeningsportalen.digdir.no](https://selvbetjeningsportalen.digdir.no)
+    - **Test:** [sjolvbetjening.test.samarbeid.digdir.no](https://sjolvbetjening.test.samarbeid.digdir.no)
+
+Logg inn på riktig portal og følg stegene under:
+
+1. Velg **Klienter** → **Maskinporten & KRR**
 2. Velg **Klienter** → **Maskinporten & KRR**
 3. Klikk **Ny integrasjon** og fyll ut:
     - Visningsnavn: `wenche`


### PR DESCRIPTION
## Hva er gjort
- Lagt til info-boks i steg 2b som forklarer forskjellen mellom test- og produksjonsmiljø
- Tydeliggjort at de fleste kun trenger å sette opp Produksjon (test er for utviklere)
- Rettet URL: test-portalen er `sjolvbetjening.test.samarbeid.digdir.no`, ikke samme som prod
- Lenker til begge portaler vises tydelig i info-boksen

## Hvorfor
Bruker spurte om hvordan man fikk satt opp test vs. prod. Dette var ikke tydelig nok i dokumentasjonen.