### PR TITLE
chore: bump versjon til 0.11.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.11.2"
+version = "0.11.3"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary
- Bumper versjon fra `0.11.2` til `0.11.3` i forkant av PyPI-release
- Releasen inneholder cross-platform datoformat-fix fra #57 (lukker #56) — Windows-brukere får ikke lenger `ValueError` ved oppstart av `wenche ui`

## Test plan
- [x] CI grønn
- [x] Etter merge: tag `v0.11.3` og push for automatisk PyPI-publisering