### PR TITLE
Slett .streamlit-mappe

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,5 +1,0 @@
-[client]
-toolbarMode = "viewer"
-
-[browser]
-gatherUsageStats = false


### PR DESCRIPTION
Streamlit er erstattet med NiceGUI. Konfigurasjonsmappen er ikke lenger relevant.