### PR TITLE
fix: bruk date.day for datoformatering på tvers av plattformer

### DIFF
--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -682,7 +682,7 @@ def _frist_info(maaned: int, dag: int) -> tuple[str, str, str]:
     if frist < today:
         frist = date(today.year + 1, maaned, dag)
     dager = (frist - today).days
-    dato_tekst = frist.strftime("%-d. %B %Y").replace(
+    dato_tekst = f"{frist.day}. {frist.strftime('%B %Y')}".replace(
         "January", "januar").replace("February", "februar").replace(
         "March", "mars").replace("April", "april").replace(
         "May", "mai").replace("June", "juni").replace(


### PR DESCRIPTION
Fikser #56

## Problem

`wenche ui` krasjet ved oppstart på Windows med:

```
ValueError: Invalid format string
```

Årsaken var bruk av `%-d` i `strftime`-kallet i `_frist_info`. Dette direktivet er kun støttet på **Linux og macOS** — på Windows kaster Python en `ValueError`.

## Endring

```python
# Før (Linux/macOS-spesifikt):
dato_tekst = frist.strftime("%-d. %B %Y")

# Etter (fungerer på Windows, macOS og Linux):
dato_tekst = f"{frist.day}. {frist.strftime('%B %Y')}"
```

`date.day` er et heltallsattributt uten ledende null og er tilgjengelig på alle plattformer. Kun `%B %Y` (månedsnavn og år) sendes til `strftime`, og disse direktivene er portable.

## Testet på

- Windows (feilen er reprodusert og bekreftet rettet)
- Fungerer identisk på Linux/macOS (ingen atferdsendring)