### PR TITLE
docs: dokumenter Hjem-fanen og oppdater skattemelding-status

### DIFF
--- a/docs/bruk.md
+++ b/docs/bruk.md
@@ -4,6 +4,28 @@ Wenche brukes primært via **webgrensesnittet** (`wenche ui`) — et grafisk gre
 
 ---
 
+## Hjem-fanen
+
+Når du åpner `wenche ui` lander du på **Hjem**-fanen. Den viser tre fristkort — ett for hver årlige innsending:
+
+- **Skattemelding** (frist 31. mai)
+- **Årsregnskap** (frist 31. juli)
+- **Aksjonærregisteroppgave** (frist 31. januar)
+
+Hvert kort viser hvor mange dager det er igjen til neste frist, og kjører en automatisk statussjekk mot offentlige API-er for å se om innsendingen allerede er gjort:
+
+| Kort | Statuskilde |
+|---|---|
+| Skattemelding | Skatteetatens skattemelding-API (krever Maskinporten-konfig) |
+| Årsregnskap | Brønnøysundregistrenes åpne Regnskapsregister |
+| Aksjonærregisteroppgave | Ingen offentlig status-API — sjekk manuelt hos Skatteetaten |
+
+Når statussjekken bekrefter at innsendingen er gjort, vises kortet grønt med «Levert» og en lenke til Altinn-kvitteringen. Knappen **Oppdater status** kjører sjekkene på nytt.
+
+Statussjekkene gjøres mot regnskapsåret som tilhører neste frist (f.eks. 31. juli 2026 → regnskapsår 2025), ikke det arbeidsåret du har valgt i fanen **Oppsett**.
+
+---
+
 ## Autentisering
 
 Innsending av årsregnskap og aksjonærregisteroppgave krever innlogging mot Maskinporten:

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,10 +14,7 @@ Alle AS plikter å levere tre ting hvert år:
 |---|---|---|---|
 | **Årsregnskap** | Brønnøysundregistrene | 31. juli | Automatisk innsending |
 | **Aksjonærregisteroppgave** (RF-1086) | Skatteetaten via Altinn | 31. januar | Automatisk innsending |
-| **Skattemelding for AS** (RF-1028 + RF-1167) | Skatteetaten | 31. mai | Genereres lokalt — sendes inn manuelt |
-
-!!! info "Om skattemeldingen"
-    Automatisk innsending av skattemelding krever registrering som systemleverandør hos Skatteetaten. Wenche genererer i stedet et ferdig utfylt sammendrag som du kopierer inn på skatteetaten.no.
+| **Skattemelding for AS** (RF-1028 + RF-1167) | Skatteetaten | 31. mai | Automatisk innsending |
 
 ## Hva er de ulike skjemaene?
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -29,7 +29,9 @@ Denne veiledningen tar deg gjennom en komplett innsending fra start til slutt. V
     wenche ui
     ```
 
-    Wenche åpner `http://localhost:8080` i nettleseren. Du ser fem faner øverst: **Selskap**, **Regnskap**, **Aksjonærer**, **Dokumenter** og **Send til Altinn**.
+    Wenche åpner `http://localhost:8080` i nettleseren. Du ser sju faner øverst: **Hjem**, **1. Oppsett**, **2. Selskap**, **3. Regnskap**, **4. Aksjonærer**, **5. Dokumenter** og **6. Send til Altinn**.
+
+    **Hjem**-fanen viser fristkort for de tre årlige innsendingene med live statussjekk — se [Bruk → Hjem-fanen](bruk.md#hjem-fanen) for detaljer. Resten av denne tutorialen går gjennom steg 1–6.
 
 === "Kommandolinje"
 


### PR DESCRIPTION
## Sammendrag

Følger opp #55, #60 og prosjektets eksisterende skattemelding-API-implementasjon ved å bringe dokumentasjonen i samsvar med faktisk oppførsel.

## Endringer

**`docs/bruk.md`** — Ny seksjon `## Hjem-fanen` som beskriver:
- De tre fristkortene (skattemelding, årsregnskap, aksjonærregister)
- Hvilke offentlige API-er statussjekken bruker (Skatteetaten + BRG)
- Hva grønn «Levert»-tilstand betyr og hvordan «Oppdater status» fungerer
- Hvilket regnskapsår sjekken refererer til (det som hører til neste frist, jf. #60)

**`docs/tutorial.md`** — Steg 1 sa tidligere "fem faner: Selskap, Regnskap, Aksjonærer, Dokumenter og Send til Altinn". Reelt finnes det nå sju faner (Hjem og Oppsett manglet). Oppdatert listen og lagt til peker til den nye bruk.md-seksjonen.

**`docs/index.md`** — Oversiktstabellen sa "Skattemelding ... Genereres lokalt — sendes inn manuelt", men `wenche/skd_skattemelding_client.py` har vært implementert siden API-tilgang ble innvilget. Endret til "Automatisk innsending" og fjernet den nå utdaterte info-boksen som beskrev manuell skatteetaten.no-flyt.

## Hva som ikke er gjort i denne PR-en

- `docs/tutorial.md` Steg 5 beskriver fortsatt manuell skattemelding-innsending via skatteetaten.no. Det er en større rewrite (innsendingsflyten må beskrives som API-kall i stedet for manuell flyt) og hører hjemme i en egen PR.
- `docs/referanse.md` har sannsynligvis tilsvarende utdaterte avsnitt som bør gås gjennom.

## Test plan

- [x] `mkdocs build --strict` bygger uten nye feil
- [x] Verifisér visuelt på den publiserte dokumentasjonen etter merge