### PR TITLE
chore: bump versjon til 0.12.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.12.0"
+version = "0.12.1"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Sammendrag

Bump til 0.12.1 etter at #60 (fix for riktig regnskapsår i fristsjekk) ble merget.

PATCH-bump siden det er en bugfix (`fix`).

## Test plan

- [x] Versjonsstrengen i `pyproject.toml` er 0.12.1
- [x] Etter merge: tag `v0.12.1` på main og push for å trigge PyPI-publisering