### PR TITLE
Legg til live fristsjekk på Hjem-fanen

### DIFF
--- a/tests/test_fristsjekk.py
+++ b/tests/test_fristsjekk.py
@@ -1,0 +1,239 @@
+"""
+Tester for fristsjekk-modulen (wenche/fristsjekk.py).
+Verifiserer statussjekk mot Skatteetatens og Brønnøysundregistrenes API-er.
+
+Alle HTTP-kall er mocket — testene gjør ingen ekte nettverkskall.
+"""
+
+from unittest.mock import patch, MagicMock
+from xml.etree import ElementTree as ET
+
+import httpx
+import pytest
+
+from wenche.fristsjekk import (
+    FristStatus,
+    sjekk_skattemelding,
+    sjekk_aarsregnskap,
+    sjekk_aksjonaerregister,
+)
+
+
+# ---------------------------------------------------------------------------
+# Hjelpefunksjoner for test-XML
+# ---------------------------------------------------------------------------
+
+_NS = "no:skatteetaten:fastsetting:formueinntekt:skattemeldingognaeringsspesifikasjon:forespoersel:response:v2"
+
+
+def _wrapper_xml(doc_type: str) -> str:
+    """Bygg en minimal wrapper-XML med gitt <type>-verdi."""
+    return (
+        f'<skattemeldingOgNaeringsspesifikasjonforespoerselResponse xmlns="{_NS}">'
+        f"<dokumenter><skattemeldingdokument>"
+        f"<id>SKI:756:1</id><encoding>utf-8</encoding>"
+        f"<content>dW1teQ==</content>"
+        f"<type>{doc_type}</type>"
+        f"</skattemeldingdokument></dokumenter>"
+        f"</skattemeldingOgNaeringsspesifikasjonforespoerselResponse>"
+    )
+
+
+def _mock_response(status_code: int = 200, text: str = "", json_data=None) -> MagicMock:
+    """Lag et mock httpx.Response-objekt."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.is_success = 200 <= status_code < 300
+    resp.text = text
+    if json_data is not None:
+        resp.json.return_value = json_data
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# Skattemelding
+# ---------------------------------------------------------------------------
+
+class TestSjekkSkattemelding:
+
+    @patch("wenche.fristsjekk.httpx.get")
+    @patch("wenche.fristsjekk.get_skd_skattemelding_maskinporten_token", create=True)
+    def test_fastsatt_gir_innfridd(self, mock_token, mock_get):
+        """Respons med skattemeldingUpersonligFastsatt → innfridd=True."""
+        # Importer igjen etter patching
+        import wenche.fristsjekk as mod
+        mock_token_fn = MagicMock(return_value="test-token")
+        with patch.object(mod, "sjekk_skattemelding", wraps=mod.sjekk_skattemelding):
+            with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", mock_token_fn):
+                mock_get.return_value = _mock_response(
+                    text=_wrapper_xml("skattemeldingUpersonligFastsatt"),
+                )
+                result = mod.sjekk_skattemelding("931808869", 2025)
+
+        assert result.innfridd is True
+        assert "sendt inn og godkjent" in result.brukertekst
+        assert "931808869" in result.lenke
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_utkast_gir_ikke_innfridd(self, mock_get):
+        """Respons med skattemeldingUpersonligUtkast → innfridd=False."""
+        with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
+            mock_get.return_value = _mock_response(
+                text=_wrapper_xml("skattemeldingUpersonligUtkast"),
+            )
+            result = sjekk_skattemelding("931808869", 2025)
+
+        assert result.innfridd is False
+        assert "ikke innsendt" in result.brukertekst
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_http_feil_gir_beskrivelse(self, mock_get):
+        """HTTP 500 fra Skatteetaten → innfridd=False med feilmelding."""
+        with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
+            mock_get.return_value = _mock_response(status_code=500)
+            result = sjekk_skattemelding("931808869", 2025)
+
+        assert result.innfridd is False
+        assert "HTTP 500" in result.beskrivelse
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_ugyldig_xml_gir_beskrivelse(self, mock_get):
+        """Ugyldig XML fra Skatteetaten → innfridd=False med feilmelding."""
+        with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
+            mock_get.return_value = _mock_response(text="dette er ikke xml")
+            result = sjekk_skattemelding("931808869", 2025)
+
+        assert result.innfridd is False
+        assert "Ugyldig svar" in result.beskrivelse
+
+    def test_manglende_maskinporten_gir_beskrivelse(self):
+        """RuntimeError fra auth → innfridd=False med 'ikke konfigurert'."""
+        with patch(
+            "wenche.auth.get_skd_skattemelding_maskinporten_token",
+            side_effect=RuntimeError("MASKINPORTEN_CLIENT_ID mangler"),
+        ):
+            result = sjekk_skattemelding("931808869", 2025)
+
+        assert result.innfridd is False
+        assert "Maskinporten" in result.beskrivelse
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_nettverksfeil_gir_beskrivelse(self, mock_get):
+        """Timeout/nettverksfeil → innfridd=False med feilmelding."""
+        with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
+            mock_get.side_effect = httpx.ConnectError("Connection refused")
+            result = sjekk_skattemelding("931808869", 2025)
+
+        assert result.innfridd is False
+        assert "kontakte Skatteetaten" in result.beskrivelse
+
+
+# ---------------------------------------------------------------------------
+# Årsregnskap
+# ---------------------------------------------------------------------------
+
+class TestSjekkAarsregnskap:
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_regnskap_funnet_gir_innfridd(self, mock_get):
+        """Regnskap for riktig år i BRG-respons → innfridd=True."""
+        mock_get.return_value = _mock_response(json_data=[
+            {
+                "regnskapsperiode": {"fraDato": "2025-01-01", "tilDato": "2025-12-31"},
+                "mottaksdag": "2026-04-15",
+            },
+        ])
+        result = sjekk_aarsregnskap("931808869", 2025)
+
+        assert result.innfridd is True
+        assert "levert" in result.brukertekst.lower()
+        assert result.tidspunkt == "2026-04-15"
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_annet_aar_gir_ikke_innfridd(self, mock_get):
+        """Kun regnskap for 2024 i respons, spør etter 2025 → innfridd=False."""
+        mock_get.return_value = _mock_response(json_data=[
+            {
+                "regnskapsperiode": {"fraDato": "2024-01-01", "tilDato": "2024-12-31"},
+            },
+        ])
+        result = sjekk_aarsregnskap("931808869", 2025)
+
+        assert result.innfridd is False
+        assert "ikke levert" in result.brukertekst.lower()
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_tom_liste_gir_ikke_innfridd(self, mock_get):
+        """Tom liste fra BRG → innfridd=False."""
+        mock_get.return_value = _mock_response(json_data=[])
+        result = sjekk_aarsregnskap("931808869", 2025)
+
+        assert result.innfridd is False
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_http_feil_gir_beskrivelse(self, mock_get):
+        """HTTP-feil fra BRG → innfridd=False med feilmelding."""
+        mock_get.return_value = _mock_response(status_code=404)
+        result = sjekk_aarsregnskap("931808869", 2025)
+
+        assert result.innfridd is False
+        assert "kontakte" in result.beskrivelse.lower()
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_nettverksfeil_gir_beskrivelse(self, mock_get):
+        """Nettverksfeil mot BRG → innfridd=False med feilmelding."""
+        mock_get.side_effect = httpx.ConnectError("Connection refused")
+        result = sjekk_aarsregnskap("931808869", 2025)
+
+        assert result.innfridd is False
+        assert "kontakte" in result.beskrivelse.lower()
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_ugyldig_json_gir_beskrivelse(self, mock_get):
+        """Ugyldig JSON fra BRG → innfridd=False med feilmelding."""
+        resp = _mock_response()
+        resp.json.side_effect = ValueError("Invalid JSON")
+        mock_get.return_value = resp
+        result = sjekk_aarsregnskap("931808869", 2025)
+
+        assert result.innfridd is False
+        assert "Uventet svar" in result.beskrivelse
+
+
+# ---------------------------------------------------------------------------
+# Aksjonærregister
+# ---------------------------------------------------------------------------
+
+class TestSjekkAksjonaerregister:
+
+    def test_returnerer_alltid_ikke_innfridd(self):
+        """Ingen offentlig API — skal alltid returnere innfridd=False."""
+        result = sjekk_aksjonaerregister("931808869", 2025)
+
+        assert result.innfridd is False
+        assert result.beskrivelse != ""
+
+
+# ---------------------------------------------------------------------------
+# FristStatus dataklasse
+# ---------------------------------------------------------------------------
+
+class TestFristStatus:
+
+    def test_standardverdier(self):
+        """FristStatus() med standardverdier skal være ikke-innfridd."""
+        status = FristStatus()
+        assert status.innfridd is False
+        assert status.tidspunkt is None
+        assert status.lenke is None
+
+    def test_innfridd_med_lenke(self):
+        """FristStatus med alle felt utfylt."""
+        status = FristStatus(
+            innfridd=True,
+            brukertekst="Levert",
+            lenke="https://example.com",
+            tidspunkt="2026-03-30",
+        )
+        assert status.innfridd is True
+        assert status.lenke == "https://example.com"

--- a/wenche/auth.py
+++ b/wenche/auth.py
@@ -55,6 +55,9 @@ SKD_SKATTEMELDING_SCOPE = (
     "skatteetaten:formueinntekt/skattemelding "
     "altinn:instances.read altinn:instances.write"
 )
+
+# Scope for lesestatus fra SKDs skattemelding-API (ingen Altinn-instanser)
+SKD_SKATTEMELDING_LESE_SCOPE = "skatteetaten:formueinntekt/skattemelding"
 TOKEN_FILE = Path.home() / ".wenche" / "token.json"
 
 
@@ -242,6 +245,37 @@ def get_skd_aksjonaer_token() -> str:
 
     return _hent_maskinporten_token(
         client_id, private_key_pem, kid, scopes=SKD_AKSJONAER_SCOPE, org_nummer=org_nummer
+    )
+
+
+def get_skd_skattemelding_maskinporten_token() -> str:
+    """
+    Henter et Maskinporten-token med skattemelding-scope (kun lesestatus).
+
+    Brukes for read-only sjekk av fastsettingsstatus mot SKDs API.
+    Ingen Altinn-veksling — krever ikke at brukeren har Altinn-rettigheter.
+    """
+    client_id = _les_påkrevd_env(
+        "MASKINPORTEN_CLIENT_ID",
+        "Kopier .env.example til .env og fyll inn din klient-ID fra Digdirs selvbetjeningsportal.",
+    )
+    kid = _les_påkrevd_env(
+        "MASKINPORTEN_KID",
+        "Finn nøkkel-ID (UUID) i Digdirs selvbetjeningsportal under klientens nøkler og legg den i .env.",
+    )
+    vendor_orgnr = _les_påkrevd_env(
+        "ORG_NUMMER",
+        "Legg til ORG_NUMMER=<ditt organisasjonsnummer> i .env.",
+    )
+    env = os.getenv("WENCHE_ENV", "prod")
+    org_nummer = os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr) if env == "test" else vendor_orgnr
+    nokkel_sti = os.getenv("MASKINPORTEN_PRIVAT_NOKKEL", "maskinporten_privat.pem")
+    private_key_pem = _les_nokkel(nokkel_sti)
+
+    return _hent_maskinporten_token(
+        client_id, private_key_pem, kid,
+        scopes=SKD_SKATTEMELDING_LESE_SCOPE,
+        org_nummer=org_nummer,
     )
 
 

--- a/wenche/fristsjekk.py
+++ b/wenche/fristsjekk.py
@@ -5,6 +5,15 @@ Brukes av Wenche UI for å vise om frister er innfridd:
   - Skattemelding: Skatteetatens API (krever Maskinporten-token)
   - Årsregnskap:   Brønnøysundregistrenes åpne Regnskapsregister-API
   - Aksjonærregisteroppgave: Ingen offentlig status-API tilgjengelig
+
+Skattemelding-sjekken bruker endepunktet GET /api/skattemelding/v2/{aar}/{orgnr}
+som returnerer en XML-wrapper med <type>-element. Verdiene er definert i
+Skatteetatens offisielle XSD-skjema (Dokumenttype):
+  - skattemeldingUpersonligUtkast    → forhåndsutfylt, ikke innsendt
+  - skattemeldingUpersonligFastsatt  → innsendt og fastsatt
+
+Kilde: https://github.com/Skatteetaten/skattemeldingen/blob/master/src/resources/
+       xsd/skattemeldingognaeringsspesifikasjonforespoerselresponse_v2_kompakt.xsd
 """
 
 from __future__ import annotations
@@ -25,8 +34,8 @@ _SKD_BASES = {
 }
 
 # Brønnøysundregistrenes Regnskapsregister-API.
-# Åpent API uten autentisering. Dokumentasjon:
-# https://data.brreg.no/regnskapsregisteret/openapi/index.html
+# Åpent API uten autentisering.
+# Dokumentasjon: https://data.brreg.no/regnskapsregisteret/openapi/index.html
 _BRG_REGNSKAP_URL = "https://data.brreg.no/regnskapsregisteret/regnskap"
 
 
@@ -42,10 +51,10 @@ class FristStatus:
 def sjekk_skattemelding(orgnr: str, aar: int) -> FristStatus:
     """Sjekk om skattemelding er fastsatt via Skatteetatens API."""
     try:
-        from wenche.auth import get_skd_skattemelding_tokens
+        from wenche.auth import get_skd_skattemelding_maskinporten_token
 
-        tokens = get_skd_skattemelding_tokens()
-    except Exception:
+        token = get_skd_skattemelding_maskinporten_token()
+    except RuntimeError:
         return FristStatus(beskrivelse="Maskinporten ikke konfigurert")
 
     env = os.getenv("WENCHE_ENV", "prod")
@@ -55,7 +64,7 @@ def sjekk_skattemelding(orgnr: str, aar: int) -> FristStatus:
         resp = httpx.get(
             f"{base}/api/skattemelding/v2/{aar}/{orgnr}",
             headers={
-                "Authorization": f"Bearer {tokens['maskinporten_token']}",
+                "Authorization": f"Bearer {token}",
                 "Accept": "application/xml",
             },
             timeout=30,
@@ -71,6 +80,9 @@ def sjekk_skattemelding(orgnr: str, aar: int) -> FristStatus:
     except ET.ParseError:
         return FristStatus(beskrivelse="Ugyldig svar fra Skatteetaten")
 
+    # <type>-elementet i wrapper-XML-en angir dokumentstatus.
+    # "Fastsatt" i verdien betyr at skattemeldingen er innsendt og godkjent.
+    # Ref: Dokumenttype-enum i XSD (se modul-docstring).
     for elem in root.iter():
         tag = elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
         if tag == "type" and elem.text and "Fastsatt" in elem.text:
@@ -102,7 +114,7 @@ def sjekk_aarsregnskap(orgnr: str, aar: int) -> FristStatus:
 
     try:
         data = resp.json()
-    except Exception:
+    except ValueError:
         return FristStatus(beskrivelse="Uventet svar fra Regnskapsregisteret")
 
     if not isinstance(data, list):

--- a/wenche/fristsjekk.py
+++ b/wenche/fristsjekk.py
@@ -1,0 +1,133 @@
+"""
+Sjekk innsendingsstatus mot offentlige API-er.
+
+Brukes av Wenche UI for å vise om frister er innfridd:
+  - Skattemelding: Skatteetatens API (krever Maskinporten-token)
+  - Årsregnskap:   Brønnøysundregistrenes åpne Regnskapsregister-API
+  - Aksjonærregisteroppgave: Ingen offentlig status-API tilgjengelig
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from xml.etree import ElementTree as ET
+
+import httpx
+from dotenv import load_dotenv
+
+load_dotenv()
+
+# Basis-URL-er for Skatteetatens API — samme som i skd_skattemelding_client.py.
+_SKD_BASES = {
+    "test": "https://api-test.sits.no",
+    "prod": "https://api.skatteetaten.no",
+}
+
+# Brønnøysundregistrenes Regnskapsregister-API.
+# Åpent API uten autentisering. Dokumentasjon:
+# https://data.brreg.no/regnskapsregisteret/openapi/index.html
+_BRG_REGNSKAP_URL = "https://data.brreg.no/regnskapsregisteret/regnskap"
+
+
+@dataclass
+class FristStatus:
+    innfridd: bool = False
+    tidspunkt: str | None = None
+    beskrivelse: str = ""
+    brukertekst: str = ""
+    lenke: str | None = None
+
+
+def sjekk_skattemelding(orgnr: str, aar: int) -> FristStatus:
+    """Sjekk om skattemelding er fastsatt via Skatteetatens API."""
+    try:
+        from wenche.auth import get_skd_skattemelding_tokens
+
+        tokens = get_skd_skattemelding_tokens()
+    except Exception:
+        return FristStatus(beskrivelse="Maskinporten ikke konfigurert")
+
+    env = os.getenv("WENCHE_ENV", "prod")
+    base = _SKD_BASES.get(env, _SKD_BASES["prod"])
+
+    try:
+        resp = httpx.get(
+            f"{base}/api/skattemelding/v2/{aar}/{orgnr}",
+            headers={
+                "Authorization": f"Bearer {tokens['maskinporten_token']}",
+                "Accept": "application/xml",
+            },
+            timeout=30,
+        )
+    except httpx.HTTPError:
+        return FristStatus(beskrivelse="Kunne ikke kontakte Skatteetaten")
+
+    if not resp.is_success:
+        return FristStatus(beskrivelse=f"Skatteetaten svarte med HTTP {resp.status_code}")
+
+    try:
+        root = ET.fromstring(resp.text)
+    except ET.ParseError:
+        return FristStatus(beskrivelse="Ugyldig svar fra Skatteetaten")
+
+    for elem in root.iter():
+        tag = elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
+        if tag == "type" and elem.text and "Fastsatt" in elem.text:
+            return FristStatus(
+                innfridd=True,
+                brukertekst=f"Skattemeldingen for {aar} er sendt inn og godkjent.",
+                lenke=f"https://af.altinn.no/?party=urn%3Aaltinn%3Aorganization%3Aidentifier-no%3A{orgnr}",
+            )
+
+    return FristStatus(
+        beskrivelse="Ikke innsendt",
+        brukertekst=f"Skattemeldingen for {aar} er ikke innsendt ennå.",
+    )
+
+
+def sjekk_aarsregnskap(orgnr: str, aar: int) -> FristStatus:
+    """Sjekk om årsregnskap er levert via Brønnøysundregistrenes API."""
+    try:
+        resp = httpx.get(
+            f"{_BRG_REGNSKAP_URL}/{orgnr}",
+            headers={"Accept": "application/json"},
+            timeout=15,
+        )
+    except httpx.HTTPError:
+        return FristStatus(beskrivelse="Kunne ikke kontakte Regnskapsregisteret")
+
+    if not resp.is_success:
+        return FristStatus(beskrivelse="Kunne ikke kontakte Regnskapsregisteret")
+
+    try:
+        data = resp.json()
+    except Exception:
+        return FristStatus(beskrivelse="Uventet svar fra Regnskapsregisteret")
+
+    if not isinstance(data, list):
+        return FristStatus(beskrivelse="Uventet svar fra Regnskapsregisteret")
+
+    for regnskap in data:
+        periode = regnskap.get("regnskapsperiode", {})
+        fra = periode.get("fraDato", "")
+        if fra.startswith(str(aar)):
+            mottatt = regnskap.get("mottaksdag")
+            return FristStatus(
+                innfridd=True,
+                tidspunkt=mottatt,
+                brukertekst=f"Årsregnskapet for {aar} er levert til Brønnøysundregistrene.",
+            )
+
+    return FristStatus(
+        beskrivelse="Ikke levert",
+        brukertekst=f"Årsregnskapet for {aar} er ikke levert ennå.",
+    )
+
+
+def sjekk_aksjonaerregister(orgnr: str, aar: int) -> FristStatus:
+    """Aksjonærregister — ingen offentlig status-API tilgjengelig."""
+    return FristStatus(
+        beskrivelse="Ingen automatisk sjekk tilgjengelig",
+        brukertekst="Sjekk status manuelt hos Skatteetaten.",
+    )

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -697,14 +697,54 @@ def _frist_info(maaned: int, dag: int) -> tuple[str, str, str]:
         return dato_tekst, f"{dager} dager igjen", "green-600"
 
 
-def _fristkort(tittel: str, undertittel: str, maaned: int, dag: int, beskrivelse: str) -> None:
-    dato_tekst, status_tekst, farge = _frist_info(maaned, dag)
-    with ui.card().classes("w-full p-5 border border-slate-200 shadow-none rounded-xl"):
-        with ui.column().classes("gap-0 w-full"):
+def _fristkort(tittel: str, undertittel: str) -> tuple:
+    """Oppretter fristkort med loading-tilstand. Returnerer (card, content)."""
+    card = ui.card().classes("w-full p-5 border border-slate-200 shadow-none rounded-xl")
+    with card:
+        content = ui.column().classes("w-full gap-0")
+        with content:
             ui.label(tittel).classes("font-semibold text-slate-800 text-base")
-            ui.label(undertittel).classes("text-xs text-slate-500 mb-2")
-            ui.label(dato_tekst).classes(f"text-sm font-medium text-{farge}")
-            ui.label(status_tekst).classes(f"text-xs text-{farge}")
+            ui.label(undertittel).classes("text-xs text-slate-500 mb-3")
+            with ui.row().classes("items-center gap-2"):
+                ui.spinner(size="sm").classes("text-slate-400")
+                ui.label("Sjekker status...").classes("text-xs text-slate-400 italic")
+    return card, content
+
+
+def _fristkort_innfridd(card, content, tittel: str, undertittel: str, result) -> None:
+    """Vis fristkort som fullført — grønt, ingen frist, tydelig bekreftelse."""
+    card.classes(remove="border-slate-200", add="border-green-200 bg-green-50/50")
+    content.clear()
+    with content:
+        ui.label(tittel).classes("font-semibold text-slate-800 text-base")
+        ui.label(undertittel).classes("text-xs text-slate-500 mb-3")
+        with ui.row().classes("items-center gap-2"):
+            ui.icon("check_circle").classes("text-green-600 text-2xl")
+            ui.label("Levert").classes("text-lg font-bold text-green-700")
+        ui.label(result.brukertekst).classes("text-sm text-slate-600 mt-2")
+        if result.tidspunkt:
+            ui.label(f"Mottatt {result.tidspunkt}").classes("text-xs text-slate-400 mt-1")
+        if result.lenke:
+            ui.separator().classes("my-3")
+            ui.link(
+                "Åpne kvittering i Altinn →", result.lenke, new_tab=True
+            ).classes("text-sm text-green-700 font-medium")
+
+
+def _fristkort_ventende(card, content, tittel: str, undertittel: str, maaned: int, dag: int,
+                         beskrivelse: str, result=None) -> None:
+    """Vis fristkort med nedtelling til frist."""
+    dato_tekst, countdown, farge = _frist_info(maaned, dag)
+    content.clear()
+    with content:
+        ui.label(tittel).classes("font-semibold text-slate-800 text-base")
+        ui.label(undertittel).classes("text-xs text-slate-500 mb-2")
+        if result and result.beskrivelse:
+            with ui.row().classes("items-center gap-1 mb-1"):
+                ui.icon("schedule").classes("text-slate-400 text-base")
+                ui.label(result.beskrivelse).classes("text-sm text-slate-500")
+        ui.label(dato_tekst).classes(f"text-sm font-medium text-{farge}")
+        ui.label(countdown).classes(f"text-xs text-{farge}")
         ui.separator().classes("my-3")
         ui.label(beskrivelse).classes("text-sm text-slate-600")
 
@@ -720,28 +760,62 @@ def _bygg_hjem_fane() -> None:
         ui.link("dokumentasjonen", "https://olefredrik.github.io/Wenche/", new_tab=True).classes("text-sm")
         ui.label(", der finner du hjelp til å sette opp alt riktig.").classes("text-sm text-slate-500")
 
-    ui.label("Frister").classes("text-lg font-semibold mb-3")
+    with ui.row().classes("items-center gap-3 mb-3"):
+        ui.label("Frister").classes("text-lg font-semibold")
+        ui.button(
+            "Oppdater status",
+            on_click=lambda: sjekk_alle_frister(),
+        ).props("outline color=primary size=sm flat icon=refresh")
+
+    frister = [
+        {"key": "skattemelding", "tittel": "Skattemelding", "undertittel": "RF-1167 + RF-1028",
+         "maaned": 5, "dag": 31,
+         "beskrivelse": "Wenche beregner skatten og sender skattemeldingen digitalt via Altinn i steg 6."},
+        {"key": "aarsregnskap", "tittel": "Årsregnskap", "undertittel": "Brønnøysundregistrene",
+         "maaned": 7, "dag": 31,
+         "beskrivelse": "Sendes digitalt via Altinn i steg 6. "
+                        "Krever signering med BankID av daglig leder eller styreleder."},
+        {"key": "aksjonaerregister", "tittel": "Aksjonærregisteroppgave",
+         "undertittel": "RF-1086, Skatteetaten", "maaned": 1, "dag": 31,
+         "beskrivelse": "Sendes maskinelt til Skatteetatens API via steg 6. "
+                        "Ingen manuell signering nødvendig."},
+    ]
+
+    kort: dict[str, tuple] = {}
     with ui.grid(columns=3).classes("w-full gap-4"):
-        _fristkort(
-            "Skattemelding",
-            "RF-1167 + RF-1028",
-            5, 31,
-            "Wenche beregner skatten og sender skattemeldingen digitalt via Altinn i steg 6.",
-        )
-        _fristkort(
-            "Årsregnskap",
-            "Brønnøysundregistrene",
-            7, 31,
-            "Sendes digitalt via Altinn i steg 6. "
-            "Krever signering med BankID av daglig leder eller styreleder.",
-        )
-        _fristkort(
-            "Aksjonærregisteroppgave",
-            "RF-1086, Skatteetaten",
-            1, 31,
-            "Sendes maskinelt til Skatteetatens API via steg 6. "
-            "Ingen manuell signering nødvendig.",
-        )
+        for f in frister:
+            card, content = _fristkort(f["tittel"], f["undertittel"])
+            kort[f["key"]] = (card, content, f)
+
+    async def sjekk_alle_frister():
+        from wenche.fristsjekk import sjekk_skattemelding, sjekk_aarsregnskap, sjekk_aksjonaerregister
+
+        orgnr = state.org_nummer
+        aar = int(state.regnskapsaar)
+        check_fns = {
+            "skattemelding": sjekk_skattemelding,
+            "aarsregnskap": sjekk_aarsregnskap,
+            "aksjonaerregister": sjekk_aksjonaerregister,
+        }
+
+        for key, (card, content, info) in kort.items():
+            try:
+                result = await run.io_bound(check_fns[key], orgnr, aar)
+                if result.innfridd:
+                    _fristkort_innfridd(card, content, info["tittel"], info["undertittel"], result)
+                else:
+                    _fristkort_ventende(
+                        card, content, info["tittel"], info["undertittel"],
+                        info["maaned"], info["dag"], info["beskrivelse"], result,
+                    )
+            except Exception:
+                _fristkort_ventende(
+                    card, content, info["tittel"], info["undertittel"],
+                    info["maaned"], info["dag"], info["beskrivelse"],
+                )
+
+    # Sjekk automatisk ved sidelasting
+    ui.timer(1.0, sjekk_alle_frister, once=True)
 
     ui.separator().classes("my-6")
     ui.label("Ansvarsfraskrivelse").classes("text-sm font-semibold text-slate-700 mb-1")

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -784,35 +784,59 @@ def _bygg_hjem_fane() -> None:
     kort: dict[str, tuple] = {}
     with ui.grid(columns=3).classes("w-full gap-4"):
         for f in frister:
-            card, content = _fristkort(f["tittel"], f["undertittel"])
+            if f["key"] == "aksjonaerregister":
+                # Ingen automatisk sjekk — vis sluttilstand direkte uten spinner.
+                from wenche.fristsjekk import FristStatus
+                card, content = _fristkort(f["tittel"], f["undertittel"])
+                _fristkort_ventende(
+                    card, content, f["tittel"], f["undertittel"],
+                    f["maaned"], f["dag"], f["beskrivelse"],
+                    FristStatus(beskrivelse="Ingen automatisk sjekk tilgjengelig"),
+                )
+            else:
+                card, content = _fristkort(f["tittel"], f["undertittel"])
             kort[f["key"]] = (card, content, f)
 
+    async def _sjekk_en_frist(key, check_fn, orgnr, aar):
+        """Kjør én fristsjekk og oppdater kortet."""
+        card, content, info = kort[key]
+        try:
+            result = await run.io_bound(check_fn, orgnr, aar)
+            if result.innfridd:
+                _fristkort_innfridd(card, content, info["tittel"], info["undertittel"], result)
+            else:
+                _fristkort_ventende(
+                    card, content, info["tittel"], info["undertittel"],
+                    info["maaned"], info["dag"], info["beskrivelse"], result,
+                )
+        except Exception:
+            _fristkort_ventende(
+                card, content, info["tittel"], info["undertittel"],
+                info["maaned"], info["dag"], info["beskrivelse"],
+            )
+
     async def sjekk_alle_frister():
-        from wenche.fristsjekk import sjekk_skattemelding, sjekk_aarsregnskap, sjekk_aksjonaerregister
+        import asyncio
+        from wenche.fristsjekk import sjekk_skattemelding, sjekk_aarsregnskap
 
         orgnr = state.org_nummer
         aar = int(state.regnskapsaar)
-        check_fns = {
-            "skattemelding": sjekk_skattemelding,
-            "aarsregnskap": sjekk_aarsregnskap,
-            "aksjonaerregister": sjekk_aksjonaerregister,
-        }
 
-        for key, (card, content, info) in kort.items():
-            try:
-                result = await run.io_bound(check_fns[key], orgnr, aar)
-                if result.innfridd:
-                    _fristkort_innfridd(card, content, info["tittel"], info["undertittel"], result)
-                else:
+        # Ikke send API-kall med placeholder eller tomt org.nr.
+        if not orgnr or orgnr == "123456789":
+            for key, (card, content, info) in kort.items():
+                if key != "aksjonaerregister":
                     _fristkort_ventende(
                         card, content, info["tittel"], info["undertittel"],
-                        info["maaned"], info["dag"], info["beskrivelse"], result,
+                        info["maaned"], info["dag"], info["beskrivelse"],
                     )
-            except Exception:
-                _fristkort_ventende(
-                    card, content, info["tittel"], info["undertittel"],
-                    info["maaned"], info["dag"], info["beskrivelse"],
-                )
+            return
+
+        # Kjør skattemelding- og årsregnskap-sjekk parallelt.
+        await asyncio.gather(
+            _sjekk_en_frist("skattemelding", sjekk_skattemelding, orgnr, aar),
+            _sjekk_en_frist("aarsregnskap", sjekk_aarsregnskap, orgnr, aar),
+        )
 
     # Sjekk automatisk ved sidelasting
     ui.timer(1.0, sjekk_alle_frister, once=True)


### PR DESCRIPTION
## Sammendrag

Fristkortene på Hjem-fanen sjekker nå automatisk om innsendinger er levert, slik at brukeren umiddelbart ser hva som gjenstår uten å måtte logge inn på Altinn eller Skatteetaten manuelt.

### Hva endres

**Ny fil: `wenche/fristsjekk.py`**
- `sjekk_skattemelding(orgnr, aar)` — spør Skatteetatens API om meldingen er fastsatt (krever Maskinporten-token)
- `sjekk_aarsregnskap(orgnr, aar)` — spør Brønnøysundregistrenes åpne Regnskapsregister-API (ingen autentisering nødvendig)
- `sjekk_aksjonaerregister(orgnr, aar)` — returnerer «ingen automatisk sjekk» (SKD har ingen offentlig status-API)
- `FristStatus`-dataklasse med felt for `innfridd`, `brukertekst`, `lenke` og `tidspunkt`
- Robust feilhåndtering: nettverksfeil, ugyldig XML, manglende Maskinporten-konfig — alt gir brukervennlige meldinger i stedet for å krasje

**Endret: `wenche/ui.py`**
- Fristkort har nå to tilstander:
  - **Levert**: Grønt kort med sjekkmerke, klartekst («Skattemeldingen for 2025 er sendt inn og godkjent»), og lenke til Altinn innboks med org.nr. forhåndsvalgt i URL-en. Frist og nedtelling fjernes helt.
  - **Ventende**: Beholder dagens design med nedtelling
- Automatisk sjekk ved sidelasting (async via `run.io_bound`, blokkerer ikke UI)
- «Oppdater status»-knapp for manuell re-sjekk
- Loading-tilstand med spinner mens API-sjekkene kjører

### Bakgrunn

Som bruker av Wenche for et holdingselskap oppdaget jeg at det var vanskelig å vite om frister faktisk var innfridd. Hjem-fanen viste alltid nedtelling uavhengig av om oppgaven var levert. Denne endringen gjør at brukeren med ett blikk ser hva som er gjort og hva som gjenstår.

### Skjermbilde

Leverte oppgaver vises slik (eksempel — skattemelding innfridd):

```
┌─────────────────────────────────────┐
│  Skattemelding                      │
│  RF-1167 + RF-1028                  │
│                                     │
│  ✅ Levert                          │
│  Skattemeldingen for 2025 er sendt  │
│  inn og godkjent.                   │
│  ─────────────────────              │
│  Åpne kvittering i Altinn →        │
└─────────────────────────────────────┘
```

## Test plan

- [ ] `wenche ui` — Hjem-fanen laster og viser spinner mens den sjekker
- [ ] Skattemelding vises som «Levert» med grønt kort når den er fastsatt hos SKD
- [ ] Årsregnskap vises som «Levert» når det finnes i Regnskapsregisteret
- [ ] Ventende oppgaver viser frist med nedtelling som før
- [ ] «Oppdater status»-knappen re-sjekker alle frister
- [ ] Feilhåndtering: fjern `.env` midlertidig — skattemelding-sjekken skal vise «Maskinporten ikke konfigurert», ikke krasje
- [ ] Altinn-lenken inneholder riktig org.nr. fra config

🤖 Generated with [Claude Code](https://claude.com/claude-code)