### PR TITLE
fix(ui): Hjem-fanens statussjekk slår alltid opp mot prod

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.12.2"
+version = "0.12.3"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_fristsjekk.py
+++ b/tests/test_fristsjekk.py
@@ -137,6 +137,32 @@ class TestSjekkSkattemelding:
         assert result.innfridd is False
         assert "kontakte Skatteetaten" in result.beskrivelse
 
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_bruker_alltid_prod_url_og_forcer_prod_token(self, mock_get):
+        """API-kallet skal alltid gå mot prod-Skatteetaten og prod-Maskinporten."""
+        mock_auth = MagicMock(return_value="t")
+        with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", mock_auth):
+            mock_get.return_value = _mock_response(text=_wrapper_xml("skattemeldingUpersonligUtkast"))
+            sjekk_skattemelding("931808869", 2025)
+
+        # API-URL skal være prod uavhengig av WENCHE_ENV
+        call_url = mock_get.call_args[0][0]
+        assert call_url.startswith("https://api.skatteetaten.no/")
+
+        # Auth-funksjonen skal kalles med env_override="prod"
+        assert mock_auth.call_args.kwargs.get("env_override") == "prod"
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_404_gir_ikke_klargjort_melding(self, mock_get):
+        """HTTP 404 (skattemelding ikke klargjort av SKD) → pen melding, ikke feilmelding."""
+        with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
+            mock_get.return_value = _mock_response(status_code=404)
+            result = sjekk_skattemelding("931808869", 2026)
+
+        assert result.innfridd is False
+        assert "ikke klargjort" in result.brukertekst.lower()
+        assert "HTTP" not in result.beskrivelse
+
 
 # ---------------------------------------------------------------------------
 # Årsregnskap

--- a/wenche/auth.py
+++ b/wenche/auth.py
@@ -24,18 +24,36 @@ load_dotenv()
 
 _ENV = os.getenv("WENCHE_ENV", "prod")
 
+_MASKINPORTEN_ENDPOINTS = {
+    "test": {
+        "token_url": "https://test.maskinporten.no/token",
+        "audience": "https://test.maskinporten.no/",
+    },
+    "prod": {
+        "token_url": "https://maskinporten.no/token",
+        "audience": "https://maskinporten.no/",
+    },
+}
+
 if _ENV == "test":
-    MASKINPORTEN_TOKEN_URL = "https://test.maskinporten.no/token"
-    MASKINPORTEN_AUD = "https://test.maskinporten.no/"
+    MASKINPORTEN_TOKEN_URL = _MASKINPORTEN_ENDPOINTS["test"]["token_url"]
+    MASKINPORTEN_AUD = _MASKINPORTEN_ENDPOINTS["test"]["audience"]
     ALTINN_EXCHANGE_URL = (
         "https://platform.tt02.altinn.no/authentication/api/v1/exchange/maskinporten"
     )
 else:
-    MASKINPORTEN_TOKEN_URL = "https://maskinporten.no/token"
-    MASKINPORTEN_AUD = "https://maskinporten.no/"
+    MASKINPORTEN_TOKEN_URL = _MASKINPORTEN_ENDPOINTS["prod"]["token_url"]
+    MASKINPORTEN_AUD = _MASKINPORTEN_ENDPOINTS["prod"]["audience"]
     ALTINN_EXCHANGE_URL = (
         "https://platform.altinn.no/authentication/api/v1/exchange/maskinporten"
     )
+
+
+def _maskinporten_endpoints(env_override: str | None = None) -> tuple[str, str]:
+    """Returner (token_url, audience) for ønsket Maskinporten-miljø."""
+    env = env_override or _ENV
+    cfg = _MASKINPORTEN_ENDPOINTS.get(env, _MASKINPORTEN_ENDPOINTS["prod"])
+    return cfg["token_url"], cfg["audience"]
 
 # Scopes for innsending av instanser via Altinn
 SCOPES = "altinn:instances.read altinn:instances.write"
@@ -67,18 +85,21 @@ def _lag_jwt(
     kid: str,
     scopes: str = SCOPES,
     org_nummer: str | None = None,
+    env_override: str | None = None,
 ) -> str:
     """
     Lager et signert JWT for Maskinporten JWT grant-flyten.
 
     Hvis org_nummer er oppgitt, legges authorization_details til i JWT-et
-    for å hente et systembruker-token.
+    for å hente et systembruker-token. env_override='prod' eller 'test'
+    overstyrer WENCHE_ENV for audience.
     """
+    _, aud = _maskinporten_endpoints(env_override)
     now = int(time.time())
     claims = {
         "iss": client_id,
         "sub": client_id,
-        "aud": MASKINPORTEN_AUD,
+        "aud": aud,
         "scope": scopes,
         "iat": now,
         "exp": now + 119,  # Maskinporten tillater maks 120 sekunder
@@ -105,11 +126,16 @@ def _hent_maskinporten_token(
     kid: str,
     scopes: str = SCOPES,
     org_nummer: str | None = None,
+    env_override: str | None = None,
 ) -> str:
-    """Henter et Maskinporten access token."""
-    assertion = _lag_jwt(client_id, private_key_pem, kid, scopes=scopes, org_nummer=org_nummer)
+    """Henter et Maskinporten access token. env_override overstyrer WENCHE_ENV."""
+    assertion = _lag_jwt(
+        client_id, private_key_pem, kid,
+        scopes=scopes, org_nummer=org_nummer, env_override=env_override,
+    )
+    token_url, _ = _maskinporten_endpoints(env_override)
     resp = httpx.post(
-        MASKINPORTEN_TOKEN_URL,
+        token_url,
         data={
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
             "assertion": assertion,
@@ -248,12 +274,16 @@ def get_skd_aksjonaer_token() -> str:
     )
 
 
-def get_skd_skattemelding_maskinporten_token() -> str:
+def get_skd_skattemelding_maskinporten_token(env_override: str | None = None) -> str:
     """
     Henter et Maskinporten-token med skattemelding-scope (kun lesestatus).
 
     Brukes for read-only sjekk av fastsettingsstatus mot SKDs API.
     Ingen Altinn-veksling — krever ikke at brukeren har Altinn-rettigheter.
+
+    env_override='prod' eller 'test' overstyrer WENCHE_ENV. Brukes f.eks. av
+    Hjem-fanens statussjekk som alltid skal slå opp mot prod for å vise
+    reell innsendingsstatus, uavhengig av aktivt arbeidsmiljø.
     """
     client_id = _les_påkrevd_env(
         "MASKINPORTEN_CLIENT_ID",
@@ -267,7 +297,7 @@ def get_skd_skattemelding_maskinporten_token() -> str:
         "ORG_NUMMER",
         "Legg til ORG_NUMMER=<ditt organisasjonsnummer> i .env.",
     )
-    env = os.getenv("WENCHE_ENV", "prod")
+    env = env_override or os.getenv("WENCHE_ENV", "prod")
     org_nummer = os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr) if env == "test" else vendor_orgnr
     nokkel_sti = os.getenv("MASKINPORTEN_PRIVAT_NOKKEL", "maskinporten_privat.pem")
     private_key_pem = _les_nokkel(nokkel_sti)
@@ -276,6 +306,7 @@ def get_skd_skattemelding_maskinporten_token() -> str:
         client_id, private_key_pem, kid,
         scopes=SKD_SKATTEMELDING_LESE_SCOPE,
         org_nummer=org_nummer,
+        env_override=env_override,
     )
 
 

--- a/wenche/fristsjekk.py
+++ b/wenche/fristsjekk.py
@@ -18,7 +18,6 @@ Kilde: https://github.com/Skatteetaten/skattemeldingen/blob/master/src/resources
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from datetime import date
 from xml.etree import ElementTree as ET
@@ -47,11 +46,9 @@ def regnskapsaar_for_frist(maaned: int, dag: int) -> int:
     """
     return neste_frist(maaned, dag).year - 1
 
-# Basis-URL-er for Skatteetatens API — samme som i skd_skattemelding_client.py.
-_SKD_BASES = {
-    "test": "https://api-test.sits.no",
-    "prod": "https://api.skatteetaten.no",
-}
+# Hjem-fanens statussjekk slår alltid opp mot prod, uavhengig av WENCHE_ENV.
+# Brukeren skal se reell innsendingsstatus i prod, ikke status mot et test-orgnr.
+_SKD_PROD_BASE = "https://api.skatteetaten.no"
 
 # Brønnøysundregistrenes Regnskapsregister-API.
 # Åpent API uten autentisering.
@@ -69,20 +66,22 @@ class FristStatus:
 
 
 def sjekk_skattemelding(orgnr: str, aar: int) -> FristStatus:
-    """Sjekk om skattemelding er fastsatt via Skatteetatens API."""
+    """
+    Sjekk om skattemelding er fastsatt via Skatteetatens API.
+
+    Slår alltid opp mot prod-Skatteetaten og prod-Maskinporten,
+    uavhengig av WENCHE_ENV. Hjem-fanen viser reell innsendingsstatus.
+    """
     try:
         from wenche.auth import get_skd_skattemelding_maskinporten_token
 
-        token = get_skd_skattemelding_maskinporten_token()
+        token = get_skd_skattemelding_maskinporten_token(env_override="prod")
     except RuntimeError:
-        return FristStatus(beskrivelse="Maskinporten ikke konfigurert")
-
-    env = os.getenv("WENCHE_ENV", "prod")
-    base = _SKD_BASES.get(env, _SKD_BASES["prod"])
+        return FristStatus(beskrivelse="Maskinporten ikke konfigurert for prod")
 
     try:
         resp = httpx.get(
-            f"{base}/api/skattemelding/v2/{aar}/{orgnr}",
+            f"{_SKD_PROD_BASE}/api/skattemelding/v2/{aar}/{orgnr}",
             headers={
                 "Authorization": f"Bearer {token}",
                 "Accept": "application/xml",
@@ -91,6 +90,13 @@ def sjekk_skattemelding(orgnr: str, aar: int) -> FristStatus:
         )
     except httpx.HTTPError:
         return FristStatus(beskrivelse="Kunne ikke kontakte Skatteetaten")
+
+    if resp.status_code == 404:
+        # 404 betyr ingen skattemelding for året — typisk før forhåndsutfylt åpner.
+        return FristStatus(
+            beskrivelse="Ingen skattemelding klargjort ennå",
+            brukertekst=f"Skattemeldingen for {aar} er ikke klargjort av Skatteetaten ennå.",
+        )
 
     if not resp.is_success:
         return FristStatus(beskrivelse=f"Skatteetaten svarte med HTTP {resp.status_code}")


### PR DESCRIPTION
## Sammendrag

Brukere som kjører Wenche med `WENCHE_ENV=test` fikk feilmeldingen *"Skatteetaten svarte med HTTP 400"* på skattemelding-kortet i Hjem-fanen. Rota: fristsjekken sendte prod-orgnr mot test-API-et (`api-test.sits.no`), som svarer *"Ugyldig identifikator"* for ikke-syntetiske org.nr.

Brukerens intensjon: Hjem-fanen handler om reell innsendingsstatus, ikke test-miljø-data. Sjekken skal derfor alltid slå opp mot prod, uavhengig av aktivt arbeidsmiljø.

## Endringer

**`wenche/auth.py`**
- Nytt `_MASKINPORTEN_ENDPOINTS`-dict og `_maskinporten_endpoints(env_override)`-helper
- `_lag_jwt`, `_hent_maskinporten_token` og `get_skd_skattemelding_maskinporten_token` tar nå et valgfritt `env_override`-argument som overstyrer `WENCHE_ENV` for Maskinporten-endepunkt og audience
- Default-oppførsel uendret (følger `WENCHE_ENV`)

**`wenche/fristsjekk.py`**
- `sjekk_skattemelding` bruker alltid `api.skatteetaten.no` (hardkodet prod)
- Kaller `get_skd_skattemelding_maskinporten_token(env_override="prod")` for å tvinge prod-Maskinporten
- HTTP 404 (typisk før Skatteetaten klargjør forhåndsutfylt skattemelding) håndteres som informativ melding *"Skattemeldingen for {år} er ikke klargjort av Skatteetaten ennå."* i stedet for *"HTTP 404"*

**Versjon** bumpet til 0.12.3 (PATCH, bugfix).

## Resultat for ulike brukere

| Bruker | Hjem-fanen viser |
|---|---|
| Prod-mode med prod-credentials (vanlig case) | Reell prod-status, uendret oppførsel |
| Test-mode med kun test-credentials (utvikler) | *"Maskinporten ikke konfigurert for prod"* i stedet for *"HTTP 400"* |
| Test-mode med både test- og prod-credentials | Reell prod-status |

## Test plan

- [x] Full testsuite: 202/202 passerer (2 nye tester)
- [x] Diagnose-script mot reelt API verifiserer at prod-URL og `env_override="prod"` brukes konsekvent
- [ ] Verifisér visuelt i `wenche ui`: skattemelding-kortet i Hjem-fanen viser meningsfull melding uansett WENCHE_ENV