### PR TITLE
Fiks BRG XSD-valideringsfeil, SKD prod-URL og base64-dekoding

### DIFF
--- a/tests/test_brg_xml_fixes.py
+++ b/tests/test_brg_xml_fixes.py
@@ -1,0 +1,394 @@
+"""
+Tests for BRG XML fixes: corrected orid values, linje_enkel structure,
+and base64 decoding of forhåndsutfylt skattemelding.
+"""
+
+import base64
+import xml.etree.ElementTree as ET
+
+import pytest
+
+from wenche.brg_xml import generer_hovedskjema, generer_underskjema
+from wenche.models import (
+    Aarsregnskap,
+    Anleggsmidler,
+    Balanse,
+    Driftsinntekter,
+    Driftskostnader,
+    Egenkapital,
+    EgenkapitalOgGjeld,
+    Eiendeler,
+    Finansposter,
+    KortsiktigGjeld,
+    LangsiktigGjeld,
+    Omloepmidler,
+    Resultatregnskap,
+    Selskap,
+)
+
+NS = "http://schema.brreg.no/regnsys/aarsregnskap_vanlig/underskjema"
+NS_H = "http://schema.brreg.no/regnsys/aarsregnskap_vanlig"
+
+
+def _parse(xml_bytes: bytes) -> ET.Element:
+    return ET.fromstring(xml_bytes)
+
+
+def _orid(root: ET.Element, tag: str) -> dict[str, str]:
+    """Return {child_tag: orid} for immediate children of first matching element."""
+    el = root.find(f".//{{{NS}}}{tag}")
+    if el is None:
+        return {}
+    return {
+        child.tag.split("}")[-1]: child.attrib.get("orid", "")
+        for child in el
+    }
+
+
+@pytest.fixture
+def regnskap_med_alle_poster():
+    """Regnskap that exercises linje_enkel paths and corrected orid elements."""
+    selskap = Selskap(
+        navn="Testselskap AS",
+        org_nummer="987654321",
+        daglig_leder="Test Testesen",
+        styreleder="Test Testesen",
+        forretningsadresse="Testveien 1, 0001 Oslo",
+        stiftelsesaar=2020,
+        aksjekapital=30000,
+    )
+    return Aarsregnskap(
+        selskap=selskap,
+        regnskapsaar=2025,
+        resultatregnskap=Resultatregnskap(
+            driftsinntekter=Driftsinntekter(salgsinntekter=50000),
+            driftskostnader=Driftskostnader(andre_driftskostnader=20000),
+            finansposter=Finansposter(
+                andre_finansinntekter=1000,
+                rentekostnader=15000,
+            ),
+        ),
+        balanse=Balanse(
+            eiendeler=Eiendeler(
+                anleggsmidler=Anleggsmidler(
+                    andre_aksjer=200000,
+                    langsiktige_fordringer=50000,
+                ),
+                omloepmidler=Omloepmidler(bankinnskudd=5000),
+            ),
+            egenkapital_og_gjeld=EgenkapitalOgGjeld(
+                egenkapital=Egenkapital(
+                    aksjekapital=30000,
+                    overkursfond=10000,
+                    annen_egenkapital=-124000,
+                ),
+                langsiktig_gjeld=LangsiktigGjeld(laan_fra_aksjonaer=300000),
+                kortsiktig_gjeld=KortsiktigGjeld(leverandoergjeld=39000),
+            ),
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Corrected orid values
+# ---------------------------------------------------------------------------
+
+
+class TestSumOverfoeringerOgDisponeringer:
+    def test_orid_aarets_is_7071(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        orids = _orid(root, "sumOverfoeringerOgDisponeringer")
+        assert orids["aarets"] == "7071"
+
+    def test_orid_fjoraarets_is_7072(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        orids = _orid(root, "sumOverfoeringerOgDisponeringer")
+        assert orids["fjoraarets"] == "7072"
+
+
+class TestInvesteringAksjerAndeler:
+    def test_orid_beskrivelse_is_29024(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        el = root.find(f".//{{{NS}}}investeringAksjerAndeler/{{{NS}}}beskrivelse")
+        assert el is not None
+        assert el.attrib["orid"] == "29024"
+
+    def test_orid_aarets_is_7100(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        el = root.find(f".//{{{NS}}}investeringAksjerAndeler/{{{NS}}}aarets")
+        assert el is not None
+        assert el.attrib["orid"] == "7100"
+
+    def test_orid_fjoraarets_is_7101(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        el = root.find(f".//{{{NS}}}investeringAksjerAndeler/{{{NS}}}fjoraarets")
+        assert el is not None
+        assert el.attrib["orid"] == "7101"
+
+
+class TestAnnenFordring:
+    def test_orid_beskrivelse_is_29025(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        el = root.find(f".//{{{NS}}}annenFordring/{{{NS}}}beskrivelse")
+        assert el is not None
+        assert el.attrib["orid"] == "29025"
+
+    def test_orid_aarets_is_203(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        el = root.find(f".//{{{NS}}}annenFordring/{{{NS}}}aarets")
+        assert el is not None
+        assert el.attrib["orid"] == "203"
+
+    def test_orid_fjoraarets_is_27585(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        el = root.find(f".//{{{NS}}}annenFordring/{{{NS}}}fjoraarets")
+        assert el is not None
+        assert el.attrib["orid"] == "27585"
+
+
+class TestAnnenRenteinntekt:
+    def test_orid_aarets_is_150(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        orids = _orid(root, "annenRenteinntekt")
+        assert orids["aarets"] == "150"
+
+    def test_orid_fjoraarets_is_7030(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        orids = _orid(root, "annenRenteinntekt")
+        assert orids["fjoraarets"] == "7030"
+
+
+# ---------------------------------------------------------------------------
+# linje_enkel: no altinnRowId, no <beskrivelse>
+# ---------------------------------------------------------------------------
+
+
+class TestLinjeEnkel:
+    """Elements using linje_enkel must have no altinnRowId attribute and no <beskrivelse> child."""
+
+    LINJE_ENKEL_TAGS = [
+        "rentekostnad",
+        "annenRenteinntekt",
+        "overkursfond",
+        "langsiktigKonserngjeld",
+        "leverandoergjeld",
+    ]
+
+    def test_no_altinn_row_id(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        for tag in self.LINJE_ENKEL_TAGS:
+            el = root.find(f".//{{{NS}}}{tag}")
+            if el is not None:
+                assert "altinnRowId" not in el.attrib, (
+                    f"{tag} should not have altinnRowId"
+                )
+
+    def test_no_beskrivelse_child(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        for tag in self.LINJE_ENKEL_TAGS:
+            el = root.find(f".//{{{NS}}}{tag}")
+            if el is not None:
+                besk = el.find(f"{{{NS}}}beskrivelse")
+                assert besk is None, (
+                    f"{tag} should not have <beskrivelse> child"
+                )
+
+    def test_has_aarets_and_fjoraarets(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        for tag in self.LINJE_ENKEL_TAGS:
+            el = root.find(f".//{{{NS}}}{tag}")
+            if el is not None:
+                assert el.find(f"{{{NS}}}aarets") is not None, (
+                    f"{tag} missing <aarets>"
+                )
+                assert el.find(f"{{{NS}}}fjoraarets") is not None, (
+                    f"{tag} missing <fjoraarets>"
+                )
+
+    def test_rentekostnad_value(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        el = root.find(f".//{{{NS}}}rentekostnad/{{{NS}}}aarets")
+        assert el is not None
+        assert int(el.text) == 15000
+
+    def test_overkursfond_value(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        el = root.find(f".//{{{NS}}}overkursfond/{{{NS}}}aarets")
+        assert el is not None
+        assert int(el.text) == 10000
+
+    def test_leverandoergjeld_value(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        el = root.find(f".//{{{NS}}}leverandoergjeld/{{{NS}}}aarets")
+        assert el is not None
+        assert int(el.text) == 39000
+
+    def test_langsiktig_konserngjeld_value(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        el = root.find(f".//{{{NS}}}langsiktigKonserngjeld/{{{NS}}}aarets")
+        assert el is not None
+        assert int(el.text) == 300000
+
+    def test_zero_values_omitted(self, eksempel_regnskap):
+        """linje_enkel with 0 for both years should produce no element."""
+        root = _parse(generer_underskjema(eksempel_regnskap))
+        assert root.find(f".//{{{NS}}}rentekostnad") is None
+        assert root.find(f".//{{{NS}}}overkursfond") is None
+        assert root.find(f".//{{{NS}}}leverandoergjeld") is None
+
+
+class TestLinjeVsLinjeEnkel:
+    """Regular linje() elements MUST have altinnRowId and <beskrivelse>."""
+
+    LINJE_TAGS = [
+        "annenDriftskostnad",
+        "investeringAksjerAndeler",
+        "annenFordring",
+    ]
+
+    def test_has_altinn_row_id(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        for tag in self.LINJE_TAGS:
+            el = root.find(f".//{{{NS}}}{tag}")
+            if el is not None:
+                assert "altinnRowId" in el.attrib, (
+                    f"{tag} should have altinnRowId"
+                )
+
+    def test_has_beskrivelse(self, regnskap_med_alle_poster):
+        root = _parse(generer_underskjema(regnskap_med_alle_poster))
+        for tag in self.LINJE_TAGS:
+            el = root.find(f".//{{{NS}}}{tag}")
+            if el is not None:
+                besk = el.find(f"{{{NS}}}beskrivelse")
+                assert besk is not None, (
+                    f"{tag} should have <beskrivelse> child"
+                )
+
+
+# ---------------------------------------------------------------------------
+# noteMaskinellBehandling = "10"
+# ---------------------------------------------------------------------------
+
+
+def test_note_maskinell_behandling_is_10(regnskap_med_alle_poster):
+    root = _parse(generer_hovedskjema(regnskap_med_alle_poster))
+    note = root.find(f".//{{{NS_H}}}noteMaskinellBehandling")
+    assert note is not None
+    assert note.text == "10"
+
+
+# ---------------------------------------------------------------------------
+# Base64 decoding of forhåndsutfylt skattemelding
+# ---------------------------------------------------------------------------
+
+
+class TestBase64Dekoding:
+    """Test wrapper-XML unwrapping in SkdSkattemeldingClient.hent_forhåndsutfylt."""
+
+    def _make_wrapper(self, inner_xml: bytes) -> bytes:
+        encoded = base64.b64encode(inner_xml).decode()
+        ns = "no:skatteetaten:fastsetting:formueinntekt:skattemeldingognaeringsspesifikasjon:forespoersel:response:v2"
+        return (
+            f'<response xmlns="{ns}">'
+            f"<content>{encoded}</content>"
+            f"</response>"
+        ).encode()
+
+    def test_unwraps_base64_wrapper(self):
+        from xml.etree.ElementTree import ParseError, fromstring
+        import binascii
+
+        inner = b"<skattemeldingUpersonlig>test</skattemeldingUpersonlig>"
+        wrapper = self._make_wrapper(inner)
+
+        # Replicate the decoding logic from hent_forhåndsutfylt
+        root = fromstring(wrapper)
+        ns = "no:skatteetaten:fastsetting:formueinntekt:skattemeldingognaeringsspesifikasjon:forespoersel:response:v2"
+        content_el = root.find(f".//{{{ns}}}content")
+        if content_el is None:
+            content_el = root.find(".//{*}content")
+        result = base64.b64decode(content_el.text) if content_el is not None and content_el.text else wrapper
+
+        assert result == inner
+
+    def test_wildcard_namespace_fallback(self):
+        inner = b"<skattemeldingUpersonlig>data</skattemeldingUpersonlig>"
+        encoded = base64.b64encode(inner).decode()
+        wrapper = (
+            f'<response xmlns="some:other:namespace">'
+            f"<content>{encoded}</content>"
+            f"</response>"
+        ).encode()
+
+        from xml.etree.ElementTree import fromstring
+        root = fromstring(wrapper)
+        ns = "no:skatteetaten:fastsetting:formueinntekt:skattemeldingognaeringsspesifikasjon:forespoersel:response:v2"
+        content_el = root.find(f".//{{{ns}}}content")
+        if content_el is None:
+            content_el = root.find(".//{*}content")
+        result = base64.b64decode(content_el.text) if content_el is not None and content_el.text else wrapper
+
+        assert result == inner
+
+    def test_non_wrapper_xml_returned_as_is(self):
+        from xml.etree.ElementTree import ParseError, fromstring
+        import binascii
+
+        raw = b"<skattemeldingUpersonlig>direkte</skattemeldingUpersonlig>"
+
+        # Replicate decoding logic — no <content> element found
+        try:
+            root = fromstring(raw)
+            ns = "no:skatteetaten:fastsetting:formueinntekt:skattemeldingognaeringsspesifikasjon:forespoersel:response:v2"
+            content_el = root.find(f".//{{{ns}}}content")
+            if content_el is None:
+                content_el = root.find(".//{*}content")
+            if content_el is not None and content_el.text:
+                result = base64.b64decode(content_el.text)
+            else:
+                result = raw
+        except (ParseError, binascii.Error):
+            result = raw
+
+        assert result == raw
+
+    def test_invalid_xml_falls_through(self):
+        from xml.etree.ElementTree import ParseError
+        import binascii
+
+        raw = b"this is not xml at all"
+
+        try:
+            from xml.etree.ElementTree import fromstring
+            root = fromstring(raw)
+            content_el = root.find(".//{*}content")
+            if content_el is not None and content_el.text:
+                result = base64.b64decode(content_el.text)
+            else:
+                result = raw
+        except (ParseError, binascii.Error):
+            result = raw
+
+        assert result == raw
+
+    def test_bad_base64_falls_through(self):
+        import binascii
+        from xml.etree.ElementTree import ParseError, fromstring
+
+        ns = "no:skatteetaten:fastsetting:formueinntekt:skattemeldingognaeringsspesifikasjon:forespoersel:response:v2"
+        raw = f'<response xmlns="{ns}"><content>!!!not-base64!!!</content></response>'.encode()
+
+        try:
+            root = fromstring(raw)
+            content_el = root.find(f".//{{{ns}}}content")
+            if content_el is None:
+                content_el = root.find(".//{*}content")
+            if content_el is not None and content_el.text:
+                result = base64.b64decode(content_el.text)
+            else:
+                result = raw
+        except (ParseError, binascii.Error):
+            result = raw
+
+        assert result == raw

--- a/wenche/brg_xml.py
+++ b/wenche/brg_xml.py
@@ -119,7 +119,7 @@ def generer_hovedskjema(regnskap: Aarsregnskap) -> bytes:
       <navn orid="1">{s.navn}</navn>
     </enhet>
     <opplysningerInnsending>
-      <noteMaskinellBehandling orid="37499">20</noteMaskinellBehandling>
+      <noteMaskinellBehandling orid="37499">10</noteMaskinellBehandling>
       <systemNavn orid="39007">Wenche</systemNavn>
     </opplysningerInnsending>
   </Innsender>

--- a/wenche/brg_xml.py
+++ b/wenche/brg_xml.py
@@ -182,7 +182,11 @@ def generer_underskjema(regnskap: Aarsregnskap) -> bytes:
             f'</{tag}>'
         )
 
-    # Hjelpefunksjon: lager enkelt element uten beskrivelse (single-occurrence)
+    # Hjelpefunksjon for single-occurrence elementer.
+    # Utelater altinnRowId og <beskrivelse> med vilje: XSD-en for disse
+    # elementene (f.eks. rentekostnad, langsiktigKonserngjeld, overkursfond)
+    # definerer dem uten disse attributtene/barna, i motsetning til
+    # repeatable-elementer som bruker linje().
     def linje_enkel(tag: str, verdi: float,
                     orid_aarets: str, orid_fjor: str,
                     fjor_verdi: float = 0.0) -> str:

--- a/wenche/brg_xml.py
+++ b/wenche/brg_xml.py
@@ -168,7 +168,7 @@ def generer_underskjema(regnskap: Aarsregnskap) -> bytes:
     def _i(v: float) -> int:
         return round(v)
 
-    # Hjelpefunksjon: lager linjeelement med altinnRowId kun hvis verdi != 0
+    # Hjelpefunksjon: lager linjeelement med altinnRowId og beskrivelse (unbounded-elementer)
     def linje(tag: str, verdi: float, besk: str, orid_besk: str,
               orid_aarets: str, orid_fjor: str, fjor_verdi: float = 0.0) -> str:
         iv, ifv = _i(verdi), _i(fjor_verdi)
@@ -177,6 +177,20 @@ def generer_underskjema(regnskap: Aarsregnskap) -> bytes:
         return (
             f'<{tag} altinnRowId="{_row_id()}">'
             f'<beskrivelse orid="{orid_besk}">{besk}</beskrivelse>'
+            f'<aarets orid="{orid_aarets}">{iv}</aarets>'
+            f'<fjoraarets orid="{orid_fjor}">{ifv}</fjoraarets>'
+            f'</{tag}>'
+        )
+
+    # Hjelpefunksjon: lager enkelt element uten beskrivelse (single-occurrence)
+    def linje_enkel(tag: str, verdi: float,
+                    orid_aarets: str, orid_fjor: str,
+                    fjor_verdi: float = 0.0) -> str:
+        iv, ifv = _i(verdi), _i(fjor_verdi)
+        if iv == 0 and ifv == 0:
+            return ""
+        return (
+            f'<{tag}>'
             f'<aarets orid="{orid_aarets}">{iv}</aarets>'
             f'<fjoraarets orid="{orid_fjor}">{ifv}</fjoraarets>'
             f'</{tag}>'
@@ -256,14 +270,14 @@ def generer_underskjema(regnskap: Aarsregnskap) -> bytes:
       </nettoFinans>
       <finansinntekt>
         {linje("investeringDatterforetakTilknyttetSelskap", fp.utbytte_fra_datterselskap, "Utbytte fra datterselskap", "29004", "27934", "27935", ffp.utbytte_fra_datterselskap)}
-        {linje("annenRenteinntekt", fp.andre_finansinntekter, "Andre finansinntekter", "29006", "152", "7032", ffp.andre_finansinntekter)}
+        {linje_enkel("annenRenteinntekt", fp.andre_finansinntekter, "150", "7030", ffp.andre_finansinntekter)}
         <sumFinansinntekter>
           <aarets orid="153">{_i(fp.sum_inntekter)}</aarets>
           <fjoraarets orid="7993">{_i(ffp.sum_inntekter)}</fjoraarets>
         </sumFinansinntekter>
       </finansinntekt>
       <finanskostnad>
-        {linje("rentekostnad", fp.rentekostnader, "Rentekostnader", "29009", "7037", "7038", ffp.rentekostnader)}
+        {linje_enkel("rentekostnad", fp.rentekostnader, "7037", "7038", ffp.rentekostnader)}
         {linje("annenFinanskostnad", fp.andre_finanskostnader, "Andre finanskostnader", "29011", "156", "7041", ffp.andre_finanskostnader)}
         <sumFinanskostnader>
           <aarets orid="17130">{_i(fp.sum_kostnader)}</aarets>
@@ -285,8 +299,8 @@ def generer_underskjema(regnskap: Aarsregnskap) -> bytes:
       </resultat>
       <overfoeringer>
         <sumOverfoeringerOgDisponeringer>
-          <aarets orid="7067">{_i(r.aarsresultat)}</aarets>
-          <fjoraarets orid="7068">{_i(fr.aarsresultat)}</fjoraarets>
+          <aarets orid="7071">{_i(r.aarsresultat)}</aarets>
+          <fjoraarets orid="7072">{_i(fr.aarsresultat)}</fjoraarets>
         </sumOverfoeringerOgDisponeringer>
       </overfoeringer>
     </resultatregnskapResultat>
@@ -306,8 +320,8 @@ def generer_underskjema(regnskap: Aarsregnskap) -> bytes:
             <aarets orid="9686">{_i(am.aksjer_i_datterselskap)}</aarets>
             <fjoraarets orid="10289">{_i(fam.aksjer_i_datterselskap)}</fjoraarets>
           </investeringDatterselskap>
-          {linje("investeringAksjerAndeler", am.andre_aksjer, "Andre aksjer", "29018", "7727", "8012", fam.andre_aksjer)}
-          {linje("annenFordring", am.langsiktige_fordringer, "Langsiktige fordringer", "29019", "6500", "7093", fam.langsiktige_fordringer)}
+          {linje("investeringAksjerAndeler", am.andre_aksjer, "Andre aksjer", "29024", "7100", "7101", fam.andre_aksjer)}
+          {linje("annenFordring", am.langsiktige_fordringer, "Langsiktige fordringer", "29025", "203", "27585", fam.langsiktige_fordringer)}
           <sumFinansielleAnleggsmidler>
             <aarets orid="5267">{_i(am.sum)}</aarets>
             <fjoraarets orid="8014">{_i(fam.sum)}</fjoraarets>
@@ -348,7 +362,7 @@ def generer_underskjema(regnskap: Aarsregnskap) -> bytes:
       <balanseEgenkapitalInnskuttOpptjentEgenkapital>
         <innskuttEgenkapital>
           {linje("selskapskapital", ek.aksjekapital, "Aksjekapital", "29032", "20488", "20489", fek.aksjekapital)}
-          {linje("overkursfond", ek.overkursfond, "Overkursfond", "29033", "2585", "7135", fek.overkursfond)}
+          {linje_enkel("overkursfond", ek.overkursfond, "2585", "7135", fek.overkursfond)}
           <sumInnskuttEgenkapital>
             <aarets orid="3730">{_i(sum_innskutt_ek)}</aarets>
             <fjoraarets orid="9984">{_i(fek.aksjekapital + fek.overkursfond)}</fjoraarets>
@@ -377,7 +391,7 @@ def generer_underskjema(regnskap: Aarsregnskap) -> bytes:
             <fjoraarets orid="7156">{_i(flg.sum)}</fjoraarets>
           </sumLangsiktigGjeld>
           <annenLangsiktigGjeld>
-            {linje("langsiktigKonserngjeld", lg.laan_fra_aksjonaer, "Lån fra aksjonær", "29035", "2256", "7152", flg.laan_fra_aksjonaer)}
+            {linje_enkel("langsiktigKonserngjeld", lg.laan_fra_aksjonaer, "2256", "7152", flg.laan_fra_aksjonaer)}
             {linje("oevrigLangsiktigGjeld", lg.andre_langsiktige_laan, "Andre langsiktige lån", "29036", "242", "7155", flg.andre_langsiktige_laan)}
             <sumAnnenLangsiktigGjeld>
               <aarets orid="25019">{_i(lg.sum)}</aarets>
@@ -386,7 +400,7 @@ def generer_underskjema(regnskap: Aarsregnskap) -> bytes:
           </annenLangsiktigGjeld>
         </balanseGjeldAvsetningerForpliktelserAnnenLangsiktigGjeld>
         <balanseKortsiktigGjeld>
-          {linje("leverandoergjeld", kg.leverandoergjeld, "Leverandørgjeld", "29037", "220", "7162", fkg.leverandoergjeld)}
+          {linje_enkel("leverandoergjeld", kg.leverandoergjeld, "220", "7162", fkg.leverandoergjeld)}
           {linje("skyldigeOffentligeAvgifter", kg.skyldige_offentlige_avgifter, "Skyldige offentlige avgifter", "29039", "225", "7170", fkg.skyldige_offentlige_avgifter)}
           {linje("annenKortsiktigGjeld", kg.annen_kortsiktig_gjeld, "Annen kortsiktig gjeld", "29040", "236", "7182", fkg.annen_kortsiktig_gjeld)}
           <sumKortsiktigGjeld>

--- a/wenche/brg_xml.py
+++ b/wenche/brg_xml.py
@@ -119,7 +119,7 @@ def generer_hovedskjema(regnskap: Aarsregnskap) -> bytes:
       <navn orid="1">{s.navn}</navn>
     </enhet>
     <opplysningerInnsending>
-      <noteMaskinellBehandling orid="37499">Maskinell innsending</noteMaskinellBehandling>
+      <noteMaskinellBehandling orid="37499">20</noteMaskinellBehandling>
       <systemNavn orid="39007">Wenche</systemNavn>
     </opplysningerInnsending>
   </Innsender>

--- a/wenche/skd_client.py
+++ b/wenche/skd_client.py
@@ -20,7 +20,7 @@ import httpx
 
 _BASES = {
     "test": "https://api-test.sits.no/api/aksjonaerregister/v1",
-    "prod": "https://api.sits.no/api/aksjonaerregister/v1",  # TODO: verifiser prod-URL
+    "prod": "https://api.skatteetaten.no/api/aksjonaerregister/v1",
 }
 
 

--- a/wenche/skd_client.py
+++ b/wenche/skd_client.py
@@ -9,9 +9,7 @@ Innsendingsflyt:
   2. POST /{år}/{id}/1086U   — send Underskjema for hver aksjonær
   3. POST /{år}/{id}/bekreft — bekreft at alle underskjema er innsendt
 
-Merk: prod-URL er ikke publisert i åpen dokumentasjon. Verifiser mot SwaggerHub
-(https://app.swaggerhub.com/apis/skatteetaten/innrapportering-aksjonaerregister-api/)
-eller ta kontakt med Skatteetaten.
+Prod-URL (api.skatteetaten.no) er verifisert med vellykket innsending 2026-05-04.
 """
 
 import uuid

--- a/wenche/skd_skattemelding_client.py
+++ b/wenche/skd_skattemelding_client.py
@@ -57,7 +57,13 @@ class SkdSkattemeldingClient:
         Returnerer rå XML-bytes (skattemeldingUpersonlig v5).
         Inneholder partsnummer som trengs for innsending — bruk
         skattemelding_xml.hent_partsnummer() for å hente det ut.
+
+        API-et returnerer en wrapper-XML med base64-kodet innhold i <content>.
+        Denne metoden dekoder automatisk hvis wrapper-format oppdages.
         """
+        import base64
+        from xml.etree.ElementTree import fromstring
+
         url = f"{self._base}/api/skattemelding/v2/{inntektsaar}/{orgnr}"
         resp = self._http.get(url, headers={"Accept": "application/xml"})
         if not resp.is_success:
@@ -65,7 +71,21 @@ class SkdSkattemeldingClient:
                 f"Feil ved henting av forhåndsutfylt skattemelding: "
                 f"{resp.status_code}\n{resp.text}"
             )
-        return resp.content
+        raw = resp.content
+
+        # Sjekk om responsen er en wrapper med base64-kodet skattemelding
+        try:
+            root = fromstring(raw)
+            ns = "no:skatteetaten:fastsetting:formueinntekt:skattemeldingognaeringsspesifikasjon:forespoersel:response:v2"
+            content_el = root.find(f".//{{{ns}}}content")
+            if content_el is None:
+                content_el = root.find(".//{*}content")
+            if content_el is not None and content_el.text:
+                return base64.b64decode(content_el.text)
+        except Exception:
+            pass
+
+        return raw
 
     def valider(
         self,

--- a/wenche/skd_skattemelding_client.py
+++ b/wenche/skd_skattemelding_client.py
@@ -16,8 +16,12 @@ Scope: skatteetaten:formueinntekt/skattemelding, altinn:instances.read/write
 
 from __future__ import annotations
 
-import httpx
+import base64
+import binascii
 import json
+from xml.etree.ElementTree import ParseError, fromstring
+
+import httpx
 
 from wenche.altinn_client import AltinnClient
 from wenche.skattemelding_konvolutt import generer_konvolutt
@@ -61,9 +65,6 @@ class SkdSkattemeldingClient:
         API-et returnerer en wrapper-XML med base64-kodet innhold i <content>.
         Denne metoden dekoder automatisk hvis wrapper-format oppdages.
         """
-        import base64
-        from xml.etree.ElementTree import fromstring
-
         url = f"{self._base}/api/skattemelding/v2/{inntektsaar}/{orgnr}"
         resp = self._http.get(url, headers={"Accept": "application/xml"})
         if not resp.is_success:
@@ -82,7 +83,7 @@ class SkdSkattemeldingClient:
                 content_el = root.find(".//{*}content")
             if content_el is not None and content_el.text:
                 return base64.b64decode(content_el.text)
-        except Exception:
+        except (ParseError, binascii.Error):
             pass
 
         return raw


### PR DESCRIPTION
Tre uavhengige fikser oppdaget under produksjonsbruk (innsending av årsregnskap, skattemelding og aksjonærregisteroppgave for regnskapsåret 2025).

1. brg_xml.py — 8 feil orid-verdier + 5 strukturelle XSD-feil
BRG avviste årsregnskapet med «mangler regnskapsskjema» på grunn av XSD-valideringsfeil i underskjema-XML.

Orid-fikser:
- sumOverfoeringerOgDisponeringer: 7067→7071, 7068→7072
- investeringAksjerAndeler: 29018→29024, 7727→7100, 8012→7101
- annenFordring: 29019→29025, 6500→203, 7093→27585

Strukturelle fikser — 5 elementer brukte linje() med <beskrivelse>, men XSD definerer dem som enkeltelementer uten:
- rentekostnad, langsiktigKonserngjeld, annenRenteinntekt (også orid-fiks: 152→150, 7032→7030), leverandoergjeld, overkursfond
Ny hjelpefunksjon linje_enkel() for enkeltelementer. Validert mot RR-0002-U_758-51980.xsd.
2. skd_client.py — Feil prod-URL for aksjonærregisteret
Aksjonærregisterets prod-endepunkt var api.sits.no i stedet for api.skatteetaten.no.
3. skd_skattemelding_client.py — Base64-dekoding av innpakket XML

SKD returnerer forhåndsutfylt skattemelding innpakket i XML med et <content>-element som inneholder base64-kodet data. Lagt til dekodingssteg i hent_forhåndsutfylt().