### PR TITLE
chore: bump versjon til 0.12.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.11.3"
+version = "0.12.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Sammendrag

Bump til 0.12.0 etter at #55 (live fristsjekk på Hjem-fanen) ble merget.

MINOR-bump siden det er ny funksjonalitet (`feat`).

## Test plan

- [x] Versjonsstrengen i `pyproject.toml` er 0.12.0
- [x] Etter merge: tag `v0.12.0` på main og push for å trigge PyPI-publisering