### PR TITLE
Bump versjon til 0.11.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.11.1"
+version = "0.11.2"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Sammendrag

Patch-bump etter at PR #53 ble merget — tre prod-fikser fra @Villu er nå tilgjengelig på main:

- BRG XSD-valideringsfeil i underskjema (8 orid-verdier + 5 strukturelle feil)
- Korrekt prod-URL for aksjonærregisteret (`api.skatteetaten.no` i stedet for `api.sits.no`)
- Base64-dekoding av wrapper-XML ved henting av forhåndsutfylt skattemelding

Bumper fra `0.11.1` til `0.11.2` slik at fiksene blir tilgjengelige på PyPI.

## Test plan

- [x] CI passerer (testsuite kjører automatisk)
- [x] Etter merge: kjør `/release` for å publisere 0.11.2 til PyPI
