### PR TITLE
feat(ui): per-miljø-oppsett (credentials, orgnr og systembruker pr test/prod)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,29 @@
+# --- Maskinporten-credentials ---
+#
+# Maskinporten test og prod er separate registre med ulike klient-UUID-er.
+# Du kan håndtere det på to måter:
+#
+# 1) Enkelt: kun ett miljø. Bruk de generiske variabelnavnene under.
+#
+# 2) Begge miljø: legg til _TEST og _PROD-suffix. Wenche velger riktig sett
+#    basert på WENCHE_ENV. Eksempel:
+#
+#       MASKINPORTEN_CLIENT_ID_TEST=test-uuid-her
+#       MASKINPORTEN_KID_TEST=test-kid-her
+#       MASKINPORTEN_CLIENT_ID_PROD=prod-uuid-her
+#       MASKINPORTEN_KID_PROD=prod-kid-her
+#
+#    Da kan du bytte mellom miljø med kun WENCHE_ENV-endringen.
+#    Privat nøkkel-filen kan gjenbrukes hvis du har lastet opp samme
+#    offentlige nøkkel i begge miljø; eventuelt sett _TEST/_PROD-varianter.
+
 # Maskinporten klient-ID
 # Hentes fra Digdirs selvbetjeningsportal etter at søknad er innvilget
 MASKINPORTEN_CLIENT_ID=din-client-id-her
+
+# Nøkkel-ID (UUID) fra Digdirs selvbetjeningsportal
+# Vises under klientens nøkler etter at du har lastet opp offentlig nøkkel
+MASKINPORTEN_KID=uuid-fra-portalen-her
 
 # Sti til privat RSA-nøkkel (relativ til prosjektmappen)
 # Generer nøkkelpar med:
@@ -8,10 +31,18 @@ MASKINPORTEN_CLIENT_ID=din-client-id-her
 #   openssl rsa -in maskinporten_privat.pem -pubout -out maskinporten_offentlig.pem
 MASKINPORTEN_PRIVAT_NOKKEL=maskinporten_privat.pem
 
-# Nøkkel-ID (UUID) fra Digdirs selvbetjeningsportal
-# Vises under klientens nøkler etter at du har lastet opp offentlig nøkkel
-MASKINPORTEN_KID=uuid-fra-portalen-her
+# --- Virksomhet ---
 
-# Sett til "test" for å bruke testmiljø (Maskinporten test + Altinn tt02)
-# Sett til "prod" for produksjon (standard)
+# Ditt eget organisasjonsnummer (9 siffer). Samme i test og prod.
+ORG_NUMMER=ditt-organisasjonsnummer
+
+# --- Miljø ---
+
+# Sett til "test" for testmiljø (Maskinporten test + Altinn tt02 + SKD test).
+# Sett til "prod" for produksjon (standard).
 WENCHE_ENV=prod
+
+# I testmiljø må systembrukeren tilhøre et syntetisk Tenor-org.
+# Hent et test-AS fra https://www.skatteetaten.no/testdata/ og legg inn her.
+# Kun nødvendig hvis WENCHE_ENV=test.
+# SKD_TEST_ORG_NUMMER=

--- a/.env.example
+++ b/.env.example
@@ -1,31 +1,35 @@
-# --- Maskinporten-credentials ---
+# --- Maskinporten-credentials per miljø ---
 #
 # Maskinporten test og prod er separate registre med ulike klient-UUID-er.
+# Hvert miljø har sin egen klient-ID, sin egen nøkkel-ID og sitt eget
+# organisasjonsnummer.
+#
 # Du kan håndtere det på to måter:
 #
-# 1) Enkelt: kun ett miljø. Bruk de generiske variabelnavnene under.
+# 1) Kun ett miljø. Bruk de generiske variabelnavnene under (uten suffix).
 #
-# 2) Begge miljø: legg til _TEST og _PROD-suffix. Wenche velger riktig sett
-#    basert på WENCHE_ENV. Eksempel:
+# 2) Begge miljø samtidig. Legg til _TEST og _PROD-suffix. Wenche velger
+#    riktig sett basert på WENCHE_ENV. Anbefalt hvis du veksler mellom
+#    miljøene; vanligvis konfigureres dette enklest fra Oppsett-fanen i
+#    `wenche ui`.
 #
 #       MASKINPORTEN_CLIENT_ID_TEST=test-uuid-her
 #       MASKINPORTEN_KID_TEST=test-kid-her
 #       MASKINPORTEN_CLIENT_ID_PROD=prod-uuid-her
 #       MASKINPORTEN_KID_PROD=prod-kid-her
-#
-#    Da kan du bytte mellom miljø med kun WENCHE_ENV-endringen.
-#    Privat nøkkel-filen kan gjenbrukes hvis du har lastet opp samme
-#    offentlige nøkkel i begge miljø; eventuelt sett _TEST/_PROD-varianter.
 
 # Maskinporten klient-ID
-# Hentes fra Digdirs selvbetjeningsportal etter at søknad er innvilget
+# Hentes fra Digdirs selvbetjeningsportal etter at søknad er innvilget.
+# Test- og prod-klientene er separate UUID-er.
 MASKINPORTEN_CLIENT_ID=din-client-id-her
 
 # Nøkkel-ID (UUID) fra Digdirs selvbetjeningsportal
-# Vises under klientens nøkler etter at du har lastet opp offentlig nøkkel
+# Vises under klientens nøkler etter at du har lastet opp offentlig nøkkel.
 MASKINPORTEN_KID=uuid-fra-portalen-her
 
 # Sti til privat RSA-nøkkel (relativ til prosjektmappen)
+# Samme nøkkel kan brukes i begge miljø hvis du har lastet opp samme
+# offentlige nøkkel til både test- og prod-klienten i Digdir.
 # Generer nøkkelpar med:
 #   openssl genrsa -out maskinporten_privat.pem 2048
 #   openssl rsa -in maskinporten_privat.pem -pubout -out maskinporten_offentlig.pem
@@ -33,16 +37,20 @@ MASKINPORTEN_PRIVAT_NOKKEL=maskinporten_privat.pem
 
 # --- Virksomhet ---
 
-# Ditt eget organisasjonsnummer (9 siffer). Samme i test og prod.
+# Ditt eget organisasjonsnummer (9 siffer). Brukes som leverandørens orgnr
+# og som systembruker_org i prod-Maskinporten.
 ORG_NUMMER=ditt-organisasjonsnummer
+
+# Syntetisk Tenor-orgnr som brukes som systembruker_org i tt02.
+# Altinn tt02 og SKDs testmiljø kjenner ikke ekte org.nr. — du må bruke
+# et test-AS fra https://www.skatteetaten.no/testdata/.
+# Kun nødvendig hvis du faktisk skal sende inn i testmiljø.
+# SKD_TEST_ORG_NUMMER=
 
 # --- Miljø ---
 
-# Sett til "test" for testmiljø (Maskinporten test + Altinn tt02 + SKD test).
-# Sett til "prod" for produksjon (standard).
+# Påvirker CLI-kommandoer (wenche send-*, wenche login osv.) og
+# Maskinporten/Altinn-URL-ene som brukes. Send-fanen i UI-et har egen
+# test/prod-toggle som overstyrer denne per innsending.
+# "prod" er standard.
 WENCHE_ENV=prod
-
-# I testmiljø må systembrukeren tilhøre et syntetisk Tenor-org.
-# Hent et test-AS fra https://www.skatteetaten.no/testdata/ og legg inn her.
-# Kun nødvendig hvis WENCHE_ENV=test.
-# SKD_TEST_ORG_NUMMER=

--- a/docs/bruk.md
+++ b/docs/bruk.md
@@ -16,13 +16,29 @@ Hvert kort viser hvor mange dager det er igjen til neste frist, og kjører en au
 
 | Kort | Statuskilde |
 |---|---|
-| Skattemelding | Skatteetatens skattemelding-API (krever Maskinporten-konfig) |
+| Skattemelding | Skatteetatens skattemelding-API (krever prod-Maskinporten-konfig) |
 | Årsregnskap | Brønnøysundregistrenes åpne Regnskapsregister |
 | Aksjonærregisteroppgave | Ingen offentlig status-API — sjekk manuelt hos Skatteetaten |
 
 Når statussjekken bekrefter at innsendingen er gjort, vises kortet grønt med «Levert» og en lenke til Altinn-kvitteringen. Knappen **Oppdater status** kjører sjekkene på nytt.
 
-Statussjekkene gjøres mot regnskapsåret som tilhører neste frist (f.eks. 31. juli 2026 → regnskapsår 2025), ikke det arbeidsåret du har valgt i fanen **Oppsett**.
+Statussjekkene refererer alltid til **produksjonsmiljøet**, uavhengig av om du har konfigurert test- eller prod-credentials i Oppsett. Frister og innsendinger er reelle hendelser for din virksomhet, og test-API-ene ville bare avvist din ekte org.nr. uansett. Hvis du ikke har prod-credentials konfigurert ennå, viser skattemelding-kortet en pen feilmelding i status-raden — det stopper deg ikke fra å bruke testmiljø-flyten i resten av appen.
+
+Statussjekkene gjøres mot regnskapsåret som tilhører neste frist (f.eks. 31. juli 2026 → regnskapsår 2025).
+
+---
+
+## Oppsett-fanen
+
+Under **1. Oppsett** finner du «Per miljø-oppsett» med to kort side om side — Testmiljø (tt02) og Produksjon. Hvert kort er et selvstendig oppsett for sitt miljø:
+
+- **Maskinporten-credentials:** Klient-ID og Nøkkel-ID. Test og prod er separate Maskinporten-registre, så hver har sin UUID.
+- **Organisasjonsnummer:** Test krever et syntetisk Tenor-orgnr fra [skatteetaten.no/testdata](https://www.skatteetaten.no/testdata/); prod bruker din egen org.
+- **Systembruker i Altinn:** Status oppdateres automatisk ved sidelasting. Statuskortet viser hva som mangler eller hva som er klart, og **Avansert**-ekspansjonen har knapper for å registrere system, opprette eller fornye systembruker, og oppdatere rettigheter.
+
+Under kortene ligger felles innstillinger (privat nøkkel), en **Lagre konfigurasjon**-knapp, og en **Tilkoblingstest** som sjekker alle tre forutsetninger per miljø (Maskinporten, Altinn-veksling og systembruker) og oppsummerer «klar for innsending» eller hva som mangler.
+
+Når du senere sender inn, velger du test eller prod direkte i Send-fanen — Oppsett-fanen har ikke noen aktivt-miljø-bryter, fordi du kan ha begge miljø konfigurert samtidig.
 
 ---
 
@@ -149,12 +165,12 @@ Teknisk dokumentasjon: [github.com/Skatteetaten/skattemeldingen](https://github.
 Wenche sender RF-1086 direkte til Skatteetatens eget REST-API — ikke via Altinn-instansflyt. Innsendingen er maskinell og krever ikke manuell signering.
 
 !!! note "Forutsetninger"
-    - Maskinporten-klienten din må ha fått scopet `skatteetaten:innrapporteringaksjonaerregisteroppgave` innvilget. Se [steg 2d i oppsett](oppsett.md#2d-sok-om-tilgang-til-skds-api-for-aksjonaerregisteroppgave).
+    - Maskinporten-klienten din må ha fått scopet `skatteetaten:innrapporteringaksjonaerregisteroppgave` innvilget. Se [steg 2e i oppsett](oppsett.md#2e-sk-om-tilgang-til-skds-api-for-aksjonrregisteroppgave).
     - Systembrukeren for din organisasjon må inkludere SKD-rettigheten. Denne settes opp automatisk av `wenche opprett-systembruker` — se [steg 5 i oppsett](oppsett.md#steg-5-registrer-systembruker-i-altinn).
     - `kontakt_epost` må være utfylt under `selskap` i `config.yaml` (eller i Wenche UI under **Selskap**).
 
 !!! warning "Testmiljø krever syntetiske testdata"
-    Bruker du `WENCHE_ENV=test` må systembrukeren tilhøre en syntetisk testorganisasjon fra Tenor, og `SKD_TEST_ORG_NUMMER` må være satt i `.env`. Se [steg 5b i oppsett](oppsett.md#5b-opprett-systembrukerforespørsel) for fullstendig veiledning.
+    Bruker du `WENCHE_ENV=test` må systembrukeren tilhøre en syntetisk testorganisasjon fra Tenor, og `SKD_TEST_ORG_NUMMER` må være satt i `.env`. Se [steg 5 i oppsett](oppsett.md#steg-5-registrer-systembruker-i-altinn) for fullstendig veiledning.
 
 === "Webgrensesnitt"
 

--- a/docs/oppsett.md
+++ b/docs/oppsett.md
@@ -187,6 +187,18 @@ WENCHE_ENV=prod
 | `ORG_NUMMER` | Ditt organisasjonsnummer (9 siffer) |
 | `WENCHE_ENV` | `prod` for produksjon, `test` for Altinn tt02-testmiljø |
 
+!!! tip "Bruker du både test og prod?"
+    Maskinporten test og prod er separate registre, så samme klient-UUID fungerer ikke i begge miljø. Hvis du veksler mellom miljøene, kan du legge inn begge sett credentials i `.env` samtidig med `_TEST`- og `_PROD`-suffix:
+
+    ```
+    MASKINPORTEN_CLIENT_ID_TEST=test-uuid-her
+    MASKINPORTEN_KID_TEST=test-kid-her
+    MASKINPORTEN_CLIENT_ID_PROD=prod-uuid-her
+    MASKINPORTEN_KID_PROD=prod-kid-her
+    ```
+
+    Da bytter Wenche automatisk credentials basert på `WENCHE_ENV` (eller miljø-toggle i Oppsett-fanen i UI-et). Generiske variabler uten suffix fungerer fortsatt som fallback for brukere som kun har ett miljø.
+
 ---
 
 ## Steg 4 — Fyll ut config.yaml

--- a/docs/oppsett.md
+++ b/docs/oppsett.md
@@ -160,44 +160,50 @@ Når SKD bekrefter at tilgangen er innvilget, logg inn i Digdirs selvbetjeningsp
 
 ## Steg 3 — Konfigurer miljøvariabler
 
+!!! tip "Webgrensesnittet håndterer dette for deg"
+    Starter du `wenche ui` og går til **Oppsett**-fanen, kan du fylle inn alle credentials direkte i nettleseren. Hvert miljø (Test og Produksjon) har sitt eget kort der du angir klient-ID, nøkkel-ID og organisasjonsnummer. Lagre-knappen skriver til `.env` for deg. Manuell redigering under er for de som foretrekker terminal.
+
 Kopier eksempelfilen:
 
 ```bash
 cp .env.example .env
 ```
 
-Åpne `.env` og fyll inn verdiene fra portalen:
+Åpne `.env` og fyll inn verdiene fra portalen. Variabelnavnene har miljø-suffix (`_TEST` / `_PROD`) slik at samme `.env`-fil kan inneholde begge oppsett:
 
 ```
-MASKINPORTEN_CLIENT_ID=din-klient-id-her
-MASKINPORTEN_KID=uuid-fra-portalen-her
+# Test (Altinn tt02)
+MASKINPORTEN_CLIENT_ID_TEST=test-klient-uuid-her
+MASKINPORTEN_KID_TEST=test-nokkel-uuid-her
+SKD_TEST_ORG_NUMMER=syntetisk-tenor-orgnr-her
+
+# Produksjon
+MASKINPORTEN_CLIENT_ID_PROD=prod-klient-uuid-her
+MASKINPORTEN_KID_PROD=prod-nokkel-uuid-her
+ORG_NUMMER=ditt-eget-organisasjonsnummer
+
+# Felles for begge miljø
 MASKINPORTEN_PRIVAT_NOKKEL=maskinporten_privat.pem
-ORG_NUMMER=ditt-organisasjonsnummer
 WENCHE_ENV=prod
 ```
 
 !!! warning "Ikke bruk anførselstegn"
-    Verdiene skal skrives direkte uten hermetegn, slik som vist ovenfor.
+    Verdiene skal skrives direkte uten hermetegn.
 
 | Variabel | Hva det er |
 |---|---|
-| `MASKINPORTEN_CLIENT_ID` | Klient-ID fra selvbetjeningsportalen |
-| `MASKINPORTEN_KID` | UUID som portalen tildelte nøkkelen din |
-| `MASKINPORTEN_PRIVAT_NOKKEL` | Sti til din private nøkkelfil (standard: `maskinporten_privat.pem`) |
-| `ORG_NUMMER` | Ditt organisasjonsnummer (9 siffer) |
-| `WENCHE_ENV` | `prod` for produksjon, `test` for Altinn tt02-testmiljø |
+| `MASKINPORTEN_CLIENT_ID_TEST` / `_PROD` | Klient-ID fra Digdirs selvbetjeningsportal — egen UUID per miljø |
+| `MASKINPORTEN_KID_TEST` / `_PROD` | UUID som portalen tildelte den offentlige nøkkelen for klienten |
+| `ORG_NUMMER` | Ditt eget organisasjonsnummer (9 siffer). Brukes som systembruker_org i prod |
+| `SKD_TEST_ORG_NUMMER` | Syntetisk Tenor-orgnr som brukes som systembruker_org i testmiljø. Påkrevd hvis du faktisk skal sende inn i test |
+| `MASKINPORTEN_PRIVAT_NOKKEL` | Sti til din private nøkkelfil (samme nøkkel kan brukes i begge miljø) |
+| `WENCHE_ENV` | `prod` (standard) eller `test`. Påvirker CLI-kommandoer; Send-fanen i UI-et har egen test/prod-velger som overstyrer per innsending |
 
-!!! tip "Bruker du både test og prod?"
-    Maskinporten test og prod er separate registre, så samme klient-UUID fungerer ikke i begge miljø. Hvis du veksler mellom miljøene, kan du legge inn begge sett credentials i `.env` samtidig med `_TEST`- og `_PROD`-suffix:
+!!! info "Hvorfor separate test/prod-credentials?"
+    Maskinporten test og prod er adskilte registre. En klient registrert i test-portalen finnes ikke i prod-portalen og motsatt, så samme UUID fungerer ikke i begge. På samme måte krever Altinn tt02 og SKD test syntetiske Tenor-orgnumre — din ekte org.nr. er ikke kjent der.
 
-    ```
-    MASKINPORTEN_CLIENT_ID_TEST=test-uuid-her
-    MASKINPORTEN_KID_TEST=test-kid-her
-    MASKINPORTEN_CLIENT_ID_PROD=prod-uuid-her
-    MASKINPORTEN_KID_PROD=prod-kid-her
-    ```
-
-    Da bytter Wenche automatisk credentials basert på `WENCHE_ENV` (eller miljø-toggle i Oppsett-fanen i UI-et). Generiske variabler uten suffix fungerer fortsatt som fallback for brukere som kun har ett miljø.
+!!! tip "Bare ett miljø?"
+    Hvis du kun skal bruke prod, kan du droppe `_TEST`-variablene og `SKD_TEST_ORG_NUMMER`. Hvis du kun skal teste, dropp `_PROD`-variablene. Generiske navn uten suffix (`MASKINPORTEN_CLIENT_ID`, `MASKINPORTEN_KID`) fungerer fortsatt som fallback for bakoverkompatibilitet, men vi anbefaler suffix-formen.
 
 ---
 
@@ -218,98 +224,57 @@ cp config.example.yaml config.yaml
 
 ## Steg 5 — Registrer systembruker i Altinn
 
-Altinn 3 krever at datasystemer som handlar på vegne av virksomheter bruker **systemtilgang** — en mekanisme der systemet registreres i Altinns systemregister og virksomheten godkjenner tilgangen eksplisitt. Wenche er bygget rundt denne modellen fra starten av, og bruker ikke den eldre virksomhetsbruker-funksjonaliteten. Mottar du e-post fra Digitaliseringsdirektoratet om at systemer mot Altinn må tilpasses innen 31. mai 2026, trenger du ikke gjøre noe med Wenche — kravet er allerede oppfylt.
+Altinn 3 krever at datasystemer som handler på vegne av virksomheter bruker **systemtilgang** — en mekanisme der systemet registreres i Altinns systemregister og virksomheten godkjenner tilgangen eksplisitt. Wenche er bygget rundt denne modellen fra starten av, og bruker ikke den eldre virksomhetsbruker-funksjonaliteten. Mottar du e-post fra Digitaliseringsdirektoratet om at systemer mot Altinn må tilpasses innen 31. mai 2026, trenger du ikke gjøre noe med Wenche — kravet er allerede oppfylt.
 
-Selve oppsettet gjøres **én gang per miljø** (test/prod):
+Hvert miljø (test og prod) trenger sin egen systembruker. Settes opp uavhengig.
 
-!!! note "Bruker du webgrensesnittet?"
-    Disse stegene kan gjøres direkte i nettleseren: start `wenche ui` og gå til **Oppsett → Systembruker-oppsett**.
+### Anbefalt: bruk webgrensesnittet
 
-### 5a. Registrer system
+Start `wenche ui` og gå til **1. Oppsett**-fanen. Under «Per miljø-oppsett» finner du to kort — Testmiljø (tt02) og Produksjon. Hvert kort viser status for systembrukeren i det miljøet, og har knapper for å sette den opp.
 
-```bash
-wenche registrer-system
-```
+**For å opprette en ny systembruker:**
 
-Registrerer Wenche i Altinns systemregister med riktige tilgangsrettigheter. Kan kjøres på nytt uten skade — oppdaterer automatisk hvis systemet allerede finnes.
+1. Sørg for at Maskinporten-credentials og organisasjonsnummer er fylt inn i kortet (og lagret).
+2. Åpne **Avansert**-ekspansjonen i kortet og klikk **Registrer system**. Dette registrerer Wenche i Altinns systemregister med de nødvendige tilgangsrettighetene. Idempotent — kan kjøres flere ganger uten skade.
+3. Klikk **Opprett systembruker** i samme kort. Wenche oppretter en forespørsel og viser en «Godkjenn i Altinn →»-lenke.
+4. Åpne lenken og godkjenn:
+    - **Produksjon:** Logg inn med BankID som daglig leder eller styreleder.
+    - **Testmiljø:** Logg inn med TestID. Bruk fødselsnummeret til daglig leder for Tenor-orgen din (finnes under **Kildedata → rollegrupper → DAGL** i [Tenor testdatasøk](https://www.skatteetaten.no/testdata/)).
+5. Tilbake i Wenche: klikk **Jeg har godkjent — sjekk status** ved siden av lenken. Status oppdateres til **Systembruker godkjent**.
 
-### 5b. Oppdater rettigheter på eksisterende systembruker
+**Hvis status fortsatt sier «venter»:** Vent 10-20 sekunder og klikk knappen igjen — Altinn trenger noen sekunder på å registrere godkjenningen.
 
-!!! note "Valgfritt — kun hvis du allerede har en godkjent systembruker"
-    Har du satt opp Wenche tidligere (f.eks. for årsregnskap) og nettopp lagt til et nytt scope (f.eks. skattemelding), skal du bruke dette steget — **ikke** steg 5c. Eksisterende rettigheter beholdes; kun de nye legges til.
+### Når trenger jeg å gjøre dette på nytt?
 
-Send en endringsforespørsel via webgrensesnittet: start `wenche ui`, gå til **Oppsett → Systembruker-oppsett**, og klikk **Oppdater systembruker-rettigheter**. Du får en lenke — åpne den i nettleseren, logg inn med ID-porten, og godkjenn endringen.
+| Situasjon | Handling |
+|---|---|
+| Setter opp Wenche for første gang | Steg 5 (registrer + opprett systembruker) |
+| Vil bruke et annet miljø også (test ↔ prod) | Steg 5 for det andre miljøet — uavhengig |
+| Har lagt til nye scopes (f.eks. skattemelding etter at årsregnskap allerede er satt opp) | Bruk **Oppdater rettigheter** i Avansert-ekspansjonen — sender en endringsforespørsel som beholder eksisterende rettigheter og bare legger til nye |
+| Systembrukeren er Avvist eller har utløpt | Klikk **Opprett (ny) systembruker** i Avansert — lager en fersk forespørsel |
 
----
+### Verifiser oppsett
 
-### 5c. Opprett systembrukerforespørsel
+I Oppsett-fanen → **Tilkoblingstest** → klikk **Test tilkobling mot Altinn**. Resultatet viser tre sjekker per miljø:
 
-=== "Produksjon"
+1. ✓ Maskinporten og Altinn-veksling (credentials gyldige)
+2. ✓ Systembruker (godkjent og aktiv)
+3. ✓ Klar for innsending
 
-    ```bash
-    wenche opprett-systembruker
-    ```
+Hvis alt er grønt, er du klar til å sende inn.
 
-    Oppretter en forespørsel på ditt eget organisasjonsnummer (`ORG_NUMMER` fra `.env`) og skriver ut en `confirmUrl`. Åpne lenken i nettleseren, logg inn med ID-porten, og godkjenn tilgangen.
-
-=== "Testmiljø (tt02)"
-
-    Altinns testmiljø bruker syntetiske testdata. Din egen organisasjon finnes ikke i testregisteret, og du må bruke en **syntetisk testorganisasjon fra Tenor**.
-
-    **1. Finn en syntetisk test-AS i Tenor**
-
-    Gå til [Tenor testdatasøk](https://www.skatteetaten.no/testdata/) og søk frem et aksjeselskap (AS). Noter deg:
-
-    - Organisasjonsnummeret til selskapet
-    - Fødselsnummeret til daglig leder (finnes under **Kildedata → rollegrupper → DAGL**)
-
-    **2. Opprett systembrukerforespørsel for Tenor-org**
-
-    ```bash
-    wenche opprett-systembruker --org <tenor-orgnr>
-    ```
-
-    Erstatt `<tenor-orgnr>` med organisasjonsnummeret du fant i Tenor.
-
-    **3. Godkjenn forespørselen**
-
-    Kommandoen skriver ut en `confirmUrl`. Åpne lenken i nettleseren og logg inn med **TestID** (syntetisk BankID) ved å bruke fødselsnummeret til daglig leder fra steg 1.
-
-    **4. Konfigurer testmiljøet i `.env`**
-
-    Legg til følgende linje i `.env`:
-
-    ```
-    SKD_TEST_ORG_NUMMER=<tenor-orgnr>
-    ```
-
-    Wenche bruker da automatisk Tenor-org-et i XML-en og i Maskinporten-tokenet når `WENCHE_ENV=test`.
-
-    !!! info "Hvorfor syntetiske data i test?"
-        Skatteetaten og Altinns testmiljø er populert med data fra Tenor. Din reelle organisasjon eksisterer ikke i testregisteret, og innsending vil feile på bekreftelsessteget. Bruk av syntetisk org i test er ikke en begrensning i Wenche — det er et krav fra SKD og Altinn.
-
-### 5c. Verifiser oppsett
-
-Når forespørselen er godkjent, test at innlogging fungerer:
+### Alternativ: kommandolinje
 
 ```bash
-wenche login
+wenche registrer-system            # Registrer system (samme som UI-knappen)
+wenche opprett-systembruker        # Opprett systembruker for ORG_NUMMER (prod)
+wenche opprett-systembruker --org <tenor-orgnr>  # For test, oppgi Tenor-orgnr eksplisitt
+wenche login                       # Test tilkobling (henter token mot aktivt miljø)
 ```
 
-Vellykket utskrift:
+`WENCHE_ENV` i `.env` styrer hvilket miljø CLI-kommandoene gjelder. UI-et håndterer test/prod uavhengig av denne variabelen.
 
-```
-Autentiserer mot Maskinporten (systembruker)...
-Maskinporten-token mottatt. Henter Altinn-token...
-Autentisering vellykket.
-```
-
-Logg deretter ut igjen:
-
-```bash
-wenche logout
-```
-
-Får du feilen `invalid_altinn_customer_configuration` betyr det at systembrukeren ikke er godkjent ennå — fullfør steg 5c. Dobbeltsjekk ellers at klient-ID og KID i `.env` stemmer med det som vises i selvbetjeningsportalen.
+!!! warning "Test krever syntetiske Tenor-orgnumre"
+    Altinn tt02 og SKDs testmiljø er populert med data fra Tenor. Din egen organisasjon finnes ikke i testregisteret, og innsending vil feile (typisk med en uventet 500-feil) hvis du forsøker å bruke ekte org.nr. i test. Bruk alltid et test-AS fra [skatteetaten.no/testdata](https://www.skatteetaten.no/testdata/) når du tester.
 
 [Gå videre til bruk →](bruk.md){ .md-button .md-button--primary }

--- a/docs/referanse.md
+++ b/docs/referanse.md
@@ -131,15 +131,28 @@ Liste over alle aksjonærer per 31.12 i regnskapsåret.
 
 ## Miljøvariabler (.env)
 
+Maskinporten test og prod er separate registre med ulike klient-UUID-er. Wenche støtter to konvensjoner: miljø-spesifikke variabler (anbefalt) eller generiske variabler. Hvis begge er satt, vinner miljø-spesifikk variant.
+
+### Miljø-spesifikke variabler (anbefalt)
+
+| Variabel | Brukes når | Beskrivelse |
+|---|---|---|
+| `MASKINPORTEN_CLIENT_ID_TEST` | testmiljø | Klient-ID for test-Maskinporten fra Digdir |
+| `MASKINPORTEN_KID_TEST` | testmiljø | UUID for offentlig nøkkel registrert på test-klienten |
+| `MASKINPORTEN_CLIENT_ID_PROD` | prod | Klient-ID for prod-Maskinporten fra Digdir |
+| `MASKINPORTEN_KID_PROD` | prod | UUID for offentlig nøkkel registrert på prod-klienten |
+
+### Felles og generiske
+
 | Variabel | Påkrevd | Beskrivelse |
 |---|---|---|
-| `MASKINPORTEN_CLIENT_ID` | ja | Klient-ID fra Digdir selvbetjeningsportal |
-| `MASKINPORTEN_KID` | ja | UUID som portalen tildelte den offentlige nøkkelen |
-| `MASKINPORTEN_PRIVAT_NOKKEL` | ja | Sti til privat nøkkelfil. Standard: `maskinporten_privat.pem` |
-| `ORG_NUMMER` | ja | Organisasjonsnummeret til leverandøren (deg/selskapet som bruker Wenche), 9 siffer |
-| `WENCHE_ENV` | nei | `prod` for produksjon, `test` for Altinn tt02-testmiljø. Standard: `prod` |
-| `SKD_TEST_ORG_NUMMER` | nei | Organisasjonsnummeret til en syntetisk testorganisasjon fra Tenor. Brukes i testmiljø (`WENCHE_ENV=test`) som mottaker for systembrukerforespørsel og i XML-innsending til SKD |
-| `SKD_TEST_PARTSNUMMER` | nei | Partsnummer fra Tenor for testorganisasjonen. Setter man denne hopper Wenche over kallet til SKDs forhåndsutfylt-API (som ikke alltid har data for syntetiske org i test) og bruker partsnummeret direkte |
+| `MASKINPORTEN_PRIVAT_NOKKEL` | ja | Sti til privat nøkkelfil. Samme nøkkel kan brukes i begge miljø. Standard: `maskinporten_privat.pem` |
+| `ORG_NUMMER` | ja (for prod) | Ditt eget organisasjonsnummer (9 siffer). Brukes som systembruker_org og party i prod |
+| `SKD_TEST_ORG_NUMMER` | ja (for test) | Syntetisk Tenor-orgnr som brukes som systembruker_org og party i testmiljø |
+| `WENCHE_ENV` | nei | `prod` (standard) eller `test`. Påvirker CLI-kommandoer. Send-fanen i UI-et har egen velger som overstyrer per innsending |
+| `SKD_TEST_PARTSNUMMER` | nei | Partsnummer fra Tenor for skattemelding-test. Setter man denne hopper Wenche over kallet til SKDs forhåndsutfylt-API og bruker partsnummeret direkte |
+| `MASKINPORTEN_CLIENT_ID` | nei | Generisk fallback. Brukes hvis ingen miljø-spesifikk variant er satt |
+| `MASKINPORTEN_KID` | nei | Generisk fallback. Brukes hvis ingen miljø-spesifikk variant er satt |
 
 ---
 
@@ -225,7 +238,7 @@ wenche send-skattemelding [--config FILSTI] [--dry-run]
 | `--config` | Sti til konfigurasjonsfil. Standard: `config.yaml` |
 | `--dry-run` | Henter forhåndsutfylt og genererer XML lokalt (`skattemelding.xml` og `naeringsspesifikasjon.xml`) uten å sende |
 
-Krever at Maskinporten-klienten har fått scopet `skatteetaten:formueinntekt/skattemelding` innvilget. Se [steg 2e i oppsett](oppsett.md#2e-sok-om-tilgang-til-skds-api-for-skattemelding).
+Krever at Maskinporten-klienten har fått scopet `skatteetaten:formueinntekt/skattemelding` innvilget. Se [steg 2f i oppsett](oppsett.md#2f-sk-om-tilgang-til-skds-api-for-skattemelding).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.12.2"
+version = "0.13.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_auth_env.py
+++ b/tests/test_auth_env.py
@@ -7,7 +7,12 @@ from unittest.mock import patch
 
 import pytest
 
-from wenche.auth import _les_miljo_env
+from wenche.auth import (
+    _altinn_exchange_url,
+    _les_miljo_env,
+    _maskinporten_aud,
+    _maskinporten_token_url,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -84,3 +89,36 @@ class TestLesMiljoEnv:
         os.environ["MASKINPORTEN_CLIENT_ID_PROD"] = "prod-uuid"
         assert _les_miljo_env("MASKINPORTEN_CLIENT_ID", "prod") == "prod-uuid"
         assert _les_miljo_env("MASKINPORTEN_CLIENT_ID", "PROD") == "prod-uuid"
+
+
+class TestRuntimeEnvUrls:
+    """URL-ene må reflektere gjeldende WENCHE_ENV, ikke cachet verdi ved import."""
+
+    def test_token_url_bytter_med_env(self):
+        with patch.dict(os.environ, {"WENCHE_ENV": "test"}):
+            assert _maskinporten_token_url() == "https://test.maskinporten.no/token"
+        with patch.dict(os.environ, {"WENCHE_ENV": "prod"}):
+            assert _maskinporten_token_url() == "https://maskinporten.no/token"
+
+    def test_audience_bytter_med_env(self):
+        with patch.dict(os.environ, {"WENCHE_ENV": "test"}):
+            assert _maskinporten_aud() == "https://test.maskinporten.no/"
+        with patch.dict(os.environ, {"WENCHE_ENV": "prod"}):
+            assert _maskinporten_aud() == "https://maskinporten.no/"
+
+    def test_altinn_exchange_url_bytter_med_env(self):
+        with patch.dict(os.environ, {"WENCHE_ENV": "test"}):
+            assert "tt02" in _altinn_exchange_url()
+        with patch.dict(os.environ, {"WENCHE_ENV": "prod"}):
+            assert "tt02" not in _altinn_exchange_url()
+            assert "platform.altinn.no" in _altinn_exchange_url()
+
+    def test_default_er_prod_naar_env_ikke_satt(self):
+        # Fjern WENCHE_ENV midlertidig
+        opprinnelig = os.environ.pop("WENCHE_ENV", None)
+        try:
+            assert _maskinporten_token_url() == "https://maskinporten.no/token"
+            assert _maskinporten_aud() == "https://maskinporten.no/"
+        finally:
+            if opprinnelig is not None:
+                os.environ["WENCHE_ENV"] = opprinnelig

--- a/tests/test_auth_env.py
+++ b/tests/test_auth_env.py
@@ -1,0 +1,86 @@
+"""
+Tester for miljø-spesifikk env-variabelhåndtering i wenche.auth.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from wenche.auth import _les_miljo_env
+
+
+@pytest.fixture(autouse=True)
+def rensk_env():
+    """Sørg for at testene ikke arver MASKINPORTEN-variabler fra omgivelsen."""
+    bevart = {}
+    for navn in [
+        "MASKINPORTEN_CLIENT_ID",
+        "MASKINPORTEN_CLIENT_ID_TEST",
+        "MASKINPORTEN_CLIENT_ID_PROD",
+        "MASKINPORTEN_KID",
+        "MASKINPORTEN_KID_TEST",
+        "MASKINPORTEN_KID_PROD",
+        "MASKINPORTEN_PRIVAT_NOKKEL",
+        "MASKINPORTEN_PRIVAT_NOKKEL_TEST",
+        "MASKINPORTEN_PRIVAT_NOKKEL_PROD",
+    ]:
+        if navn in os.environ:
+            bevart[navn] = os.environ.pop(navn)
+    yield
+    for navn, verdi in bevart.items():
+        os.environ[navn] = verdi
+
+
+class TestLesMiljoEnv:
+
+    def test_milj_spesifikk_prefereres_over_generisk(self):
+        os.environ["MASKINPORTEN_CLIENT_ID"] = "generisk"
+        os.environ["MASKINPORTEN_CLIENT_ID_PROD"] = "prod-uuid"
+        os.environ["MASKINPORTEN_CLIENT_ID_TEST"] = "test-uuid"
+
+        assert _les_miljo_env("MASKINPORTEN_CLIENT_ID", "prod") == "prod-uuid"
+        assert _les_miljo_env("MASKINPORTEN_CLIENT_ID", "test") == "test-uuid"
+
+    def test_faller_tilbake_til_generisk_navn(self):
+        os.environ["MASKINPORTEN_CLIENT_ID"] = "felles-uuid"
+        assert _les_miljo_env("MASKINPORTEN_CLIENT_ID", "prod") == "felles-uuid"
+        assert _les_miljo_env("MASKINPORTEN_CLIENT_ID", "test") == "felles-uuid"
+
+    def test_kun_milj_spesifikk_satt_funker(self):
+        os.environ["MASKINPORTEN_CLIENT_ID_PROD"] = "kun-prod"
+
+        assert _les_miljo_env("MASKINPORTEN_CLIENT_ID", "prod") == "kun-prod"
+
+        # Test-miljø har verken _TEST eller generisk → skal feile
+        with pytest.raises(RuntimeError) as exc:
+            _les_miljo_env("MASKINPORTEN_CLIENT_ID", "test", "hjelp")
+        assert "MASKINPORTEN_CLIENT_ID_TEST" in str(exc.value)
+        assert "fallback" in str(exc.value)
+
+    def test_paakrevd_uten_treff_kaster(self):
+        with pytest.raises(RuntimeError) as exc:
+            _les_miljo_env("MASKINPORTEN_CLIENT_ID", "prod", "fyll inn klient-ID")
+        assert "MASKINPORTEN_CLIENT_ID_PROD" in str(exc.value)
+        assert "fyll inn klient-ID" in str(exc.value)
+
+    def test_ikke_paakrevd_returnerer_default(self):
+        verdi = _les_miljo_env(
+            "MASKINPORTEN_PRIVAT_NOKKEL", "prod",
+            paakrevd=False, default="maskinporten_privat.pem",
+        )
+        assert verdi == "maskinporten_privat.pem"
+
+    def test_ikke_paakrevd_returnerer_milj_verdi_naar_satt(self):
+        os.environ["MASKINPORTEN_PRIVAT_NOKKEL_PROD"] = "prod_key.pem"
+        verdi = _les_miljo_env(
+            "MASKINPORTEN_PRIVAT_NOKKEL", "prod",
+            paakrevd=False, default="maskinporten_privat.pem",
+        )
+        assert verdi == "prod_key.pem"
+
+    def test_env_lower_case_funker_ogs(self):
+        """Skal akseptere både 'prod'/'test' og 'PROD'/'TEST'."""
+        os.environ["MASKINPORTEN_CLIENT_ID_PROD"] = "prod-uuid"
+        assert _les_miljo_env("MASKINPORTEN_CLIENT_ID", "prod") == "prod-uuid"
+        assert _les_miljo_env("MASKINPORTEN_CLIENT_ID", "PROD") == "prod-uuid"

--- a/tests/test_fristsjekk.py
+++ b/tests/test_fristsjekk.py
@@ -5,6 +5,7 @@ Verifiserer statussjekk mot Skatteetatens og Brønnøysundregistrenes API-er.
 Alle HTTP-kall er mocket — testene gjør ingen ekte nettverkskall.
 """
 
+import os
 from datetime import date
 from unittest.mock import patch, MagicMock
 from xml.etree import ElementTree as ET
@@ -64,11 +65,18 @@ def _mock_response(status_code: int = 200, text: str = "", json_data=None) -> Ma
 # Skattemelding
 # ---------------------------------------------------------------------------
 
+@pytest.fixture
+def prod_env():
+    """Kjør test med WENCHE_ENV=prod slik at sjekk_skattemelding går full flyt."""
+    with patch.dict(os.environ, {"WENCHE_ENV": "prod"}):
+        yield
+
+
 class TestSjekkSkattemelding:
 
     @patch("wenche.fristsjekk.httpx.get")
     @patch("wenche.fristsjekk.get_skd_skattemelding_maskinporten_token", create=True)
-    def test_fastsatt_gir_innfridd(self, mock_token, mock_get):
+    def test_fastsatt_gir_innfridd(self, mock_token, mock_get, prod_env):
         """Respons med skattemeldingUpersonligFastsatt → innfridd=True."""
         # Importer igjen etter patching
         import wenche.fristsjekk as mod
@@ -85,7 +93,7 @@ class TestSjekkSkattemelding:
         assert "931808869" in result.lenke
 
     @patch("wenche.fristsjekk.httpx.get")
-    def test_utkast_gir_ikke_innfridd(self, mock_get):
+    def test_utkast_gir_ikke_innfridd(self, mock_get, prod_env):
         """Respons med skattemeldingUpersonligUtkast → innfridd=False."""
         with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
             mock_get.return_value = _mock_response(
@@ -97,7 +105,7 @@ class TestSjekkSkattemelding:
         assert "ikke innsendt" in result.brukertekst
 
     @patch("wenche.fristsjekk.httpx.get")
-    def test_http_feil_gir_beskrivelse(self, mock_get):
+    def test_http_feil_gir_beskrivelse(self, mock_get, prod_env):
         """HTTP 500 fra Skatteetaten → innfridd=False med feilmelding."""
         with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
             mock_get.return_value = _mock_response(status_code=500)
@@ -107,7 +115,7 @@ class TestSjekkSkattemelding:
         assert "HTTP 500" in result.beskrivelse
 
     @patch("wenche.fristsjekk.httpx.get")
-    def test_ugyldig_xml_gir_beskrivelse(self, mock_get):
+    def test_ugyldig_xml_gir_beskrivelse(self, mock_get, prod_env):
         """Ugyldig XML fra Skatteetaten → innfridd=False med feilmelding."""
         with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
             mock_get.return_value = _mock_response(text="dette er ikke xml")
@@ -116,7 +124,7 @@ class TestSjekkSkattemelding:
         assert result.innfridd is False
         assert "Ugyldig svar" in result.beskrivelse
 
-    def test_manglende_maskinporten_gir_beskrivelse(self):
+    def test_manglende_maskinporten_gir_beskrivelse(self, prod_env):
         """RuntimeError fra auth → innfridd=False med 'ikke konfigurert'."""
         with patch(
             "wenche.auth.get_skd_skattemelding_maskinporten_token",
@@ -128,7 +136,7 @@ class TestSjekkSkattemelding:
         assert "Maskinporten" in result.beskrivelse
 
     @patch("wenche.fristsjekk.httpx.get")
-    def test_nettverksfeil_gir_beskrivelse(self, mock_get):
+    def test_nettverksfeil_gir_beskrivelse(self, mock_get, prod_env):
         """Timeout/nettverksfeil → innfridd=False med feilmelding."""
         with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
             mock_get.side_effect = httpx.ConnectError("Connection refused")
@@ -136,6 +144,15 @@ class TestSjekkSkattemelding:
 
         assert result.innfridd is False
         assert "kontakte Skatteetaten" in result.beskrivelse
+
+    def test_testmiljo_hopper_over_sjekken(self):
+        """I testmiljø skal vi vise informativ melding, ikke ringe API-et."""
+        with patch.dict(os.environ, {"WENCHE_ENV": "test"}):
+            result = sjekk_skattemelding("922020523", 2025)
+
+        assert result.innfridd is False
+        assert "test" in result.beskrivelse.lower() or "test" in result.brukertekst.lower()
+        assert "prod" in result.brukertekst.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_fristsjekk.py
+++ b/tests/test_fristsjekk.py
@@ -145,14 +145,21 @@ class TestSjekkSkattemelding:
         assert result.innfridd is False
         assert "kontakte Skatteetaten" in result.beskrivelse
 
-    def test_testmiljo_hopper_over_sjekken(self):
-        """I testmiljø skal vi vise informativ melding, ikke ringe API-et."""
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_tvinger_prod_uavhengig_av_wenche_env(self, mock_get):
+        """Sjekken skal alltid gå mot prod, selv om WENCHE_ENV=test."""
         with patch.dict(os.environ, {"WENCHE_ENV": "test"}):
-            result = sjekk_skattemelding("922020523", 2025)
+            with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
+                mock_get.return_value = _mock_response(
+                    text=_wrapper_xml("skattemeldingUpersonligUtkast"),
+                )
+                result = sjekk_skattemelding("922020523", 2025)
 
+        # Skal ha ringt prod-URL, ikke test-URL
+        called_url = mock_get.call_args[0][0]
+        assert "api.skatteetaten.no" in called_url
+        assert "api-test.sits.no" not in called_url
         assert result.innfridd is False
-        assert "test" in result.beskrivelse.lower() or "test" in result.brukertekst.lower()
-        assert "prod" in result.brukertekst.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/wenche/auth.py
+++ b/wenche/auth.py
@@ -22,20 +22,43 @@ from dotenv import load_dotenv
 
 load_dotenv()
 
-_ENV = os.getenv("WENCHE_ENV", "prod")
+# Miljø-spesifikke URL-er evalueres ved hvert kall (ikke ved modulinnlastning),
+# slik at brukeren kan bytte miljø i UI-et og få umiddelbar effekt uten å
+# starte Wenche på nytt.
 
-if _ENV == "test":
-    MASKINPORTEN_TOKEN_URL = "https://test.maskinporten.no/token"
-    MASKINPORTEN_AUD = "https://test.maskinporten.no/"
-    ALTINN_EXCHANGE_URL = (
+def _gjeldende_env() -> str:
+    return os.getenv("WENCHE_ENV", "prod")
+
+
+def _maskinporten_token_url() -> str:
+    return (
+        "https://test.maskinporten.no/token"
+        if _gjeldende_env() == "test"
+        else "https://maskinporten.no/token"
+    )
+
+
+def _maskinporten_aud() -> str:
+    return (
+        "https://test.maskinporten.no/"
+        if _gjeldende_env() == "test"
+        else "https://maskinporten.no/"
+    )
+
+
+def _altinn_exchange_url() -> str:
+    return (
         "https://platform.tt02.altinn.no/authentication/api/v1/exchange/maskinporten"
+        if _gjeldende_env() == "test"
+        else "https://platform.altinn.no/authentication/api/v1/exchange/maskinporten"
     )
-else:
-    MASKINPORTEN_TOKEN_URL = "https://maskinporten.no/token"
-    MASKINPORTEN_AUD = "https://maskinporten.no/"
-    ALTINN_EXCHANGE_URL = (
-        "https://platform.altinn.no/authentication/api/v1/exchange/maskinporten"
-    )
+
+
+# Bakoverkompatibel modul-tilgang for ekstern kode (bruk funksjonene over for
+# kall som skal respektere endring av WENCHE_ENV ved kjøretid).
+MASKINPORTEN_TOKEN_URL = _maskinporten_token_url()
+MASKINPORTEN_AUD = _maskinporten_aud()
+ALTINN_EXCHANGE_URL = _altinn_exchange_url()
 
 # Scopes for innsending av instanser via Altinn
 SCOPES = "altinn:instances.read altinn:instances.write"
@@ -78,7 +101,7 @@ def _lag_jwt(
     claims = {
         "iss": client_id,
         "sub": client_id,
-        "aud": MASKINPORTEN_AUD,
+        "aud": _maskinporten_aud(),
         "scope": scopes,
         "iat": now,
         "exp": now + 119,  # Maskinporten tillater maks 120 sekunder
@@ -109,7 +132,7 @@ def _hent_maskinporten_token(
     """Henter et Maskinporten access token."""
     assertion = _lag_jwt(client_id, private_key_pem, kid, scopes=scopes, org_nummer=org_nummer)
     resp = httpx.post(
-        MASKINPORTEN_TOKEN_URL,
+        _maskinporten_token_url(),
         data={
             "grant_type": "urn:ietf:params:oauth:grant-type:jwt-bearer",
             "assertion": assertion,
@@ -200,7 +223,7 @@ def login() -> dict:
 
     print("Maskinporten-token mottatt. Henter Altinn-token...")
     altinn_resp = httpx.get(
-        ALTINN_EXCHANGE_URL,
+        _altinn_exchange_url(),
         headers={"Authorization": f"Bearer {maskinporten_token}"},
         timeout=15,
     )
@@ -353,7 +376,7 @@ def get_skd_skattemelding_tokens() -> dict:
     )
 
     altinn_resp = httpx.get(
-        ALTINN_EXCHANGE_URL,
+        _altinn_exchange_url(),
         headers={"Authorization": f"Bearer {maskinporten_token}"},
         timeout=15,
     )

--- a/wenche/auth.py
+++ b/wenche/auth.py
@@ -141,25 +141,56 @@ def _les_påkrevd_env(navn: str, hjelpetekst: str) -> str:
     return verdi
 
 
+def _les_miljo_env(
+    navn: str,
+    env: str,
+    hjelpetekst: str | None = None,
+    paakrevd: bool = True,
+    default: str | None = None,
+) -> str | None:
+    """
+    Les en credential-variabel som potensielt er miljø-spesifikk.
+
+    Sjekker først `{navn}_{ENV}` (f.eks. MASKINPORTEN_CLIENT_ID_TEST),
+    deretter `{navn}` som fallback. Brukere som bare har én klient kan
+    fortsette å bruke det generiske navnet. Brukere som har separate
+    test- og prod-klienter kan ha begge sett samtidig i .env og la
+    WENCHE_ENV velge riktig sett.
+    """
+    suffix = env.upper()
+    verdi = os.getenv(f"{navn}_{suffix}") or os.getenv(navn)
+    if verdi:
+        return verdi
+    if paakrevd:
+        raise RuntimeError(
+            f"{navn}_{suffix} (eller {navn} som fallback) mangler.\n"
+            f"{hjelpetekst or ''}"
+        )
+    return default
+
+
 def login() -> dict:
     """
     Autentiserer mot Maskinporten med systembruker-token og veksler mot Altinn-token.
 
     Krever ORG_NUMMER i .env. Returnerer {'maskinporten_token': str, 'altinn_token': str}.
     """
-    client_id = _les_påkrevd_env(
-        "MASKINPORTEN_CLIENT_ID",
+    env = os.getenv("WENCHE_ENV", "prod")
+    client_id = _les_miljo_env(
+        "MASKINPORTEN_CLIENT_ID", env,
         "Kopier .env.example til .env og fyll inn din klient-ID fra Digdirs selvbetjeningsportal.",
     )
-    kid = _les_påkrevd_env(
-        "MASKINPORTEN_KID",
+    kid = _les_miljo_env(
+        "MASKINPORTEN_KID", env,
         "Finn nøkkel-ID (UUID) i Digdirs selvbetjeningsportal under klientens nøkler og legg den i .env.",
     )
     org_nummer = _les_påkrevd_env(
         "ORG_NUMMER",
         "Legg til ORG_NUMMER=<ditt organisasjonsnummer> i .env.",
     )
-    nokkel_sti = os.getenv("MASKINPORTEN_PRIVAT_NOKKEL", "maskinporten_privat.pem")
+    nokkel_sti = _les_miljo_env(
+        "MASKINPORTEN_PRIVAT_NOKKEL", env, paakrevd=False, default="maskinporten_privat.pem",
+    )
     private_key_pem = _les_nokkel(nokkel_sti)
 
     print("Autentiserer mot Maskinporten (systembruker)...")
@@ -195,15 +226,18 @@ def login_admin() -> str:
 
     Returnerer rått Maskinporten access token (ikke vekslet mot Altinn).
     """
-    client_id = _les_påkrevd_env(
-        "MASKINPORTEN_CLIENT_ID",
+    env = os.getenv("WENCHE_ENV", "prod")
+    client_id = _les_miljo_env(
+        "MASKINPORTEN_CLIENT_ID", env,
         "Kopier .env.example til .env og fyll inn din klient-ID fra Digdirs selvbetjeningsportal.",
     )
-    kid = _les_påkrevd_env(
-        "MASKINPORTEN_KID",
+    kid = _les_miljo_env(
+        "MASKINPORTEN_KID", env,
         "Finn nøkkel-ID (UUID) i Digdirs selvbetjeningsportal under klientens nøkler og legg den i .env.",
     )
-    nokkel_sti = os.getenv("MASKINPORTEN_PRIVAT_NOKKEL", "maskinporten_privat.pem")
+    nokkel_sti = _les_miljo_env(
+        "MASKINPORTEN_PRIVAT_NOKKEL", env, paakrevd=False, default="maskinporten_privat.pem",
+    )
     private_key_pem = _les_nokkel(nokkel_sti)
 
     return _hent_maskinporten_token(client_id, private_key_pem, kid, scopes=ADMIN_SCOPES)
@@ -225,12 +259,13 @@ def get_skd_aksjonaer_token() -> str:
     Krever at scope 'skatteetaten:innrapporteringaksjonaerregisteroppgave'
     er innvilget av Skatteetaten for klienten.
     """
-    client_id = _les_påkrevd_env(
-        "MASKINPORTEN_CLIENT_ID",
+    env = os.getenv("WENCHE_ENV", "prod")
+    client_id = _les_miljo_env(
+        "MASKINPORTEN_CLIENT_ID", env,
         "Kopier .env.example til .env og fyll inn din klient-ID fra Digdirs selvbetjeningsportal.",
     )
-    kid = _les_påkrevd_env(
-        "MASKINPORTEN_KID",
+    kid = _les_miljo_env(
+        "MASKINPORTEN_KID", env,
         "Finn nøkkel-ID (UUID) i Digdirs selvbetjeningsportal under klientens nøkler og legg den i .env.",
     )
     vendor_orgnr = _les_påkrevd_env(
@@ -238,9 +273,10 @@ def get_skd_aksjonaer_token() -> str:
         "Legg til ORG_NUMMER=<ditt organisasjonsnummer> i .env.",
     )
     # I SKDs testmiljø må systembrukeren tilhøre et syntetisk Tenor-org, ikke produksjonsorg.
-    env = os.getenv("WENCHE_ENV", "prod")
     org_nummer = os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr) if env == "test" else vendor_orgnr
-    nokkel_sti = os.getenv("MASKINPORTEN_PRIVAT_NOKKEL", "maskinporten_privat.pem")
+    nokkel_sti = _les_miljo_env(
+        "MASKINPORTEN_PRIVAT_NOKKEL", env, paakrevd=False, default="maskinporten_privat.pem",
+    )
     private_key_pem = _les_nokkel(nokkel_sti)
 
     return _hent_maskinporten_token(
@@ -255,21 +291,23 @@ def get_skd_skattemelding_maskinporten_token() -> str:
     Brukes for read-only sjekk av fastsettingsstatus mot SKDs API.
     Ingen Altinn-veksling — krever ikke at brukeren har Altinn-rettigheter.
     """
-    client_id = _les_påkrevd_env(
-        "MASKINPORTEN_CLIENT_ID",
+    env = os.getenv("WENCHE_ENV", "prod")
+    client_id = _les_miljo_env(
+        "MASKINPORTEN_CLIENT_ID", env,
         "Kopier .env.example til .env og fyll inn din klient-ID fra Digdirs selvbetjeningsportal.",
     )
-    kid = _les_påkrevd_env(
-        "MASKINPORTEN_KID",
+    kid = _les_miljo_env(
+        "MASKINPORTEN_KID", env,
         "Finn nøkkel-ID (UUID) i Digdirs selvbetjeningsportal under klientens nøkler og legg den i .env.",
     )
     vendor_orgnr = _les_påkrevd_env(
         "ORG_NUMMER",
         "Legg til ORG_NUMMER=<ditt organisasjonsnummer> i .env.",
     )
-    env = os.getenv("WENCHE_ENV", "prod")
     org_nummer = os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr) if env == "test" else vendor_orgnr
-    nokkel_sti = os.getenv("MASKINPORTEN_PRIVAT_NOKKEL", "maskinporten_privat.pem")
+    nokkel_sti = _les_miljo_env(
+        "MASKINPORTEN_PRIVAT_NOKKEL", env, paakrevd=False, default="maskinporten_privat.pem",
+    )
     private_key_pem = _les_nokkel(nokkel_sti)
 
     return _hent_maskinporten_token(
@@ -289,21 +327,23 @@ def get_skd_skattemelding_tokens() -> dict:
 
     I testmiljø brukes SKD_TEST_ORG_NUMMER som systembruker-org.
     """
-    client_id = _les_påkrevd_env(
-        "MASKINPORTEN_CLIENT_ID",
+    env = os.getenv("WENCHE_ENV", "prod")
+    client_id = _les_miljo_env(
+        "MASKINPORTEN_CLIENT_ID", env,
         "Kopier .env.example til .env og fyll inn din klient-ID fra Digdirs selvbetjeningsportal.",
     )
-    kid = _les_påkrevd_env(
-        "MASKINPORTEN_KID",
+    kid = _les_miljo_env(
+        "MASKINPORTEN_KID", env,
         "Finn nøkkel-ID (UUID) i Digdirs selvbetjeningsportal under klientens nøkler og legg den i .env.",
     )
     vendor_orgnr = _les_påkrevd_env(
         "ORG_NUMMER",
         "Legg til ORG_NUMMER=<ditt organisasjonsnummer> i .env.",
     )
-    env = os.getenv("WENCHE_ENV", "prod")
     org_nummer = os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr) if env == "test" else vendor_orgnr
-    nokkel_sti = os.getenv("MASKINPORTEN_PRIVAT_NOKKEL", "maskinporten_privat.pem")
+    nokkel_sti = _les_miljo_env(
+        "MASKINPORTEN_PRIVAT_NOKKEL", env, paakrevd=False, default="maskinporten_privat.pem",
+    )
     private_key_pem = _les_nokkel(nokkel_sti)
 
     maskinporten_token = _hent_maskinporten_token(

--- a/wenche/auth.py
+++ b/wenche/auth.py
@@ -211,9 +211,16 @@ def login(lagre_token: bool = True) -> dict:
         "MASKINPORTEN_KID", env,
         "Finn nøkkel-ID (UUID) i Digdirs selvbetjeningsportal under klientens nøkler og legg den i .env.",
     )
-    org_nummer = _les_påkrevd_env(
+    vendor_orgnr = _les_påkrevd_env(
         "ORG_NUMMER",
         "Legg til ORG_NUMMER=<ditt organisasjonsnummer> i .env.",
+    )
+    # I testmiljø skal Maskinporten-JWT-en hevde at vi handler på vegne av
+    # den syntetiske Tenor-orgen (kunden i test), ikke vår egen leverandør-org.
+    # Systembrukeren i tt02-Altinn er knyttet til Tenor-orgen, så uten denne
+    # mappingen får vi 403 på instance-opprettelse selv om credentials er ok.
+    org_nummer = (
+        os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr) if env == "test" else vendor_orgnr
     )
     nokkel_sti = _les_miljo_env(
         "MASKINPORTEN_PRIVAT_NOKKEL", env, paakrevd=False, default="maskinporten_privat.pem",

--- a/wenche/auth.py
+++ b/wenche/auth.py
@@ -192,11 +192,15 @@ def _les_miljo_env(
     return default
 
 
-def login() -> dict:
+def login(lagre_token: bool = True) -> dict:
     """
     Autentiserer mot Maskinporten med systembruker-token og veksler mot Altinn-token.
 
     Krever ORG_NUMMER i .env. Returnerer {'maskinporten_token': str, 'altinn_token': str}.
+
+    Hvis lagre_token=False, skrives ikke tokenet til disk. Brukes ved
+    tilkoblingstest der vi ikke vil overskrive et eksisterende aktivt token
+    eller forstyrre annen miljø-konfigurasjon.
     """
     env = os.getenv("WENCHE_ENV", "prod")
     client_id = _les_miljo_env(
@@ -234,6 +238,10 @@ def login() -> dict:
         "maskinporten_token": maskinporten_token,
         "altinn_token": altinn_token,
     }
+
+    if not lagre_token:
+        print("Autentisering vellykket (token ikke lagret).\n")
+        return tokens
 
     TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
     TOKEN_FILE.write_text(json.dumps(tokens))

--- a/wenche/fristsjekk.py
+++ b/wenche/fristsjekk.py
@@ -69,30 +69,33 @@ class FristStatus:
 
 
 def sjekk_skattemelding(orgnr: str, aar: int) -> FristStatus:
-    """Sjekk om skattemelding er fastsatt via Skatteetatens API."""
-    env = os.getenv("WENCHE_ENV", "prod")
+    """
+    Sjekk om skattemelding er fastsatt via Skatteetatens API.
 
-    # Skatteetatens testmiljø kjenner kun syntetiske Tenor-orgnumre.
-    # En statussjekk fra Hjem-fanen mot test-API-et med ekte org.nr.
-    # ville bare gitt "Ugyldig identifikator". Vi viser i stedet en
-    # informativ melding så brukeren forstår hva som mangler.
-    if env == "test":
-        return FristStatus(
-            beskrivelse="Statussjekk kun tilgjengelig i prod-miljø",
-            brukertekst=(
-                "Du er i testmiljø. Statussjekk mot Skatteetaten gjøres kun "
-                "mot prod-API-et med ekte org.nr. Bytt aktivt miljø til "
-                "Produksjon i Oppsett-fanen når du er klar."
-            ),
-        )
-
+    Hjem-fanen viser alltid reell innsendingsstatus mot prod, uavhengig av
+    WENCHE_ENV. Test-API-et kjenner uansett kun syntetiske Tenor-orgnumre.
+    Vi setter WENCHE_ENV midlertidig til 'prod' rundt auth-flyten slik at
+    prod-Maskinporten og prod-credentials brukes selv om global WENCHE_ENV
+    er noe annet.
+    """
+    opprinnelig_env = os.environ.get("WENCHE_ENV")
+    os.environ["WENCHE_ENV"] = "prod"
     try:
-        from wenche.auth import get_skd_skattemelding_maskinporten_token
+        try:
+            from wenche.auth import get_skd_skattemelding_maskinporten_token
 
-        token = get_skd_skattemelding_maskinporten_token()
-    except RuntimeError:
-        return FristStatus(beskrivelse="Maskinporten ikke konfigurert")
+            token = get_skd_skattemelding_maskinporten_token()
+        except RuntimeError:
+            return FristStatus(beskrivelse="Maskinporten ikke konfigurert for prod")
+        return _utfør_skattemelding_sjekk(token, orgnr, aar)
+    finally:
+        if opprinnelig_env is None:
+            os.environ.pop("WENCHE_ENV", None)
+        else:
+            os.environ["WENCHE_ENV"] = opprinnelig_env
 
+
+def _utfør_skattemelding_sjekk(token: str, orgnr: str, aar: int) -> FristStatus:
     base = _SKD_BASES["prod"]
 
     try:

--- a/wenche/fristsjekk.py
+++ b/wenche/fristsjekk.py
@@ -70,6 +70,22 @@ class FristStatus:
 
 def sjekk_skattemelding(orgnr: str, aar: int) -> FristStatus:
     """Sjekk om skattemelding er fastsatt via Skatteetatens API."""
+    env = os.getenv("WENCHE_ENV", "prod")
+
+    # Skatteetatens testmiljø kjenner kun syntetiske Tenor-orgnumre.
+    # En statussjekk fra Hjem-fanen mot test-API-et med ekte org.nr.
+    # ville bare gitt "Ugyldig identifikator". Vi viser i stedet en
+    # informativ melding så brukeren forstår hva som mangler.
+    if env == "test":
+        return FristStatus(
+            beskrivelse="Statussjekk kun tilgjengelig i prod-miljø",
+            brukertekst=(
+                "Du er i testmiljø. Statussjekk mot Skatteetaten gjøres kun "
+                "mot prod-API-et med ekte org.nr. Bytt aktivt miljø til "
+                "Produksjon i Oppsett-fanen når du er klar."
+            ),
+        )
+
     try:
         from wenche.auth import get_skd_skattemelding_maskinporten_token
 
@@ -77,8 +93,7 @@ def sjekk_skattemelding(orgnr: str, aar: int) -> FristStatus:
     except RuntimeError:
         return FristStatus(beskrivelse="Maskinporten ikke konfigurert")
 
-    env = os.getenv("WENCHE_ENV", "prod")
-    base = _SKD_BASES.get(env, _SKD_BASES["prod"])
+    base = _SKD_BASES["prod"]
 
     try:
         resp = httpx.get(

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -996,6 +996,12 @@ def _bygg_oppsett_fane() -> None:
     test_card_inputs: dict[str, ui.input] = {}
     prod_card_inputs: dict[str, ui.input] = {}
 
+    def _milj_har_credentials(env: str) -> bool:
+        return bool(
+            _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
+            and _les_konfig_for_milj("MASKINPORTEN_KID", env)
+        )
+
     # Helper: kjør en operasjon med en bestemt WENCHE_ENV, restorer etterpå.
     def _med_env(env: str, fn, *args, **kwargs):
         opprinnelig = os.environ.get("WENCHE_ENV")
@@ -1010,6 +1016,9 @@ def _bygg_oppsett_fane() -> None:
 
     status_kontainer: dict[str, "ui.column"] = {}
     godkjenn_url_kontainer: dict[str, "ui.element"] = {}
+    knapper_kontainer: dict[str, "ui.column"] = {}
+    handlere: dict[str, dict] = {}
+    _siste_status: dict[str, str | None] = {}
 
     def _vis_godkjenn_lenke(env: str, url: str, etikett: str = "Godkjenn i Altinn →"):
         godkjenn_url_kontainer[env].clear()
@@ -1019,6 +1028,50 @@ def _bygg_oppsett_fane() -> None:
             ui.link(etikett, url, new_tab=True).classes(
                 "text-blue-600 font-medium text-sm"
             )
+
+    def _render_handlinger(env: str):
+        """Render knappene for et miljø basert på siste kjente status.
+
+        Bare det som er relevant vises primært; resten gjemmes i Avansert.
+        """
+        if env not in knapper_kontainer or env not in handlere:
+            return
+        knapper_kontainer[env].clear()
+        status = _siste_status.get(env)
+        h = handlere[env]
+
+        with knapper_kontainer[env]:
+            if status == "ikke_opprettet":
+                ui.button("Opprett systembruker", on_click=h["opprett"]).props(
+                    "color=primary"
+                ).classes("w-full")
+            elif status == "Rejected":
+                ui.button("Opprett ny systembruker", on_click=h["opprett"]).props(
+                    "color=primary"
+                ).classes("w-full")
+            elif status in ("New", "Accepted"):
+                # Status-raden viser allerede det viktigste. Brukeren trenger
+                # ikke en stor primær-knapp — kun en lav-profil refresh.
+                pass
+
+            with ui.expansion("Avansert").classes("w-full"):
+                ui.label(
+                    "Disse trengs sjelden. Bruk dem hvis du må re-registrere "
+                    "systemet, opprette ny forespørsel, eller legge til nye "
+                    "scopes på en allerede godkjent systembruker."
+                ).classes("text-xs text-slate-500 mb-2")
+                ui.button("Sjekk status på nytt", on_click=h["sjekk_status"]).props(
+                    "outline color=primary"
+                ).classes("w-full")
+                ui.button("Oppdater rettigheter", on_click=h["oppdater"]).props(
+                    "outline color=primary"
+                ).classes("w-full")
+                ui.button("Registrer system", on_click=h["registrer"]).props(
+                    "outline color=primary"
+                ).classes("w-full")
+                ui.button("Opprett (ny) systembruker", on_click=h["opprett"]).props(
+                    "outline color=primary"
+                ).classes("w-full")
 
     def _vis_status(env: str, status: str | None, melding: str | None = None):
         kontainer = status_kontainer[env]
@@ -1102,6 +1155,10 @@ def _bygg_oppsett_fane() -> None:
                     if forklaring:
                         ui.label(forklaring).classes("text-xs text-slate-500 mt-0.5")
 
+        # Husker hvilken status vi er i, og rerender knappene kontekstuelt.
+        _siste_status[env] = "ikke_opprettet" if status == "ikke_opprettet" else status
+        _render_handlinger(env)
+
     with ui.grid(columns=2).classes("w-full gap-4"):
         for env_var, miljo_navn, ikon_navn, ikon_farge, card_inputs in [
             ("test", "Testmiljø (tt02)", "science", "text-slate-500", test_card_inputs),
@@ -1133,15 +1190,9 @@ def _bygg_oppsett_fane() -> None:
                 ui.label("Systembruker i Altinn").classes(
                     "text-xs text-slate-500 uppercase tracking-wide font-medium"
                 )
-                ui.label(
-                    "Altinn krever at virksomheten godkjenner Wenche som "
-                    "leverandørsystem før vi kan sende inn dokumenter for "
-                    "den. Det gjøres med BankID av daglig leder eller "
-                    "styreleder."
-                ).classes("text-xs text-slate-500 mt-1 mb-2")
-                status_kontainer[env_var] = ui.column().classes("gap-0 mb-2")
-                _vis_status(env_var, None)
+                status_kontainer[env_var] = ui.column().classes("gap-0 mb-2 mt-1")
                 godkjenn_url_kontainer[env_var] = ui.element("div").classes("mb-2")
+                knapper_kontainer[env_var] = ui.column().classes("w-full gap-2 mt-2")
 
                 async def sjekk_status_handler(env=env_var):
                     request_id = _les_request_id(env)
@@ -1288,25 +1339,24 @@ def _bygg_oppsett_fane() -> None:
                         n.timeout = 0
                         n.close_button = "Lukk"
 
-                with ui.column().classes("w-full gap-2 mt-2"):
-                    ui.button("Sjekk status", on_click=sjekk_status_handler).props(
-                        "color=primary"
-                    ).classes("w-full")
-                    ui.button("Registrer system", on_click=registrer_handler).props(
-                        "outline color=primary"
-                    ).classes("w-full")
-                    ui.button("Opprett systembruker", on_click=opprett_handler).props(
-                        "outline color=primary"
-                    ).classes("w-full")
-                    with ui.expansion("Avansert").classes("w-full"):
-                        ui.label(
-                            "Oppdater rettigheter sender en endringsforespørsel "
-                            "hvis du har lagt til nye scopes på en allerede godkjent "
-                            "systembruker. Eksisterende rettigheter beholdes."
-                        ).classes("text-sm text-slate-500 mb-2")
-                        ui.button(
-                            "Oppdater rettigheter", on_click=oppdater_handler,
-                        ).props("outline color=primary").classes("w-full")
+                # Registrer alle handlere så _render_handlinger kan bruke dem.
+                handlere[env_var] = {
+                    "sjekk_status": sjekk_status_handler,
+                    "registrer": registrer_handler,
+                    "opprett": opprett_handler,
+                    "oppdater": oppdater_handler,
+                }
+
+                # Initial render: viser «Status ikke sjekket»-tilstand + relevante knapper.
+                _vis_status(env_var, None)
+
+                # Auto-sjekk status ved sidelasting hvis vi har credentials og
+                # en eksisterende forespørsel. Brukeren slipper å klikke.
+                if (
+                    _milj_har_credentials(env_var)
+                    and _les_request_id(env_var)
+                ):
+                    ui.timer(1.0, sjekk_status_handler, once=True)
 
     # --- Felles for begge miljø ---
     ui.separator().classes("my-4")
@@ -1396,12 +1446,6 @@ def _bygg_oppsett_fane() -> None:
     ).classes("text-sm text-slate-500 mb-2")
 
     test_resultat_container = ui.column().classes("w-full gap-1 mt-3")
-
-    def _milj_har_credentials(env: str) -> bool:
-        return bool(
-            _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
-            and _les_konfig_for_milj("MASKINPORTEN_KID", env)
-        )
 
     def _tolk_feilmelding(env: str, raw: str) -> str:
         """Oversett rå auth-feilmelding til brukervennlig norsk."""

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -57,6 +57,24 @@ _WENCHE_DIR = Path.home() / ".wenche"
 _REQUEST_ID_FIL = _WENCHE_DIR / "systembruker_request_id.txt"  # legacy (alle miljø)
 
 
+def _med_env(env: str, fn, *args, **kwargs):
+    """
+    Kjør fn med WENCHE_ENV midlertidig satt til env, restorer etterpå.
+
+    Brukes av flere faner (Oppsett, Send, Hjem) for å midlertidig peke auth-
+    flyten mot et bestemt miljø uavhengig av globalt aktivt miljø.
+    """
+    opprinnelig = os.environ.get("WENCHE_ENV")
+    os.environ["WENCHE_ENV"] = env
+    try:
+        return fn(*args, **kwargs)
+    finally:
+        if opprinnelig is None:
+            os.environ.pop("WENCHE_ENV", None)
+        else:
+            os.environ["WENCHE_ENV"] = opprinnelig
+
+
 def _request_id_fil_for_milj(env: str) -> Path:
     """Sti til miljø-spesifikk request-id-fil. Faller tilbake til legacy-fil."""
     return _WENCHE_DIR / f"systembruker_request_id_{env}.txt"
@@ -597,35 +615,40 @@ def _les_konfig_for_milj(navn: str, env: str, default: str = "") -> str:
     """
     Les credential-verdi for gitt miljø.
 
-    Prøver først miljø-spesifikk variant ({navn}_{TEST|PROD}), faller tilbake
-    til generisk variabelnavn for brukere som kun har ett sett credentials.
+    Prøver først miljø-spesifikk variant ({navn}_{TEST|PROD}). Hvis den er
+    eksplisitt satt (selv som tom streng) er den autoritativ, slik at brukere
+    som har tømt feltet ikke får tilbake en gammel generisk fallback-verdi.
+    Faller tilbake til generisk variabelnavn kun når miljø-spesifikk
+    variabel ikke er definert i det hele tatt.
     """
-    return os.getenv(f"{navn}_{env.upper()}") or os.getenv(navn) or default
+    env_key = f"{navn}_{env.upper()}"
+    if env_key in os.environ:
+        return os.environ[env_key] or default
+    return os.getenv(navn) or default
 
 
 def _sjekk_konfig() -> list[tuple[bool, str, str]]:
     resultater = []
-    env = os.getenv("WENCHE_ENV", "prod")
-    suffix = env.upper()
 
-    client_id = _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
-    resultater.append((
-        bool(client_id),
-        f"MASKINPORTEN_CLIENT_ID for {suffix}",
-        "Satt" if client_id else f"Mangler. Sett MASKINPORTEN_CLIENT_ID_{suffix} (eller MASKINPORTEN_CLIENT_ID som fallback) i .env",
-    ))
-    kid = _les_konfig_for_milj("MASKINPORTEN_KID", env)
-    resultater.append((
-        bool(kid),
-        f"MASKINPORTEN_KID for {suffix}",
-        "Satt" if kid else f"Mangler. Sett MASKINPORTEN_KID_{suffix} (eller MASKINPORTEN_KID som fallback) i .env",
-    ))
+    # Credentials per miljø — viser status for begge slik at brukeren ser hva
+    # som er på plass uten å måtte tenke på «aktivt miljø».
+    for env, miljo_navn in [("test", "Testmiljø"), ("prod", "Produksjon")]:
+        client_id = _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
+        kid = _les_konfig_for_milj("MASKINPORTEN_KID", env)
+        komplett = bool(client_id and kid)
+        if komplett:
+            detalj = "Klient-ID og Nøkkel-ID satt"
+        elif client_id or kid:
+            detalj = "Delvis konfigurert (mangler Klient-ID eller Nøkkel-ID)"
+        else:
+            detalj = "Ikke konfigurert"
+        resultater.append((komplett, f"{miljo_navn}-credentials", detalj))
+
     orgnr = os.getenv("ORG_NUMMER")
     resultater.append((bool(orgnr), "ORG_NUMMER", "Satt" if orgnr else "Mangler. Legg til i .env-filen"))
-    nokkel_sti = _les_konfig_for_milj("MASKINPORTEN_PRIVAT_NOKKEL", env, "maskinporten_privat.pem")
+    nokkel_sti = os.getenv("MASKINPORTEN_PRIVAT_NOKKEL", "maskinporten_privat.pem")
     nokkel_ok = Path(nokkel_sti).exists()
     resultater.append((nokkel_ok, "Privat nøkkel", f"Funnet: {nokkel_sti}" if nokkel_ok else f"Finner ikke: {nokkel_sti}"))
-    resultater.append((True, "Miljø", f"{'Testmiljø (tt02)' if env == 'test' else 'Produksjon'}, bytt i Oppsett-fanen"))
     return resultater
 
 
@@ -956,33 +979,7 @@ def _bygg_oppsett_fane() -> None:
     ).classes("text-slate-500 text-sm mb-4")
 
     # --- Aktivt miljø ---
-    seksjonstittel("Aktivt miljø")
-    ui.label(
-        "Avgjør hvilket sett credentials Wenche bruker. Du kan konfigurere "
-        "begge miljø samtidig under, og bytte aktivt miljø her uten å redigere noe annet."
-    ).classes("text-sm text-slate-500 mb-3")
-
     dot_env_fil = Path(".env")
-    aktivt_env = os.getenv("WENCHE_ENV", "prod")
-
-    inp_env = ui.radio(
-        {"test": "Testmiljø (tt02)", "prod": "Produksjon"},
-        value=aktivt_env,
-    ).props("inline color=primary")
-
-    # Når brukeren bytter radio-knappen, oppdater os.environ umiddelbart slik
-    # at andre faner (særlig Hjem-fanens statussjekk) reflekterer det nye
-    # miljøet uten å vente på Lagre-klikk. Lagre-knappen persisterer fortsatt
-    # endringen til .env-filen.
-    def _radio_endret():
-        os.environ["WENCHE_ENV"] = inp_env.value
-        miljo_navn = "testmiljø" if inp_env.value == "test" else "produksjon"
-        ui.notify(
-            f"Aktivt miljø satt til {miljo_navn}. Klikk Lagre for å persistere.",
-            type="info",
-        )
-
-    inp_env.on_value_change(lambda _: _radio_endret())
 
     # --- Miljø-oppsett (credentials + systembruker per miljø) ---
     ui.separator().classes("my-4")
@@ -1001,18 +998,6 @@ def _bygg_oppsett_fane() -> None:
             _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
             and _les_konfig_for_milj("MASKINPORTEN_KID", env)
         )
-
-    # Helper: kjør en operasjon med en bestemt WENCHE_ENV, restorer etterpå.
-    def _med_env(env: str, fn, *args, **kwargs):
-        opprinnelig = os.environ.get("WENCHE_ENV")
-        os.environ["WENCHE_ENV"] = env
-        try:
-            return fn(*args, **kwargs)
-        finally:
-            if opprinnelig is None:
-                os.environ.pop("WENCHE_ENV", None)
-            else:
-                os.environ["WENCHE_ENV"] = opprinnelig
 
     status_kontainer: dict[str, "ui.column"] = {}
     godkjenn_url_kontainer: dict[str, "ui.element"] = {}
@@ -1107,6 +1092,16 @@ def _bygg_oppsett_fane() -> None:
                 "for å lage en ny forespørsel."
             )
             _vis_godkjenn_lenke(env, "")
+        elif status == "feil":
+            ikon, farge = "error_outline", "text-red-600"
+            overskrift = melding or "Kunne ikke sjekke status"
+            forklaring = (
+                "Vanligste årsaker: ugyldige credentials for dette miljøet, "
+                "klient ikke registrert hos Maskinporten, eller manglende "
+                "scopes. Klikk «Sjekk status på nytt» i Avansert for å se "
+                "den fulle feilmeldingen."
+            )
+            _vis_godkjenn_lenke(env, "")
         elif status == "ikke_opprettet":
             ikon, farge = "info", "text-slate-500"
             overskrift = "Ingen systembruker satt opp"
@@ -1194,15 +1189,23 @@ def _bygg_oppsett_fane() -> None:
                 godkjenn_url_kontainer[env_var] = ui.element("div").classes("mb-2")
                 knapper_kontainer[env_var] = ui.column().classes("w-full gap-2 mt-2")
 
-                async def sjekk_status_handler(env=env_var):
+                async def sjekk_status_handler(env=env_var, silent: bool = False):
+                    """Sjekk systembruker-status for et miljø.
+
+                    silent=True brukes ved auto-sjekk ved sidelasting — feil
+                    blir kun synlige som rødt i status-raden, ikke som
+                    forstyrrende popup-meldinger.
+                    """
                     request_id = _les_request_id(env)
                     if not request_id:
                         _vis_status(env, "ikke_opprettet")
                         return
-                    n = ui.notification(
-                        f"Sjekker status i {('testmiljø' if env == 'test' else 'produksjon')}...",
-                        spinner=True, timeout=None,
-                    )
+                    n = None
+                    if not silent:
+                        n = ui.notification(
+                            f"Sjekker status i {('testmiljø' if env == 'test' else 'produksjon')}...",
+                            spinner=True, timeout=None,
+                        )
                     try:
                         token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
                         svar = await run.io_bound(
@@ -1211,13 +1214,16 @@ def _bygg_oppsett_fane() -> None:
                             )
                         )
                         _vis_status(env, svar.get("status", "ukjent"))
-                        n.dismiss()
+                        if n is not None:
+                            n.dismiss()
                     except Exception as e:
-                        n.message = f"Feil ved statussjekk: {e}"
-                        n.spinner = False
-                        n.type = "negative"
-                        n.timeout = 0
-                        n.close_button = "Lukk"
+                        _vis_status(env, "feil", f"Kunne ikke sjekke status ({type(e).__name__})")
+                        if n is not None:
+                            n.message = f"Feil ved statussjekk: {e}"
+                            n.spinner = False
+                            n.type = "negative"
+                            n.timeout = 0
+                            n.close_button = "Lukk"
 
                 async def registrer_handler(env=env_var):
                     n = ui.notification(
@@ -1351,12 +1357,17 @@ def _bygg_oppsett_fane() -> None:
                 _vis_status(env_var, None)
 
                 # Auto-sjekk status ved sidelasting hvis vi har credentials og
-                # en eksisterende forespørsel. Brukeren slipper å klikke.
+                # en eksisterende forespørsel. Stille modus betyr at evt. feil
+                # kun synes i status-raden, ikke som popup-notifikasjoner.
                 if (
                     _milj_har_credentials(env_var)
                     and _les_request_id(env_var)
                 ):
-                    ui.timer(1.0, sjekk_status_handler, once=True)
+                    ui.timer(
+                        1.0,
+                        lambda env=env_var: sjekk_status_handler(env=env, silent=True),
+                        once=True,
+                    )
 
     # --- Felles for begge miljø ---
     ui.separator().classes("my-4")
@@ -1389,25 +1400,24 @@ def _bygg_oppsett_fane() -> None:
     async def lagre_konfig():
         from dotenv import set_key
         dot_env_fil.touch(exist_ok=True)
-        valgt_env = inp_env.value
 
-        # Lagre credentials per miljø — begge sett skrives uavhengig av aktivt miljø.
+        # Lagre credentials per miljø — begge sett skrives uavhengig av hverandre.
+        # Skriver alltid eksplisitt (selv om tomt) slik at tomming fra UI faktisk
+        # persisteres. _les_konfig_for_milj behandler eksplisitt tom som
+        # autoritativ (ikke fallback til generisk legacy-verdi).
         for kort_env, inputs in [("test", test_card_inputs), ("prod", prod_card_inputs)]:
             suffix = kort_env.upper()
-            if inputs["client_id"].value:
-                navn = f"MASKINPORTEN_CLIENT_ID_{suffix}"
-                set_key(str(dot_env_fil), navn, inputs["client_id"].value)
-                os.environ[navn] = inputs["client_id"].value
-            if inputs["kid"].value:
-                navn = f"MASKINPORTEN_KID_{suffix}"
-                set_key(str(dot_env_fil), navn, inputs["kid"].value)
-                os.environ[navn] = inputs["kid"].value
+            for felt_navn, env_navn in [
+                ("client_id", f"MASKINPORTEN_CLIENT_ID_{suffix}"),
+                ("kid", f"MASKINPORTEN_KID_{suffix}"),
+            ]:
+                verdi = inputs[felt_navn].value or ""
+                set_key(str(dot_env_fil), env_navn, verdi)
+                os.environ[env_navn] = verdi
 
         if inp_orgnr.value:
             set_key(str(dot_env_fil), "ORG_NUMMER", inp_orgnr.value)
             os.environ["ORG_NUMMER"] = inp_orgnr.value
-        set_key(str(dot_env_fil), "WENCHE_ENV", valgt_env)
-        os.environ["WENCHE_ENV"] = valgt_env
         if pem_bytes_holder:
             nokkel_sti = Path("maskinporten_privat.pem")
             nokkel_sti.write_bytes(pem_bytes_holder[0])
@@ -1415,8 +1425,7 @@ def _bygg_oppsett_fane() -> None:
             set_key(str(dot_env_fil), "MASKINPORTEN_PRIVAT_NOKKEL", str(nokkel_sti))
             os.environ["MASKINPORTEN_PRIVAT_NOKKEL"] = str(nokkel_sti)
         konfig_status.refresh()
-        miljo_navn = "testmiljø" if valgt_env == "test" else "produksjon"
-        ui.notify(f"Konfigurasjon lagret. Aktivt miljø: {miljo_navn}.", type="positive")
+        ui.notify("Konfigurasjon lagret.", type="positive")
 
     ui.button("Lagre konfigurasjon", on_click=lagre_konfig).props("color=primary").classes("mt-2")
 
@@ -2210,7 +2219,7 @@ def _bygg_send_fane() -> None:
 
     async def hent_altinn_token() -> str | None:
         try:
-            return await run.io_bound(auth.get_altinn_token)
+            return await run.io_bound(lambda: _med_env(env_valg.value, auth.get_altinn_token))
         except RuntimeError as e:
             feilmelding = str(e)
             if "invalid_altinn_customer_configuration" in feilmelding:
@@ -2266,7 +2275,7 @@ def _bygg_send_fane() -> None:
             return
         n = ui.notification("Henter Maskinporten-token med SKD-scope...", spinner=True, timeout=None)
         try:
-            skd_token = await run.io_bound(auth.get_skd_aksjonaer_token)
+            skd_token = await run.io_bound(lambda: _med_env(env_valg.value, auth.get_skd_aksjonaer_token))
             n.message = "Sender aksjonærregisteroppgave til Skatteetaten..."
 
             def _send():
@@ -2293,7 +2302,7 @@ def _bygg_send_fane() -> None:
         orgnr = os.getenv("SKD_TEST_ORG_NUMMER", state.org_nummer) if env_valg.value == "test" else state.org_nummer
         n = ui.notification("Henter tokens for skattemelding...", spinner=True, timeout=None)
         try:
-            tokens = await run.io_bound(auth.get_skd_skattemelding_tokens)
+            tokens = await run.io_bound(lambda: _med_env(env_valg.value, auth.get_skd_skattemelding_tokens))
             n.message = "Henter forhåndsutfylt skattemelding..."
 
             def _hent_og_send():

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -54,7 +54,12 @@ from wenche.naeringsspesifikasjon_xml import generer_naeringsspesifikasjon
 
 CONFIG_FIL = Path("config.yaml")
 _WENCHE_DIR = Path.home() / ".wenche"
-_REQUEST_ID_FIL = _WENCHE_DIR / "systembruker_request_id.txt"
+_REQUEST_ID_FIL = _WENCHE_DIR / "systembruker_request_id.txt"  # legacy (alle miljø)
+
+
+def _request_id_fil_for_milj(env: str) -> Path:
+    """Sti til miljø-spesifikk request-id-fil. Faller tilbake til legacy-fil."""
+    return _WENCHE_DIR / f"systembruker_request_id_{env}.txt"
 
 
 # ---------------------------------------------------------------------------
@@ -619,12 +624,21 @@ def _sjekk_konfig() -> list[tuple[bool, str, str]]:
     return resultater
 
 
-def _lagre_request_id(request_id: str) -> None:
+def _lagre_request_id(request_id: str, env: str | None = None) -> None:
     _WENCHE_DIR.mkdir(exist_ok=True)
+    if env is None:
+        env = os.getenv("WENCHE_ENV", "prod")
+    _request_id_fil_for_milj(env).write_text(request_id, encoding="utf-8")
+    # Behold også i legacy-fil for bakoverkompatibilitet
     _REQUEST_ID_FIL.write_text(request_id, encoding="utf-8")
 
 
-def _les_request_id() -> str:
+def _les_request_id(env: str | None = None) -> str:
+    if env is None:
+        env = os.getenv("WENCHE_ENV", "prod")
+    milj_fil = _request_id_fil_for_milj(env)
+    if milj_fil.exists():
+        return milj_fil.read_text(encoding="utf-8").strip()
     if _REQUEST_ID_FIL.exists():
         return _REQUEST_ID_FIL.read_text(encoding="utf-8").strip()
     return ""
@@ -1212,156 +1226,221 @@ def _bygg_oppsett_fane() -> None:
 
     # --- Systembruker-oppsett ---
     ui.separator().classes("my-4")
-    with ui.expansion("Systembruker-oppsett (gjøres én gang per miljø)").classes("w-full"):
-        ui.label(
-            "Altinn 3 krever at Wenche er registrert som leverandørsystem og at organisasjonen din "
-            "har godkjent en systembruker. Dette gjøres én gang, og på nytt hvis du bytter miljø."
-        ).classes("text-sm text-slate-500 mb-3")
+    seksjonstittel("Systembruker-oppsett")
+    ui.label(
+        "Wenche må være registrert som leverandørsystem i Altinn, og "
+        "virksomheten må ha godkjent en systembruker. Hvert miljø har sin egen "
+        "systembruker — settes opp uavhengig og forblir gyldig så lenge "
+        "rettighetene ikke endres."
+    ).classes("text-sm text-slate-500 mb-3")
 
-        seksjonstittel("Steg 1. Registrer Wenche i systemregisteret")
-        ui.label(
-            "Registrerer Wenche i Altinns systemregister. Kan kjøres på nytt uten skade."
-        ).classes("text-sm text-slate-500 mb-2")
+    # Helper: kjør en operasjon i et bestemt miljø, restorer WENCHE_ENV etterpå.
+    def _med_env(env: str, fn, *args, **kwargs):
+        opprinnelig = os.environ.get("WENCHE_ENV")
+        os.environ["WENCHE_ENV"] = env
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            if opprinnelig is None:
+                os.environ.pop("WENCHE_ENV", None)
+            else:
+                os.environ["WENCHE_ENV"] = opprinnelig
 
-        async def registrer_system():
-            n = ui.notification("Registrerer system i Altinn...", spinner=True, timeout=None)
-            try:
-                token = await run.io_bound(auth.login_admin)
-                orgnr = os.getenv("ORG_NUMMER")
-                client_id = os.getenv("MASKINPORTEN_CLIENT_ID")
-                svar = await run.io_bound(systembruker.registrer_system, token, orgnr, client_id)
-                n.message = "System oppdatert." if svar.get("oppdatert") else "System registrert."
-                n.spinner = False
-                n.type = "positive"
-                n.timeout = 5
-            except Exception as e:
-                n.message = f"Feil: {e}"
-                n.spinner = False
-                n.type = "negative"
-                n.timeout = 0
-                n.close_button = "Lukk"
+    status_kontainer: dict[str, "ui.column"] = {}
+    godkjenn_url_kontainer: dict[str, "ui.element"] = {}
 
-        ui.button("Registrer Wenche i systemregisteret", on_click=registrer_system).props("color=primary outline")
+    def _vis_status(env: str, status: str | None, melding: str | None = None):
+        kontainer = status_kontainer[env]
+        kontainer.clear()
+        if status == "Accepted":
+            ikon, farge, tekst = "check_circle", "text-green-600", "Systembruker godkjent"
+        elif status == "New":
+            ikon, farge, tekst = "schedule", "text-amber-600", "Forespørsel venter på godkjenning"
+        elif status == "Rejected":
+            ikon, farge, tekst = "error", "text-red-600", "Forespørsel avvist — opprett ny"
+        elif status:
+            ikon, farge, tekst = "info", "text-slate-500", f"Status: {status}"
+        else:
+            ikon, farge = "help_outline", "text-slate-400"
+            tekst = melding or "Status ikke sjekket ennå"
+        with kontainer:
+            with ui.element("div").classes("grid grid-cols-[auto_1fr] gap-2 items-center"):
+                ui.icon(ikon).classes(f"{farge} text-base")
+                ui.label(tekst).classes(f"text-sm {farge}")
 
-        seksjonstittel("Steg 1b. Oppdater rettigheter på eksisterende systembruker")
-        ui.label(
-            "Hvis systembrukeren allerede er godkjent og du har lagt til nye rettigheter, "
-            "send en endringsforespørsel. Eksisterende rettigheter beholdes — kun nye legges til."
-        ).classes("text-sm text-slate-500 mb-2")
-        endrings_url_container = ui.element("div")
+    with ui.grid(columns=2).classes("w-full gap-4"):
+        for env_var, miljo_navn, ikon_navn, ikon_farge in [
+            ("test", "Testmiljø (tt02)", "science", "text-slate-500"),
+            ("prod", "Produksjon", "business", "text-slate-700"),
+        ]:
+            with ui.card().classes("w-full p-4 border border-slate-200 shadow-none rounded-xl"):
+                with ui.row().classes("items-center gap-2 mb-2"):
+                    ui.icon(ikon_navn).classes(ikon_farge)
+                    ui.label(miljo_navn).classes("font-semibold text-slate-800")
 
-        async def oppdater_systembruker():
-            n = ui.notification("Henter systembrukere...", spinner=True, timeout=None)
-            try:
-                token = await run.io_bound(auth.login_admin)
-                vendor_orgnr = os.getenv("ORG_NUMMER")
-                env = os.getenv("WENCHE_ENV", "prod")
-                orgnr = os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr) if env == "test" else vendor_orgnr
-                brukere = await run.io_bound(systembruker.hent_systembrukere, token, vendor_orgnr)
-                if not brukere:
-                    n.message = "Ingen aktive systembrukere funnet. Bruk steg 2 for å opprette ny."
-                    n.spinner = False
-                    n.type = "info"
-                    n.timeout = 6
-                    return
-                # Finn systembrukeren for riktig party-org (i test: SKD_TEST_ORG_NUMMER)
-                treff = next(
-                    (b for b in brukere if b.get("reporteeOrgNo") == orgnr),
-                    brukere[0],
-                )
-                bruker_id = treff["id"]
-                # Send kun den nye skattemelding-rettigheten.
-                # Altinn-API-et krever at uendrede rettigheter utelates fra changerequest.
-                svar = await run.io_bound(
-                    systembruker.opprett_endringsforespørsel,
-                    token,
-                    bruker_id,
-                    [systembruker._SKATTEMELDING_RETT],
-                )
-                confirm_url = svar.get("confirmUrl") or svar.get("ConfirmUrl", "")
-                endrings_url_container.clear()
-                with endrings_url_container:
-                    ui.link("Godkjenn i Altinn →", confirm_url, new_tab=True).classes("text-blue-600 font-medium text-sm")
-                n.message = f"Endringsforespørsel opprettet (status: {svar.get('status', '')})"
-                n.spinner = False
-                n.type = "positive"
-                n.timeout = 5
-            except Exception as e:
-                n.message = f"Feil: {e}"
-                n.spinner = False
-                n.type = "negative"
-                n.timeout = 0
-                n.close_button = "Lukk"
+                status_kontainer[env_var] = ui.column().classes("gap-0 mb-2")
+                _vis_status(env_var, None)
 
-        ui.button("Oppdater systembruker-rettigheter", on_click=oppdater_systembruker).props("color=primary outline")
+                godkjenn_url_kontainer[env_var] = ui.element("div").classes("mb-2 min-h-0")
 
-        seksjonstittel("Steg 2. Opprett systembrukerforespørsel")
-        godkjenn_url_container = ui.element("div")
+                # Handlere — bruker env=env_var som default-arg for korrekt closure-capture.
+                async def sjekk_status_handler(env=env_var):
+                    request_id = _les_request_id(env)
+                    if not request_id:
+                        _vis_status(env, None, "Ingen forespørsel opprettet ennå")
+                        return
+                    n = ui.notification(
+                        f"Sjekker status i {('testmiljø' if env == 'test' else 'produksjon')}...",
+                        spinner=True, timeout=None,
+                    )
+                    try:
+                        token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
+                        svar = await run.io_bound(
+                            lambda: _med_env(
+                                env, systembruker.hent_forespørsel_status, token, request_id,
+                            )
+                        )
+                        _vis_status(env, svar.get("status", "ukjent"))
+                        n.dismiss()
+                    except Exception as e:
+                        n.message = f"Feil ved statussjekk: {e}"
+                        n.spinner = False
+                        n.type = "negative"
+                        n.timeout = 0
+                        n.close_button = "Lukk"
 
-        async def opprett_forespørsel():
-            n = ui.notification("Oppretter systembrukerforespørsel...", spinner=True, timeout=None)
-            try:
-                token = await run.io_bound(auth.login_admin)
-                vendor_orgnr = os.getenv("ORG_NUMMER")
-                env = os.getenv("WENCHE_ENV", "prod")
-                party_orgnr = os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr) if env == "test" else vendor_orgnr
-                svar = await run.io_bound(systembruker.opprett_forespørsel, token, vendor_orgnr, party_orgnr)
-                request_id = svar.get("id", "")
-                if request_id:
-                    _lagre_request_id(request_id)
-                confirm_url = svar.get("confirmUrl", "")
-                godkjenn_url_container.clear()
-                with godkjenn_url_container:
-                    ui.link("Godkjenn i Altinn →", confirm_url, new_tab=True).classes("text-blue-600 font-medium text-sm")
-                n.message = f"Forespørsel opprettet (status: {svar['status']})"
-                n.spinner = False
-                n.type = "positive"
-                n.timeout = 5
-            except Exception as e:
-                n.message = f"Feil: {e}"
-                n.spinner = False
-                n.type = "negative"
-                n.timeout = 0
-                n.close_button = "Lukk"
+                async def registrer_handler(env=env_var):
+                    n = ui.notification(
+                        f"Registrerer system i {('testmiljø' if env == 'test' else 'produksjon')}...",
+                        spinner=True, timeout=None,
+                    )
+                    try:
+                        token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
+                        orgnr = os.getenv("ORG_NUMMER")
+                        client_id = _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
+                        svar = await run.io_bound(
+                            lambda: _med_env(
+                                env, systembruker.registrer_system, token, orgnr, client_id,
+                            )
+                        )
+                        n.message = "System oppdatert." if svar.get("oppdatert") else "System registrert."
+                        n.spinner = False
+                        n.type = "positive"
+                        n.timeout = 5
+                    except Exception as e:
+                        n.message = f"Feil: {e}"
+                        n.spinner = False
+                        n.type = "negative"
+                        n.timeout = 0
+                        n.close_button = "Lukk"
 
-        ui.button("Opprett systembrukerforespørsel", on_click=opprett_forespørsel).props("color=primary outline")
+                async def opprett_handler(env=env_var):
+                    n = ui.notification(
+                        f"Oppretter systembruker-forespørsel i {('testmiljø' if env == 'test' else 'produksjon')}...",
+                        spinner=True, timeout=None,
+                    )
+                    try:
+                        token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
+                        vendor_orgnr = os.getenv("ORG_NUMMER")
+                        party_orgnr = (
+                            os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr)
+                            if env == "test" else vendor_orgnr
+                        )
+                        svar = await run.io_bound(
+                            lambda: _med_env(
+                                env, systembruker.opprett_forespørsel,
+                                token, vendor_orgnr, party_orgnr,
+                            )
+                        )
+                        request_id = svar.get("id", "")
+                        if request_id:
+                            _lagre_request_id(request_id, env)
+                        confirm_url = svar.get("confirmUrl", "")
+                        godkjenn_url_kontainer[env].clear()
+                        with godkjenn_url_kontainer[env]:
+                            ui.link("Godkjenn i Altinn →", confirm_url, new_tab=True).classes(
+                                "text-blue-600 font-medium text-sm"
+                            )
+                        n.message = f"Forespørsel opprettet (status: {svar.get('status', '')})"
+                        n.spinner = False
+                        n.type = "positive"
+                        n.timeout = 5
+                    except Exception as e:
+                        n.message = f"Feil: {e}"
+                        n.spinner = False
+                        n.type = "negative"
+                        n.timeout = 0
+                        n.close_button = "Lukk"
 
-        seksjonstittel("Sjekk godkjenningsstatus")
+                async def oppdater_handler(env=env_var):
+                    n = ui.notification(
+                        f"Henter systembrukere i {('testmiljø' if env == 'test' else 'produksjon')}...",
+                        spinner=True, timeout=None,
+                    )
+                    try:
+                        token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
+                        vendor_orgnr = os.getenv("ORG_NUMMER")
+                        party_orgnr = (
+                            os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr)
+                            if env == "test" else vendor_orgnr
+                        )
+                        brukere = await run.io_bound(
+                            lambda: _med_env(
+                                env, systembruker.hent_systembrukere, token, vendor_orgnr,
+                            )
+                        )
+                        if not brukere:
+                            n.message = "Ingen aktive systembrukere funnet. Opprett ny forespørsel først."
+                            n.spinner = False
+                            n.type = "info"
+                            n.timeout = 6
+                            return
+                        treff = next(
+                            (b for b in brukere if b.get("reporteeOrgNo") == party_orgnr),
+                            brukere[0],
+                        )
+                        bruker_id = treff["id"]
+                        svar = await run.io_bound(
+                            lambda: _med_env(
+                                env, systembruker.opprett_endringsforespørsel,
+                                token, bruker_id, [systembruker._SKATTEMELDING_RETT],
+                            )
+                        )
+                        confirm_url = svar.get("confirmUrl") or svar.get("ConfirmUrl", "")
+                        godkjenn_url_kontainer[env].clear()
+                        with godkjenn_url_kontainer[env]:
+                            ui.link("Godkjenn endring i Altinn →", confirm_url, new_tab=True).classes(
+                                "text-blue-600 font-medium text-sm"
+                            )
+                        n.message = f"Endringsforespørsel opprettet (status: {svar.get('status', '')})"
+                        n.spinner = False
+                        n.type = "positive"
+                        n.timeout = 5
+                    except Exception as e:
+                        n.message = f"Feil: {e}"
+                        n.spinner = False
+                        n.type = "negative"
+                        n.timeout = 0
+                        n.close_button = "Lukk"
 
-        async def sjekk_status():
-            request_id = _les_request_id()
-            if not request_id:
-                ui.notify("Ingen lagret forespørsels-ID. Opprett en forespørsel først.", type="warning")
-                return
-            n = ui.notification("Henter status...", spinner=True, timeout=None)
-            try:
-                token = await run.io_bound(auth.login_admin)
-                svar = await run.io_bound(systembruker.hent_forespørsel_status, token, request_id)
-                status = svar.get("status", "ukjent")
-                n.spinner = False
-                n.timeout = 6
-                if status == "Accepted":
-                    n.message = "Systembruker er godkjent. Du kan nå sende inn dokumenter."
-                    n.type = "positive"
-                elif status == "New":
-                    n.message = "Forespørselen venter på godkjenning."
-                    n.type = "info"
-                elif status == "Rejected":
-                    n.message = "Forespørselen ble avvist. Opprett en ny forespørsel."
-                    n.type = "negative"
-                    n.timeout = 0
-                    n.close_button = "Lukk"
-                else:
-                    n.message = f"Status: {status}"
-                    n.type = "info"
-            except Exception as e:
-                n.message = f"Feil: {e}"
-                n.spinner = False
-                n.type = "negative"
-                n.timeout = 0
-                n.close_button = "Lukk"
-
-        ui.button("Sjekk status", on_click=sjekk_status).props("color=primary outline")
+                with ui.column().classes("w-full gap-1 mt-2"):
+                    ui.button("Sjekk status", on_click=sjekk_status_handler).props(
+                        "color=primary size=sm"
+                    ).classes("w-full")
+                    ui.button("Registrer system", on_click=registrer_handler).props(
+                        "outline color=primary size=sm"
+                    ).classes("w-full")
+                    ui.button("Opprett systembruker", on_click=opprett_handler).props(
+                        "outline color=primary size=sm"
+                    ).classes("w-full")
+                    with ui.expansion("Avansert").classes("w-full text-xs"):
+                        ui.button(
+                            "Oppdater rettigheter", on_click=oppdater_handler,
+                        ).props("outline color=primary size=sm").classes("w-full")
+                        ui.label(
+                            "Send endringsforespørsel hvis du har lagt til nye scopes "
+                            "på en allerede godkjent systembruker."
+                        ).classes("text-xs text-slate-500 mt-1")
 
 
 # ---------------------------------------------------------------------------

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -630,22 +630,31 @@ def _les_konfig_for_milj(navn: str, env: str, default: str = "") -> str:
 def _sjekk_konfig() -> list[tuple[bool, str, str]]:
     resultater = []
 
-    # Credentials per miljø — viser status for begge slik at brukeren ser hva
-    # som er på plass uten å måtte tenke på «aktivt miljø».
-    for env, miljo_navn in [("test", "Testmiljø"), ("prod", "Produksjon")]:
+    # Per miljø: credentials + orgnr. Viser status for begge slik at brukeren
+    # ser hva som er på plass uten å måtte tenke på «aktivt miljø».
+    for env, miljo_navn, orgnr_var in [
+        ("test", "Testmiljø", "SKD_TEST_ORG_NUMMER"),
+        ("prod", "Produksjon", "ORG_NUMMER"),
+    ]:
         client_id = _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
         kid = _les_konfig_for_milj("MASKINPORTEN_KID", env)
-        komplett = bool(client_id and kid)
-        if komplett:
-            detalj = "Klient-ID og Nøkkel-ID satt"
-        elif client_id or kid:
-            detalj = "Delvis konfigurert (mangler Klient-ID eller Nøkkel-ID)"
-        else:
+        orgnr = os.getenv(orgnr_var, "")
+        mangler = [
+            navn for navn, verdi in
+            [("Klient-ID", client_id), ("Nøkkel-ID", kid), ("Orgnr", orgnr)]
+            if not verdi
+        ]
+        if not mangler:
+            detalj = "Klient-ID, Nøkkel-ID og Orgnr er satt"
+            ok = True
+        elif len(mangler) == 3:
             detalj = "Ikke konfigurert"
-        resultater.append((komplett, f"{miljo_navn}-credentials", detalj))
+            ok = False
+        else:
+            detalj = f"Mangler: {', '.join(mangler)}"
+            ok = False
+        resultater.append((ok, f"{miljo_navn}", detalj))
 
-    orgnr = os.getenv("ORG_NUMMER")
-    resultater.append((bool(orgnr), "ORG_NUMMER", "Satt" if orgnr else "Mangler. Legg til i .env-filen"))
     nokkel_sti = os.getenv("MASKINPORTEN_PRIVAT_NOKKEL", "maskinporten_privat.pem")
     nokkel_ok = Path(nokkel_sti).exists()
     resultater.append((nokkel_ok, "Privat nøkkel", f"Funnet: {nokkel_sti}" if nokkel_ok else f"Finner ikke: {nokkel_sti}"))
@@ -1184,6 +1193,24 @@ def _bygg_oppsett_fane() -> None:
                     value=_les_konfig_for_milj("MASKINPORTEN_KID", env_var),
                     placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
                 ).classes("w-full")
+                if env_var == "test":
+                    card_inputs["orgnr"] = ui.input(
+                        "Organisasjonsnummer (test)",
+                        value=os.getenv("SKD_TEST_ORG_NUMMER", ""),
+                        placeholder="syntetisk org fra Tenor",
+                    ).classes("w-full").tooltip(
+                        "Altinns testmiljø kjenner kun syntetiske orgnr fra "
+                        "Tenor (skatteetaten.no/testdata). Bruk et test-AS "
+                        "her, ikke ditt eget org.nr."
+                    )
+                else:
+                    card_inputs["orgnr"] = ui.input(
+                        "Organisasjonsnummer (prod)",
+                        value=os.getenv("ORG_NUMMER", ""),
+                        placeholder="123456789",
+                    ).classes("w-full").tooltip(
+                        "Ditt eget organisasjonsnummer (9 siffer)."
+                    )
 
                 # --- Systembruker-seksjon ---
                 ui.separator().classes("my-4")
@@ -1376,22 +1403,19 @@ def _bygg_oppsett_fane() -> None:
 
     # --- Felles for begge miljø ---
     ui.separator().classes("my-4")
-    seksjonstittel("Felles innstillinger")
+    seksjonstittel("Felles for begge miljø")
     ui.label(
-        "Disse gjelder uansett aktivt miljø."
+        "Samme private nøkkel kan brukes i begge miljø — vanligvis genererer "
+        "du ett nøkkelpar og laster opp den offentlige nøkkelen til både "
+        "test- og prod-klienten i Digdir."
     ).classes("text-sm text-slate-500 mb-3")
 
-    with ui.grid(columns=2).classes("w-full gap-4"):
-        inp_orgnr = ui.input(
-            "Organisasjonsnummer",
-            value=os.getenv("ORG_NUMMER", ""),
-            placeholder="123456789",
-        ).classes("w-full").tooltip("Organisasjonsnummeret til selskapet du sender inn på vegne av.")
-
-        pem_opplasting = ui.upload(
-            label="Last opp privat nøkkel (.pem)",
-            auto_upload=True,
-        ).props("flat bordered").classes("w-full").tooltip("Din maskinporten_privat.pem-fil. Lagres lokalt og sendes aldri til noen server.")
+    pem_opplasting = ui.upload(
+        label="Last opp privat nøkkel (.pem)",
+        auto_upload=True,
+    ).props("flat bordered").classes("w-full").tooltip(
+        "Din maskinporten_privat.pem-fil. Lagres lokalt og sendes aldri til noen server."
+    )
 
     pem_bytes_holder: list[bytes] = []
 
@@ -1420,9 +1444,22 @@ def _bygg_oppsett_fane() -> None:
                 set_key(str(dot_env_fil), env_navn, verdi)
                 os.environ[env_navn] = verdi
 
-        if inp_orgnr.value:
-            set_key(str(dot_env_fil), "ORG_NUMMER", inp_orgnr.value)
-            os.environ["ORG_NUMMER"] = inp_orgnr.value
+        # Orgnr per miljø: test-kort → SKD_TEST_ORG_NUMMER (Tenor-syntetisk),
+        # prod-kort → ORG_NUMMER (din egen virksomhet).
+        test_orgnr = test_card_inputs["orgnr"].value or ""
+        set_key(str(dot_env_fil), "SKD_TEST_ORG_NUMMER", test_orgnr)
+        if test_orgnr:
+            os.environ["SKD_TEST_ORG_NUMMER"] = test_orgnr
+        else:
+            os.environ.pop("SKD_TEST_ORG_NUMMER", None)
+
+        prod_orgnr = prod_card_inputs["orgnr"].value or ""
+        set_key(str(dot_env_fil), "ORG_NUMMER", prod_orgnr)
+        if prod_orgnr:
+            os.environ["ORG_NUMMER"] = prod_orgnr
+        else:
+            os.environ.pop("ORG_NUMMER", None)
+
         if pem_bytes_holder:
             nokkel_sti = Path("maskinporten_privat.pem")
             nokkel_sti.write_bytes(pem_bytes_holder[0])

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1009,49 +1009,25 @@ def _bygg_oppsett_fane() -> None:
     knapper_kontainer: dict[str, "ui.column"] = {}
     handlere: dict[str, dict] = {}
     _siste_status: dict[str, str | None] = {}
-    polling_timer: dict[str, "ui.timer"] = {}
-    polling_teller: dict[str, int] = {}
-    _POLLING_INTERVALL_SEK = 8.0
-    _POLLING_MAX_FORSOK = 38  # ~5 min med 8 sek intervall
-
-    def _start_polling(env: str):
-        """Start auto-polling av systembruker-status hvis ikke allerede aktiv."""
-        if polling_timer.get(env) is not None:
-            return  # allerede polling
-        polling_teller[env] = 0
-
-        async def _poll(env=env):
-            polling_teller[env] = polling_teller.get(env, 0) + 1
-            handlers = handlere.get(env, {})
-            sjekk = handlers.get("sjekk_status")
-            if sjekk is not None:
-                await sjekk(silent=True)
-            # _vis_status kalles av sjekk og oppdaterer _siste_status. Hvis status
-            # ikke lenger er "New", eller vi har prøvd for mange ganger, slutt.
-            if (
-                _siste_status.get(env) != "New"
-                or polling_teller[env] >= _POLLING_MAX_FORSOK
-            ):
-                _stopp_polling(env)
-
-        polling_timer[env] = ui.timer(_POLLING_INTERVALL_SEK, _poll, active=True)
-
-    def _stopp_polling(env: str):
-        t = polling_timer.pop(env, None)
-        if t is not None:
-            try:
-                t.deactivate()
-            except Exception:
-                pass
 
     def _vis_godkjenn_lenke(env: str, url: str, etikett: str = "Godkjenn i Altinn →"):
         godkjenn_url_kontainer[env].clear()
         if not url:
             return
         with godkjenn_url_kontainer[env]:
-            ui.link(etikett, url, new_tab=True).classes(
-                "text-blue-600 font-medium text-sm"
-            )
+            with ui.row().classes("items-center gap-3 flex-wrap"):
+                ui.link(etikett, url, new_tab=True).classes(
+                    "text-blue-600 font-medium text-sm"
+                )
+                # Tilbyr brukeren en rask «jeg har godkjent»-handling så de
+                # ikke trenger å åpne Avansert for å oppdatere status.
+                handlers = handlere.get(env, {})
+                sjekk = handlers.get("sjekk_status")
+                if sjekk is not None:
+                    ui.button(
+                        "Jeg har godkjent — sjekk status",
+                        on_click=sjekk,
+                    ).props("outline color=primary size=sm")
 
     def _render_handlinger(env: str):
         """Render knappene for et miljø basert på siste kjente status.
@@ -1190,16 +1166,8 @@ def _bygg_oppsett_fane() -> None:
                         ui.label(forklaring).classes("text-xs text-slate-500 mt-0.5")
 
         # Husker hvilken status vi er i, og rerender knappene kontekstuelt.
-        effektiv_status = "ikke_opprettet" if status == "ikke_opprettet" else status
-        _siste_status[env] = effektiv_status
+        _siste_status[env] = "ikke_opprettet" if status == "ikke_opprettet" else status
         _render_handlinger(env)
-
-        # Auto-poll mens vi venter på godkjenning, slik at UI-et fanger opp
-        # godkjenningen så snart den skjer i Altinn. Stopp i alle andre states.
-        if effektiv_status == "New":
-            _start_polling(env)
-        else:
-            _stopp_polling(env)
 
     with ui.grid(columns=2).classes("w-full gap-4"):
         for env_var, miljo_navn, ikon_navn, ikon_farge, card_inputs in [

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -2015,11 +2015,11 @@ def _bygg_aksjonaer_fane() -> None:
                 value=(i == 0),
             ).classes("w-full mb-2"):
                 with ui.grid(columns=2).classes("w-full gap-4"):
-                    # NB: ingen refresh-callback på navn-feltet — det ville
-                    # rebygd hele lista på hvert tastetrykk og ødelagt fokus.
-                    # Header-teksten oppdateres ved neste refresh (f.eks. når
-                    # man legger til/fjerner en aksjonær eller lagrer).
-                    txt("Navn", "navn", obj=a)
+                    # Refresh kun på blur (når feltet mister fokus), ikke på
+                    # hver tastetrykk. Det gir oss synkronisert header uten å
+                    # ødelegge fokus mens brukeren skriver.
+                    navn_inp = txt("Navn", "navn", obj=a)
+                    navn_inp.on("blur", lambda _: aksjonaer_liste.refresh())
                     num("Antall aksjer", "antall_aksjer", obj=a, step=1, min_val=1)
                     txt("Fødselsnummer (11 siffer)", "fodselsnummer", obj=a)
                     num("Utbytte utbetalt (NOK)", "utbytte_utbetalt", obj=a, min_val=0)

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -54,7 +54,6 @@ from wenche.naeringsspesifikasjon_xml import generer_naeringsspesifikasjon
 
 CONFIG_FIL = Path("config.yaml")
 _WENCHE_DIR = Path.home() / ".wenche"
-_REQUEST_ID_FIL = _WENCHE_DIR / "systembruker_request_id.txt"  # legacy (alle miljø)
 
 
 def _med_env(env: str, fn, *args, **kwargs):
@@ -666,23 +665,15 @@ def _lagre_request_id(request_id: str, env: str | None = None) -> None:
     if env is None:
         env = os.getenv("WENCHE_ENV", "prod")
     _request_id_fil_for_milj(env).write_text(request_id, encoding="utf-8")
-    # Behold også i legacy-fil for bakoverkompatibilitet
-    _REQUEST_ID_FIL.write_text(request_id, encoding="utf-8")
 
 
 def _les_request_id(env: str | None = None) -> str:
+    """Les request_id for et bestemt miljø. Ingen fallback til andre miljø."""
     if env is None:
         env = os.getenv("WENCHE_ENV", "prod")
     milj_fil = _request_id_fil_for_milj(env)
     if milj_fil.exists():
         return milj_fil.read_text(encoding="utf-8").strip()
-    # Legacy-fallback brukes kun hvis INGEN env-spesifikke filer finnes —
-    # ellers ville et test-spesifikt request_id smitte over til prod-kortet
-    # (eller motsatt) som om det var en gyldig forespørsel.
-    test_fil = _request_id_fil_for_milj("test")
-    prod_fil = _request_id_fil_for_milj("prod")
-    if not test_fil.exists() and not prod_fil.exists() and _REQUEST_ID_FIL.exists():
-        return _REQUEST_ID_FIL.read_text(encoding="utf-8").strip()
     return ""
 
 

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -2015,7 +2015,11 @@ def _bygg_aksjonaer_fane() -> None:
                 value=(i == 0),
             ).classes("w-full mb-2"):
                 with ui.grid(columns=2).classes("w-full gap-4"):
-                    txt("Navn", "navn", obj=a, on_change=aksjonaer_liste.refresh)
+                    # NB: ingen refresh-callback på navn-feltet — det ville
+                    # rebygd hele lista på hvert tastetrykk og ødelagt fokus.
+                    # Header-teksten oppdateres ved neste refresh (f.eks. når
+                    # man legger til/fjerner en aksjonær eller lagrer).
+                    txt("Navn", "navn", obj=a)
                     num("Antall aksjer", "antall_aksjer", obj=a, step=1, min_val=1)
                     txt("Fødselsnummer (11 siffer)", "fodselsnummer", obj=a)
                     num("Utbytte utbetalt (NOK)", "utbytte_utbetalt", obj=a, min_val=0)

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1076,31 +1076,66 @@ def _bygg_oppsett_fane() -> None:
     ui.separator().classes("my-4")
     seksjonstittel("Tilkoblingstest")
     ui.label(
-        "Henter et midlertidig token fra Maskinporten og veksler det mot et Altinn-token. Ingen data sendes inn."
+        "Tester Maskinporten og Altinn-veksling for hvert miljø som har credentials konfigurert. "
+        "Ingen data sendes inn og tokens lagres ikke."
     ).classes("text-sm text-slate-500 mb-2")
 
-    async def test_tilkobling():
-        alle_ok = all(ok for ok, _, _ in _sjekk_konfig())
-        if not alle_ok:
-            ui.notify("Fiks konfigurasjonsfeilene og lagre før du tester tilkoblingen.", type="warning")
-            return
-        n = ui.notification("Kobler til Maskinporten og Altinn...", spinner=True, timeout=None)
+    test_resultat_container = ui.column().classes("w-full gap-1 mt-3")
+
+    def _milj_har_credentials(env: str) -> bool:
+        return bool(
+            _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
+            and _les_konfig_for_milj("MASKINPORTEN_KID", env)
+        )
+
+    def _test_for_milj(env: str) -> tuple[bool, str]:
+        """Test tilkobling for ett spesifikt miljø. Returnerer (ok, melding)."""
+        opprinnelig_env = os.environ.get("WENCHE_ENV")
+        os.environ["WENCHE_ENV"] = env
         try:
-            await run.io_bound(auth.login)
-            n.message = "Tilkobling OK. Maskinporten og Altinn svarte som forventet."
-            n.spinner = False
-            n.type = "positive"
-            n.timeout = 6
+            auth.login(lagre_token=False)
+            return True, "Tilkobling OK"
         except RuntimeError as e:
-            n.message = str(e)
-            n.spinner = False
-            n.type = "negative"
-            n.timeout = 0
+            return False, str(e).split("\n")[0]  # første linje for visning
         except Exception as e:
-            n.message = f"Uventet feil: {e}"
-            n.spinner = False
-            n.type = "negative"
-            n.timeout = 0
+            return False, f"Uventet feil: {type(e).__name__}: {e}"
+        finally:
+            if opprinnelig_env is None:
+                os.environ.pop("WENCHE_ENV", None)
+            else:
+                os.environ["WENCHE_ENV"] = opprinnelig_env
+
+    async def test_tilkobling():
+        test_resultat_container.clear()
+        n = ui.notification("Tester tilkobling for begge miljø...", spinner=True, timeout=None)
+
+        resultater = []
+        for env in ["test", "prod"]:
+            if not _milj_har_credentials(env):
+                resultater.append((env, None, "Ingen credentials konfigurert"))
+                continue
+            ok, melding = await run.io_bound(_test_for_milj, env)
+            resultater.append((env, ok, melding))
+
+        n.dismiss()
+
+        with test_resultat_container:
+            for env, ok, melding in resultater:
+                miljo_navn = "Testmiljø (tt02)" if env == "test" else "Produksjon"
+                if ok is None:
+                    ikon, farge = "remove_circle_outline", "text-slate-400"
+                    statustekst = melding
+                elif ok:
+                    ikon, farge = "check_circle", "text-green-600"
+                    statustekst = melding
+                else:
+                    ikon, farge = "error", "text-red-600"
+                    statustekst = melding
+                with ui.row().classes("items-start gap-2"):
+                    ui.icon(ikon).classes(f"{farge} text-base mt-0.5")
+                    with ui.column().classes("gap-0"):
+                        ui.label(miljo_navn).classes("text-sm font-medium text-slate-800")
+                        ui.label(statustekst).classes(f"text-xs {farge}")
 
     ui.button("Test tilkobling mot Altinn", on_click=test_tilkobling).props("color=primary outline")
 

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -921,36 +921,74 @@ def _bygg_oppsett_fane() -> None:
         "Fyll inn Maskinporten-konfigurasjonen og test tilkoblingen mot Altinn."
     ).classes("text-slate-500 text-sm mb-4")
 
-    # --- Konfig-skjema ---
-    seksjonstittel("Konfigurasjon")
+    # --- Aktivt miljø ---
+    seksjonstittel("Aktivt miljø")
     ui.label(
-        "Klient-ID og Nøkkel-ID finner du i Digdirs selvbetjeningsportal under din Maskinporten-klient."
+        "Avgjør hvilket sett credentials Wenche bruker. Du kan konfigurere "
+        "begge miljø samtidig under, og bytte aktivt miljø her uten å redigere noe annet."
     ).classes("text-sm text-slate-500 mb-3")
 
     dot_env_fil = Path(".env")
     aktivt_env = os.getenv("WENCHE_ENV", "prod")
 
+    inp_env = ui.radio(
+        {"prod": "Produksjon", "test": "Testmiljø (tt02)"},
+        value=aktivt_env,
+    ).props("inline color=primary")
+
+    # --- Credentials per miljø ---
+    ui.separator().classes("my-4")
+    seksjonstittel("Maskinporten-credentials")
+    ui.label(
+        "Klient-ID og Nøkkel-ID finner du i Digdirs selvbetjeningsportal. "
+        "Test- og prod-Maskinporten er separate registre — fyll inn credentials "
+        "for hvert miljø du har registrert klient i."
+    ).classes("text-sm text-slate-500 mb-3")
+
+    test_card_inputs: dict[str, ui.input] = {}
+    prod_card_inputs: dict[str, ui.input] = {}
+
     with ui.grid(columns=2).classes("w-full gap-4"):
-        inp_client_id = ui.input(
-            "Klient-ID",
-            value=_les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", aktivt_env),
-            placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-        ).classes("w-full").tooltip("UUID-en til Maskinporten-klienten din i valgt miljø. Test og prod har separate UUID-er.")
+        # Test-card
+        with ui.card().classes("w-full p-4 border border-slate-200 shadow-none rounded-xl"):
+            with ui.row().classes("items-center gap-2 mb-2"):
+                ui.icon("science").classes("text-slate-500")
+                ui.label("Testmiljø (tt02)").classes("font-semibold text-slate-800")
+            test_card_inputs["client_id"] = ui.input(
+                "Klient-ID (test)",
+                value=_les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", "test"),
+                placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            ).classes("w-full")
+            test_card_inputs["kid"] = ui.input(
+                "Nøkkel-ID (test)",
+                value=_les_konfig_for_milj("MASKINPORTEN_KID", "test"),
+                placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            ).classes("w-full")
 
-        inp_env = ui.select(
-            {"prod": "Produksjon", "test": "Testmiljø (tt02)"},
-            label="Miljø",
-            value=aktivt_env,
-        ).classes("w-full")
+        # Prod-card
+        with ui.card().classes("w-full p-4 border border-slate-200 shadow-none rounded-xl"):
+            with ui.row().classes("items-center gap-2 mb-2"):
+                ui.icon("business").classes("text-slate-700")
+                ui.label("Produksjon").classes("font-semibold text-slate-800")
+            prod_card_inputs["client_id"] = ui.input(
+                "Klient-ID (prod)",
+                value=_les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", "prod"),
+                placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            ).classes("w-full")
+            prod_card_inputs["kid"] = ui.input(
+                "Nøkkel-ID (prod)",
+                value=_les_konfig_for_milj("MASKINPORTEN_KID", "prod"),
+                placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+            ).classes("w-full")
 
-        inp_kid = ui.input(
-            "Nøkkel-ID",
-            value=_les_konfig_for_milj("MASKINPORTEN_KID", aktivt_env),
-            placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-        ).classes("w-full").tooltip("UUID-en portalen tildelte nøkkelen din i valgt miljø.")
+    # --- Felles for begge miljø ---
+    ui.separator().classes("my-4")
+    seksjonstittel("Felles innstillinger")
+    ui.label(
+        "Disse gjelder uansett aktivt miljø."
+    ).classes("text-sm text-slate-500 mb-3")
 
-        ui.label("").classes("w-full")  # placeholder for grid-justering
-
+    with ui.grid(columns=2).classes("w-full gap-4"):
         inp_orgnr = ui.input(
             "Organisasjonsnummer",
             value=os.getenv("ORG_NUMMER", ""),
@@ -961,16 +999,6 @@ def _bygg_oppsett_fane() -> None:
             label="Last opp privat nøkkel (.pem)",
             auto_upload=True,
         ).props("flat bordered").classes("w-full").tooltip("Din maskinporten_privat.pem-fil. Lagres lokalt og sendes aldri til noen server.")
-
-    # Når brukeren bytter miljø skal Klient-ID og Nøkkel-ID-feltene reflektere
-    # det andre miljøets verdier, slik at brukeren kan ha to klienter i .env
-    # samtidig og veksle mellom dem uten manuell redigering.
-    def _last_inn_credentials_for_milj():
-        env = inp_env.value
-        inp_client_id.value = _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
-        inp_kid.value = _les_konfig_for_milj("MASKINPORTEN_KID", env)
-
-    inp_env.on_value_change(lambda _: _last_inn_credentials_for_milj())
 
     pem_bytes_holder: list[bytes] = []
 
@@ -985,18 +1013,19 @@ def _bygg_oppsett_fane() -> None:
         from dotenv import set_key
         dot_env_fil.touch(exist_ok=True)
         valgt_env = inp_env.value
-        suffix = valgt_env.upper()
 
-        # Klient-ID og nøkkel-ID lagres miljø-spesifikt slik at test og prod
-        # kan ha separate verdier i samme .env-fil.
-        if inp_client_id.value:
-            navn = f"MASKINPORTEN_CLIENT_ID_{suffix}"
-            set_key(str(dot_env_fil), navn, inp_client_id.value)
-            os.environ[navn] = inp_client_id.value
-        if inp_kid.value:
-            navn = f"MASKINPORTEN_KID_{suffix}"
-            set_key(str(dot_env_fil), navn, inp_kid.value)
-            os.environ[navn] = inp_kid.value
+        # Lagre credentials per miljø — begge sett skrives uavhengig av aktivt miljø.
+        for kort_env, inputs in [("test", test_card_inputs), ("prod", prod_card_inputs)]:
+            suffix = kort_env.upper()
+            if inputs["client_id"].value:
+                navn = f"MASKINPORTEN_CLIENT_ID_{suffix}"
+                set_key(str(dot_env_fil), navn, inputs["client_id"].value)
+                os.environ[navn] = inputs["client_id"].value
+            if inputs["kid"].value:
+                navn = f"MASKINPORTEN_KID_{suffix}"
+                set_key(str(dot_env_fil), navn, inputs["kid"].value)
+                os.environ[navn] = inputs["kid"].value
+
         if inp_orgnr.value:
             set_key(str(dot_env_fil), "ORG_NUMMER", inp_orgnr.value)
             os.environ["ORG_NUMMER"] = inp_orgnr.value
@@ -1009,7 +1038,8 @@ def _bygg_oppsett_fane() -> None:
             set_key(str(dot_env_fil), "MASKINPORTEN_PRIVAT_NOKKEL", str(nokkel_sti))
             os.environ["MASKINPORTEN_PRIVAT_NOKKEL"] = str(nokkel_sti)
         konfig_status.refresh()
-        ui.notify(f"Konfigurasjon lagret for {('testmiljø' if valgt_env == 'test' else 'produksjon')}.", type="positive")
+        miljo_navn = "testmiljø" if valgt_env == "test" else "produksjon"
+        ui.notify(f"Konfigurasjon lagret. Aktivt miljø: {miljo_navn}.", type="positive")
 
     ui.button("Lagre konfigurasjon", on_click=lagre_konfig).props("color=primary").classes("mt-2")
 

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -582,19 +582,39 @@ def kr(v: float) -> str:
     return f"{v:,.0f}".replace(",", "\u00a0") + " kr"
 
 
+def _les_konfig_for_milj(navn: str, env: str, default: str = "") -> str:
+    """
+    Les credential-verdi for gitt miljø.
+
+    Prøver først miljø-spesifikk variant ({navn}_{TEST|PROD}), faller tilbake
+    til generisk variabelnavn for brukere som kun har ett sett credentials.
+    """
+    return os.getenv(f"{navn}_{env.upper()}") or os.getenv(navn) or default
+
+
 def _sjekk_konfig() -> list[tuple[bool, str, str]]:
     resultater = []
-    client_id = os.getenv("MASKINPORTEN_CLIENT_ID")
-    resultater.append((bool(client_id), "MASKINPORTEN_CLIENT_ID", "Satt" if client_id else "Mangler. Legg til i .env-filen"))
-    kid = os.getenv("MASKINPORTEN_KID")
-    resultater.append((bool(kid), "MASKINPORTEN_KID", "Satt" if kid else "Mangler. Legg til i .env-filen"))
+    env = os.getenv("WENCHE_ENV", "prod")
+    suffix = env.upper()
+
+    client_id = _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
+    resultater.append((
+        bool(client_id),
+        f"MASKINPORTEN_CLIENT_ID for {suffix}",
+        "Satt" if client_id else f"Mangler. Sett MASKINPORTEN_CLIENT_ID_{suffix} (eller MASKINPORTEN_CLIENT_ID som fallback) i .env",
+    ))
+    kid = _les_konfig_for_milj("MASKINPORTEN_KID", env)
+    resultater.append((
+        bool(kid),
+        f"MASKINPORTEN_KID for {suffix}",
+        "Satt" if kid else f"Mangler. Sett MASKINPORTEN_KID_{suffix} (eller MASKINPORTEN_KID som fallback) i .env",
+    ))
     orgnr = os.getenv("ORG_NUMMER")
     resultater.append((bool(orgnr), "ORG_NUMMER", "Satt" if orgnr else "Mangler. Legg til i .env-filen"))
-    nokkel_sti = os.getenv("MASKINPORTEN_PRIVAT_NOKKEL", "maskinporten_privat.pem")
+    nokkel_sti = _les_konfig_for_milj("MASKINPORTEN_PRIVAT_NOKKEL", env, "maskinporten_privat.pem")
     nokkel_ok = Path(nokkel_sti).exists()
     resultater.append((nokkel_ok, "Privat nøkkel", f"Funnet: {nokkel_sti}" if nokkel_ok else f"Finner ikke: {nokkel_sti}"))
-    env = os.getenv("WENCHE_ENV", "prod")
-    resultater.append((True, "Miljø", f"{'Testmiljø (tt02)' if env == 'test' else 'Produksjon'}, endre med WENCHE_ENV=test i .env"))
+    resultater.append((True, "Miljø", f"{'Testmiljø (tt02)' if env == 'test' else 'Produksjon'}, bytt i Oppsett-fanen"))
     return resultater
 
 
@@ -908,25 +928,26 @@ def _bygg_oppsett_fane() -> None:
     ).classes("text-sm text-slate-500 mb-3")
 
     dot_env_fil = Path(".env")
+    aktivt_env = os.getenv("WENCHE_ENV", "prod")
 
     with ui.grid(columns=2).classes("w-full gap-4"):
         inp_client_id = ui.input(
             "Klient-ID",
-            value=os.getenv("MASKINPORTEN_CLIENT_ID", ""),
+            value=_les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", aktivt_env),
             placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-        ).classes("w-full").tooltip("UUID-en til Maskinporten-klienten din fra Digdirs selvbetjeningsportal.")
+        ).classes("w-full").tooltip("UUID-en til Maskinporten-klienten din i valgt miljø. Test og prod har separate UUID-er.")
 
         inp_env = ui.select(
             {"prod": "Produksjon", "test": "Testmiljø (tt02)"},
             label="Miljø",
-            value=os.getenv("WENCHE_ENV", "prod"),
+            value=aktivt_env,
         ).classes("w-full")
 
         inp_kid = ui.input(
             "Nøkkel-ID",
-            value=os.getenv("MASKINPORTEN_KID", ""),
+            value=_les_konfig_for_milj("MASKINPORTEN_KID", aktivt_env),
             placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-        ).classes("w-full").tooltip("UUID-en portalen tildelte nøkkelen din, synlig i nøkkellisten under klienten.")
+        ).classes("w-full").tooltip("UUID-en portalen tildelte nøkkelen din i valgt miljø.")
 
         ui.label("").classes("w-full")  # placeholder for grid-justering
 
@@ -941,6 +962,16 @@ def _bygg_oppsett_fane() -> None:
             auto_upload=True,
         ).props("flat bordered").classes("w-full").tooltip("Din maskinporten_privat.pem-fil. Lagres lokalt og sendes aldri til noen server.")
 
+    # Når brukeren bytter miljø skal Klient-ID og Nøkkel-ID-feltene reflektere
+    # det andre miljøets verdier, slik at brukeren kan ha to klienter i .env
+    # samtidig og veksle mellom dem uten manuell redigering.
+    def _last_inn_credentials_for_milj():
+        env = inp_env.value
+        inp_client_id.value = _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
+        inp_kid.value = _les_konfig_for_milj("MASKINPORTEN_KID", env)
+
+    inp_env.on_value_change(lambda _: _last_inn_credentials_for_milj())
+
     pem_bytes_holder: list[bytes] = []
 
     def pem_mottatt(e):
@@ -953,17 +984,24 @@ def _bygg_oppsett_fane() -> None:
     async def lagre_konfig():
         from dotenv import set_key
         dot_env_fil.touch(exist_ok=True)
+        valgt_env = inp_env.value
+        suffix = valgt_env.upper()
+
+        # Klient-ID og nøkkel-ID lagres miljø-spesifikt slik at test og prod
+        # kan ha separate verdier i samme .env-fil.
         if inp_client_id.value:
-            set_key(str(dot_env_fil), "MASKINPORTEN_CLIENT_ID", inp_client_id.value)
-            os.environ["MASKINPORTEN_CLIENT_ID"] = inp_client_id.value
+            navn = f"MASKINPORTEN_CLIENT_ID_{suffix}"
+            set_key(str(dot_env_fil), navn, inp_client_id.value)
+            os.environ[navn] = inp_client_id.value
         if inp_kid.value:
-            set_key(str(dot_env_fil), "MASKINPORTEN_KID", inp_kid.value)
-            os.environ["MASKINPORTEN_KID"] = inp_kid.value
+            navn = f"MASKINPORTEN_KID_{suffix}"
+            set_key(str(dot_env_fil), navn, inp_kid.value)
+            os.environ[navn] = inp_kid.value
         if inp_orgnr.value:
             set_key(str(dot_env_fil), "ORG_NUMMER", inp_orgnr.value)
             os.environ["ORG_NUMMER"] = inp_orgnr.value
-        set_key(str(dot_env_fil), "WENCHE_ENV", inp_env.value)
-        os.environ["WENCHE_ENV"] = inp_env.value
+        set_key(str(dot_env_fil), "WENCHE_ENV", valgt_env)
+        os.environ["WENCHE_ENV"] = valgt_env
         if pem_bytes_holder:
             nokkel_sti = Path("maskinporten_privat.pem")
             nokkel_sti.write_bytes(pem_bytes_holder[0])
@@ -971,7 +1009,7 @@ def _bygg_oppsett_fane() -> None:
             set_key(str(dot_env_fil), "MASKINPORTEN_PRIVAT_NOKKEL", str(nokkel_sti))
             os.environ["MASKINPORTEN_PRIVAT_NOKKEL"] = str(nokkel_sti)
         konfig_status.refresh()
-        ui.notify("Konfigurasjon lagret.", type="positive")
+        ui.notify(f"Konfigurasjon lagret for {('testmiljø' if valgt_env == 'test' else 'produksjon')}.", type="positive")
 
     ui.button("Lagre konfigurasjon", on_click=lagre_konfig).props("color=primary").classes("mt-2")
 

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1398,17 +1398,30 @@ def _bygg_oppsett_fane() -> None:
                 _vis_status(env_var, None)
 
                 # Auto-sjekk status ved sidelasting hvis vi har credentials og
-                # en eksisterende forespørsel. Stille modus betyr at evt. feil
-                # kun synes i status-raden, ikke som popup-notifikasjoner.
+                # en eksisterende forespørsel. Vi gjør to forsøk med god buffer
+                # mellom for å unngå transient race conditions ved oppstart
+                # (NiceGUI/event-loop trenger noen sekunder før alt fungerer
+                # pålitelig). Begge er stille — ingen popup ved feil. Statusen
+                # forblir på initial-tilstanden hvis begge feiler, og brukeren
+                # kan alltid klikke manuelt.
                 if (
                     _milj_har_credentials(env_var)
                     and _les_request_id(env_var)
                 ):
-                    ui.timer(
-                        1.0,
-                        lambda env=env_var: sjekk_status_handler(env=env, silent=True),
-                        once=True,
-                    )
+                    async def _auto_sjekk_med_retry(env=env_var):
+                        if _siste_status.get(env) in ("New", None):
+                            await sjekk_status_handler(env=env, silent=True)
+                            # Hvis fortsatt i venter-tilstand, prøv én gang til
+                            # om 5 sek. Da gir vi event-loopen god tid og
+                            # spammer ikke Altinn med flere kall.
+                            if _siste_status.get(env) in ("New", None):
+                                ui.timer(
+                                    5.0,
+                                    lambda e=env: sjekk_status_handler(env=e, silent=True),
+                                    once=True,
+                                )
+
+                    ui.timer(3.0, _auto_sjekk_med_retry, once=True)
 
     # --- Felles for begge miljø ---
     ui.separator().classes("my-4")

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -667,7 +667,12 @@ def _les_request_id(env: str | None = None) -> str:
     milj_fil = _request_id_fil_for_milj(env)
     if milj_fil.exists():
         return milj_fil.read_text(encoding="utf-8").strip()
-    if _REQUEST_ID_FIL.exists():
+    # Legacy-fallback brukes kun hvis INGEN env-spesifikke filer finnes —
+    # ellers ville et test-spesifikt request_id smitte over til prod-kortet
+    # (eller motsatt) som om det var en gyldig forespørsel.
+    test_fil = _request_id_fil_for_milj("test")
+    prod_fil = _request_id_fil_for_milj("prod")
+    if not test_fil.exists() and not prod_fil.exists() and _REQUEST_ID_FIL.exists():
         return _REQUEST_ID_FIL.read_text(encoding="utf-8").strip()
     return ""
 

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -62,6 +62,11 @@ def _request_id_fil_for_milj(env: str) -> Path:
     return _WENCHE_DIR / f"systembruker_request_id_{env}.txt"
 
 
+def _confirm_url_fil_for_milj(env: str) -> Path:
+    """Sti til miljø-spesifikk fil for sist mottatte godkjenningslenke."""
+    return _WENCHE_DIR / f"systembruker_confirm_url_{env}.txt"
+
+
 # ---------------------------------------------------------------------------
 # Tilstandsklasser
 # ---------------------------------------------------------------------------
@@ -644,6 +649,20 @@ def _les_request_id(env: str | None = None) -> str:
     return ""
 
 
+def _lagre_confirm_url(url: str, env: str) -> None:
+    if not url:
+        return
+    _WENCHE_DIR.mkdir(exist_ok=True)
+    _confirm_url_fil_for_milj(env).write_text(url, encoding="utf-8")
+
+
+def _les_confirm_url(env: str) -> str:
+    fil = _confirm_url_fil_for_milj(env)
+    if fil.exists():
+        return fil.read_text(encoding="utf-8").strip()
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # Gjenbrukbare UI-komponenter
 # ---------------------------------------------------------------------------
@@ -992,24 +1011,96 @@ def _bygg_oppsett_fane() -> None:
     status_kontainer: dict[str, "ui.column"] = {}
     godkjenn_url_kontainer: dict[str, "ui.element"] = {}
 
+    def _vis_godkjenn_lenke(env: str, url: str, etikett: str = "Godkjenn i Altinn →"):
+        godkjenn_url_kontainer[env].clear()
+        if not url:
+            return
+        with godkjenn_url_kontainer[env]:
+            ui.link(etikett, url, new_tab=True).classes(
+                "text-blue-600 font-medium text-sm"
+            )
+
     def _vis_status(env: str, status: str | None, melding: str | None = None):
         kontainer = status_kontainer[env]
         kontainer.clear()
+        miljo_navn = "testmiljø (tt02)" if env == "test" else "produksjon"
+
         if status == "Accepted":
-            ikon, farge, tekst = "check_circle", "text-green-600", "Systembruker godkjent"
+            ikon, farge = "check_circle", "text-green-600"
+            overskrift = "Systembruker godkjent"
+            forklaring = (
+                f"Virksomheten har godkjent Wenche som leverandørsystem i {miljo_navn}. "
+                f"Wenche kan nå sende inn dokumenter på vegne av virksomheten."
+            )
+            _vis_godkjenn_lenke(env, "")  # ikke vis lenken når godkjent
         elif status == "New":
-            ikon, farge, tekst = "schedule", "text-amber-600", "Forespørsel venter på godkjenning"
+            ikon, farge = "schedule", "text-amber-600"
+            overskrift = "Forespørsel venter på godkjenning"
+            forklaring = (
+                f"Du har bedt om at Wenche skal kunne handle på vegne av virksomheten i "
+                f"{miljo_navn}. Daglig leder eller styreleder må logge inn på Altinn med "
+                f"BankID og godkjenne forespørselen. Inntil det er gjort kan ikke Wenche "
+                f"sende inn dokumenter i dette miljøet."
+            )
+            # Vis lagret godkjenningslenke hvis den finnes (etter restart osv.)
+            lagret_url = _les_confirm_url(env)
+            if lagret_url:
+                _vis_godkjenn_lenke(env, lagret_url)
         elif status == "Rejected":
-            ikon, farge, tekst = "error", "text-red-600", "Forespørsel avvist — opprett ny"
+            ikon, farge = "error", "text-red-600"
+            overskrift = "Forespørsel avvist"
+            forklaring = (
+                "Forrige systembruker-forespørsel ble avvist. Klikk «Opprett systembruker» "
+                "for å lage en ny forespørsel."
+            )
+            _vis_godkjenn_lenke(env, "")
+        elif status == "ikke_opprettet":
+            ikon, farge = "info", "text-slate-500"
+            overskrift = "Ingen systembruker satt opp"
+            forklaring = (
+                "Wenche må ha en godkjent systembruker for å sende inn dokumenter på "
+                f"vegne av virksomheten i {miljo_navn}. Klikk «Opprett systembruker» for "
+                "å starte. Du får en lenke som daglig leder eller styreleder må følge "
+                "for å godkjenne i Altinn med BankID."
+            )
+            _vis_godkjenn_lenke(env, "")
         elif status:
-            ikon, farge, tekst = "info", "text-slate-500", f"Status: {status}"
+            ikon, farge = "info", "text-slate-500"
+            overskrift = f"Status: {status}"
+            forklaring = melding or ""
         else:
-            ikon, farge = "help_outline", "text-slate-400"
-            tekst = melding or "Status ikke sjekket ennå"
+            # Ingen status sjekket ennå. Se om vi har en lagret forespørsel
+            # for å gi mer presis kontekst.
+            har_forespørsel = bool(_les_request_id(env))
+            if har_forespørsel:
+                ikon, farge = "schedule", "text-amber-600"
+                overskrift = "Forespørsel sendt — status ikke sjekket"
+                forklaring = (
+                    "Du har bedt om at Wenche skal kunne handle på vegne av "
+                    f"virksomheten i {miljo_navn}. Klikk «Sjekk status» for å se om "
+                    "den er godkjent. Hvis ikke, må daglig leder eller styreleder "
+                    "godkjenne den i Altinn med BankID."
+                )
+                lagret_url = _les_confirm_url(env)
+                if lagret_url:
+                    _vis_godkjenn_lenke(env, lagret_url)
+            else:
+                ikon, farge = "info", "text-slate-500"
+                overskrift = "Ingen systembruker satt opp ennå"
+                forklaring = (
+                    "Wenche må ha en godkjent systembruker for å sende inn dokumenter "
+                    f"på vegne av virksomheten i {miljo_navn}. Klikk «Opprett "
+                    "systembruker» for å starte. Du får en lenke som daglig leder "
+                    "eller styreleder må følge for å godkjenne i Altinn med BankID."
+                )
+
         with kontainer:
-            with ui.element("div").classes("grid grid-cols-[auto_1fr] gap-2 items-center"):
-                ui.icon(ikon).classes(f"{farge} text-base")
-                ui.label(tekst).classes(f"text-sm {farge}")
+            with ui.element("div").classes("grid grid-cols-[auto_1fr] gap-2 items-start"):
+                ui.icon(ikon).classes(f"{farge} text-base mt-0.5")
+                with ui.column().classes("gap-0 min-w-0"):
+                    ui.label(overskrift).classes(f"text-sm font-medium {farge}")
+                    if forklaring:
+                        ui.label(forklaring).classes("text-xs text-slate-500 mt-0.5")
 
     with ui.grid(columns=2).classes("w-full gap-4"):
         for env_var, miljo_navn, ikon_navn, ikon_farge, card_inputs in [
@@ -1042,14 +1133,20 @@ def _bygg_oppsett_fane() -> None:
                 ui.label("Systembruker i Altinn").classes(
                     "text-xs text-slate-500 uppercase tracking-wide font-medium"
                 )
-                status_kontainer[env_var] = ui.column().classes("gap-0 mb-2 mt-1")
+                ui.label(
+                    "Altinn krever at virksomheten godkjenner Wenche som "
+                    "leverandørsystem før vi kan sende inn dokumenter for "
+                    "den. Det gjøres med BankID av daglig leder eller "
+                    "styreleder."
+                ).classes("text-xs text-slate-500 mt-1 mb-2")
+                status_kontainer[env_var] = ui.column().classes("gap-0 mb-2")
                 _vis_status(env_var, None)
                 godkjenn_url_kontainer[env_var] = ui.element("div").classes("mb-2")
 
                 async def sjekk_status_handler(env=env_var):
                     request_id = _les_request_id(env)
                     if not request_id:
-                        _vis_status(env, None, "Ingen forespørsel opprettet ennå")
+                        _vis_status(env, "ikke_opprettet")
                         return
                     n = ui.notification(
                         f"Sjekker status i {('testmiljø' if env == 'test' else 'produksjon')}...",
@@ -1119,12 +1216,16 @@ def _bygg_oppsett_fane() -> None:
                         if request_id:
                             _lagre_request_id(request_id, env)
                         confirm_url = svar.get("confirmUrl", "")
-                        godkjenn_url_kontainer[env].clear()
-                        with godkjenn_url_kontainer[env]:
-                            ui.link("Godkjenn i Altinn →", confirm_url, new_tab=True).classes(
-                                "text-blue-600 font-medium text-sm"
-                            )
-                        n.message = f"Forespørsel opprettet (status: {svar.get('status', '')})"
+                        if confirm_url:
+                            _lagre_confirm_url(confirm_url, env)
+                        # Oppdater status-visningen samtidig så brukeren ser
+                        # at vi nå venter på godkjenning, ikke bare en flat
+                        # notification.
+                        _vis_status(env, "New")
+                        n.message = (
+                            "Forespørsel opprettet. Klikk lenken i kortet for å "
+                            "godkjenne i Altinn."
+                        )
                         n.spinner = False
                         n.type = "positive"
                         n.timeout = 5

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1193,18 +1193,20 @@ def _bygg_oppsett_fane() -> None:
                 miljo_navn = "Testmiljø (tt02)" if env == "test" else "Produksjon"
                 if ok is None:
                     ikon, farge = "remove_circle_outline", "text-slate-400"
-                    statustekst = melding
                 elif ok:
                     ikon, farge = "check_circle", "text-green-600"
-                    statustekst = melding
                 else:
                     ikon, farge = "error", "text-red-600"
-                    statustekst = melding
-                with ui.row().classes("items-start gap-2"):
+                # Grid med fast ikon-kolonne og fleksibel tekst-kolonne så lange
+                # meldinger wrapper i tekstkolonnen i stedet for å skyve ikonet
+                # ned på egen linje.
+                with ui.element("div").classes(
+                    "grid grid-cols-[auto_1fr] gap-2 items-start w-full"
+                ):
                     ui.icon(ikon).classes(f"{farge} text-base mt-0.5")
-                    with ui.column().classes("gap-0"):
+                    with ui.column().classes("gap-0 min-w-0"):
                         ui.label(miljo_navn).classes("text-sm font-medium text-slate-800")
-                        ui.label(statustekst).classes(f"text-xs {farge}")
+                        ui.label(melding).classes(f"text-xs {farge}")
 
     ui.button("Test tilkobling mot Altinn", on_click=test_tilkobling).props("color=primary outline")
 

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -932,9 +932,23 @@ def _bygg_oppsett_fane() -> None:
     aktivt_env = os.getenv("WENCHE_ENV", "prod")
 
     inp_env = ui.radio(
-        {"prod": "Produksjon", "test": "Testmiljø (tt02)"},
+        {"test": "Testmiljø (tt02)", "prod": "Produksjon"},
         value=aktivt_env,
     ).props("inline color=primary")
+
+    # Når brukeren bytter radio-knappen, oppdater os.environ umiddelbart slik
+    # at andre faner (særlig Hjem-fanens statussjekk) reflekterer det nye
+    # miljøet uten å vente på Lagre-klikk. Lagre-knappen persisterer fortsatt
+    # endringen til .env-filen.
+    def _radio_endret():
+        os.environ["WENCHE_ENV"] = inp_env.value
+        miljo_navn = "testmiljø" if inp_env.value == "test" else "produksjon"
+        ui.notify(
+            f"Aktivt miljø satt til {miljo_navn}. Klikk Lagre for å persistere.",
+            type="info",
+        )
+
+    inp_env.on_value_change(lambda _: _radio_endret())
 
     # --- Credentials per miljø ---
     ui.separator().classes("my-4")

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1009,6 +1009,40 @@ def _bygg_oppsett_fane() -> None:
     knapper_kontainer: dict[str, "ui.column"] = {}
     handlere: dict[str, dict] = {}
     _siste_status: dict[str, str | None] = {}
+    polling_timer: dict[str, "ui.timer"] = {}
+    polling_teller: dict[str, int] = {}
+    _POLLING_INTERVALL_SEK = 8.0
+    _POLLING_MAX_FORSOK = 38  # ~5 min med 8 sek intervall
+
+    def _start_polling(env: str):
+        """Start auto-polling av systembruker-status hvis ikke allerede aktiv."""
+        if polling_timer.get(env) is not None:
+            return  # allerede polling
+        polling_teller[env] = 0
+
+        async def _poll(env=env):
+            polling_teller[env] = polling_teller.get(env, 0) + 1
+            handlers = handlere.get(env, {})
+            sjekk = handlers.get("sjekk_status")
+            if sjekk is not None:
+                await sjekk(silent=True)
+            # _vis_status kalles av sjekk og oppdaterer _siste_status. Hvis status
+            # ikke lenger er "New", eller vi har prøvd for mange ganger, slutt.
+            if (
+                _siste_status.get(env) != "New"
+                or polling_teller[env] >= _POLLING_MAX_FORSOK
+            ):
+                _stopp_polling(env)
+
+        polling_timer[env] = ui.timer(_POLLING_INTERVALL_SEK, _poll, active=True)
+
+    def _stopp_polling(env: str):
+        t = polling_timer.pop(env, None)
+        if t is not None:
+            try:
+                t.deactivate()
+            except Exception:
+                pass
 
     def _vis_godkjenn_lenke(env: str, url: str, etikett: str = "Godkjenn i Altinn →"):
         godkjenn_url_kontainer[env].clear()
@@ -1156,8 +1190,16 @@ def _bygg_oppsett_fane() -> None:
                         ui.label(forklaring).classes("text-xs text-slate-500 mt-0.5")
 
         # Husker hvilken status vi er i, og rerender knappene kontekstuelt.
-        _siste_status[env] = "ikke_opprettet" if status == "ikke_opprettet" else status
+        effektiv_status = "ikke_opprettet" if status == "ikke_opprettet" else status
+        _siste_status[env] = effektiv_status
         _render_handlinger(env)
+
+        # Auto-poll mens vi venter på godkjenning, slik at UI-et fanger opp
+        # godkjenningen så snart den skjer i Altinn. Stopp i alle andre states.
+        if effektiv_status == "New":
+            _start_polling(env)
+        else:
+            _stopp_polling(env)
 
     with ui.grid(columns=2).classes("w-full gap-4"):
         for env_var, miljo_navn, ikon_navn, ikon_farge, card_inputs in [

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1250,6 +1250,14 @@ def _bygg_oppsett_fane() -> None:
                         if n is not None:
                             n.dismiss()
                     except Exception as e:
+                        if silent:
+                            # Stille auto-sjekk skal aldri forstyrre brukeren med
+                            # rød feiltekst på en transient feil ved oppstart.
+                            # Status forblir på initial-tilstanden («Forespørsel
+                            # sendt — status ikke sjekket» eller tilsvarende),
+                            # og brukeren kan klikke «Sjekk status på nytt» for
+                            # å se full feilmelding hvis problemet vedvarer.
+                            return
                         _vis_status(env, "feil", f"Kunne ikke sjekke status ({type(e).__name__})")
                         if n is not None:
                             n.message = f"Feil ved statussjekk: {e}"

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, field
 from datetime import date
 from pathlib import Path
 
+import httpx
 import yaml
 from nicegui import app, run, ui
 
@@ -1088,6 +1089,59 @@ def _bygg_oppsett_fane() -> None:
             and _les_konfig_for_milj("MASKINPORTEN_KID", env)
         )
 
+    def _tolk_feilmelding(env: str, raw: str) -> str:
+        """Oversett rå auth-feilmelding til brukervennlig norsk."""
+        import json
+        import re
+
+        miljo = "testmiljøet (tt02)" if env == "test" else "produksjonsmiljøet"
+        portal = (
+            "sjolvbetjening.test.samarbeid.digdir.no"
+            if env == "test"
+            else "sjolvbetjening.samarbeid.digdir.no"
+        )
+
+        # Maskinporten-feil: "Maskinporten svarte 400:\n{...json...}"
+        if "Maskinporten svarte" in raw:
+            m = re.search(r"\{.*\}", raw, re.DOTALL)
+            if m:
+                try:
+                    p = json.loads(m.group(0))
+                    kode = p.get("error", "")
+                    beskr = p.get("error_description", "")
+
+                    if kode == "invalid_grant" and "Client authentication" in beskr:
+                        return (
+                            f"Klient-ID-en din er ikke registrert i {miljo} "
+                            f"hos Maskinporten. Sjekk at klienten er opprettet "
+                            f"i riktig portal ({portal}) og at klient-ID + "
+                            f"nøkkel-ID i {('test' if env == 'test' else 'prod')}-kortet "
+                            f"matcher det som ligger der."
+                        )
+                    if kode == "invalid_grant":
+                        return f"Maskinporten avviste innloggingen: {beskr or kode}."
+                    if kode == "invalid_client":
+                        return f"Maskinporten kjenner ikke klient-ID-en i {miljo}."
+                    if kode == "invalid_scope":
+                        return (
+                            "Klienten mangler ett eller flere scopes du har "
+                            f"prøvd å hente. Legg dem til på klienten i {portal}."
+                        )
+                    return f"Maskinporten-feil ({kode}): {beskr or 'ingen detaljer'}."
+                except (json.JSONDecodeError, AttributeError):
+                    pass
+
+            m = re.search(r"svarte (\d+)", raw)
+            if m:
+                return (
+                    f"Maskinporten svarte med HTTP {m.group(1)} for {miljo}. "
+                    "Sjekk credentials og at klienten er registrert i riktig miljø."
+                )
+
+        # Andre RuntimeError-meldinger (manglende env, manglende nøkkelfil osv.)
+        # Vis bare første linje for å holde meldingen kort.
+        return raw.split("\n")[0]
+
     def _test_for_milj(env: str) -> tuple[bool, str]:
         """Test tilkobling for ett spesifikt miljø. Returnerer (ok, melding)."""
         opprinnelig_env = os.environ.get("WENCHE_ENV")
@@ -1096,9 +1150,24 @@ def _bygg_oppsett_fane() -> None:
             auth.login(lagre_token=False)
             return True, "Tilkobling OK"
         except RuntimeError as e:
-            return False, str(e).split("\n")[0]  # første linje for visning
+            return False, _tolk_feilmelding(env, str(e))
+        except httpx.HTTPStatusError as e:
+            kode = e.response.status_code
+            if kode == 401:
+                return False, (
+                    f"Altinn avviste tokenet (HTTP 401). Maskinporten-tokenet "
+                    f"ble hentet, men Altinn aksepterer det ikke. Vanligste "
+                    f"årsak: scopene altinn:instances.* er ikke aktivert på "
+                    f"klienten din i dette miljøet."
+                )
+            if kode == 403:
+                return False, (
+                    f"Altinn avslo tilgangen (HTTP 403). Sjekk at systembruker "
+                    f"er opprettet og godkjent for org.nr. {os.getenv('ORG_NUMMER', '')}."
+                )
+            return False, f"Altinn svarte med HTTP {kode}."
         except Exception as e:
-            return False, f"Uventet feil: {type(e).__name__}: {e}"
+            return False, f"Uventet feil ({type(e).__name__}): {e}"
         finally:
             if opprinnelig_env is None:
                 os.environ.pop("WENCHE_ENV", None)

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -965,50 +965,247 @@ def _bygg_oppsett_fane() -> None:
 
     inp_env.on_value_change(lambda _: _radio_endret())
 
-    # --- Credentials per miljø ---
+    # --- Miljø-oppsett (credentials + systembruker per miljø) ---
     ui.separator().classes("my-4")
-    seksjonstittel("Maskinporten-credentials")
+    seksjonstittel("Per miljø-oppsett")
     ui.label(
         "Klient-ID og Nøkkel-ID finner du i Digdirs selvbetjeningsportal. "
-        "Test- og prod-Maskinporten er separate registre — fyll inn credentials "
-        "for hvert miljø du har registrert klient i."
+        "Test og prod er separate Maskinporten-registre — hvert miljø har egne "
+        "credentials og egen systembruker som settes opp uavhengig av hverandre."
     ).classes("text-sm text-slate-500 mb-3")
 
     test_card_inputs: dict[str, ui.input] = {}
     prod_card_inputs: dict[str, ui.input] = {}
 
-    with ui.grid(columns=2).classes("w-full gap-4"):
-        # Test-card
-        with ui.card().classes("w-full p-4 border border-slate-200 shadow-none rounded-xl"):
-            with ui.row().classes("items-center gap-2 mb-2"):
-                ui.icon("science").classes("text-slate-500")
-                ui.label("Testmiljø (tt02)").classes("font-semibold text-slate-800")
-            test_card_inputs["client_id"] = ui.input(
-                "Klient-ID (test)",
-                value=_les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", "test"),
-                placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-            ).classes("w-full")
-            test_card_inputs["kid"] = ui.input(
-                "Nøkkel-ID (test)",
-                value=_les_konfig_for_milj("MASKINPORTEN_KID", "test"),
-                placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-            ).classes("w-full")
+    # Helper: kjør en operasjon med en bestemt WENCHE_ENV, restorer etterpå.
+    def _med_env(env: str, fn, *args, **kwargs):
+        opprinnelig = os.environ.get("WENCHE_ENV")
+        os.environ["WENCHE_ENV"] = env
+        try:
+            return fn(*args, **kwargs)
+        finally:
+            if opprinnelig is None:
+                os.environ.pop("WENCHE_ENV", None)
+            else:
+                os.environ["WENCHE_ENV"] = opprinnelig
 
-        # Prod-card
-        with ui.card().classes("w-full p-4 border border-slate-200 shadow-none rounded-xl"):
-            with ui.row().classes("items-center gap-2 mb-2"):
-                ui.icon("business").classes("text-slate-700")
-                ui.label("Produksjon").classes("font-semibold text-slate-800")
-            prod_card_inputs["client_id"] = ui.input(
-                "Klient-ID (prod)",
-                value=_les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", "prod"),
-                placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-            ).classes("w-full")
-            prod_card_inputs["kid"] = ui.input(
-                "Nøkkel-ID (prod)",
-                value=_les_konfig_for_milj("MASKINPORTEN_KID", "prod"),
-                placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
-            ).classes("w-full")
+    status_kontainer: dict[str, "ui.column"] = {}
+    godkjenn_url_kontainer: dict[str, "ui.element"] = {}
+
+    def _vis_status(env: str, status: str | None, melding: str | None = None):
+        kontainer = status_kontainer[env]
+        kontainer.clear()
+        if status == "Accepted":
+            ikon, farge, tekst = "check_circle", "text-green-600", "Systembruker godkjent"
+        elif status == "New":
+            ikon, farge, tekst = "schedule", "text-amber-600", "Forespørsel venter på godkjenning"
+        elif status == "Rejected":
+            ikon, farge, tekst = "error", "text-red-600", "Forespørsel avvist — opprett ny"
+        elif status:
+            ikon, farge, tekst = "info", "text-slate-500", f"Status: {status}"
+        else:
+            ikon, farge = "help_outline", "text-slate-400"
+            tekst = melding or "Status ikke sjekket ennå"
+        with kontainer:
+            with ui.element("div").classes("grid grid-cols-[auto_1fr] gap-2 items-center"):
+                ui.icon(ikon).classes(f"{farge} text-base")
+                ui.label(tekst).classes(f"text-sm {farge}")
+
+    with ui.grid(columns=2).classes("w-full gap-4"):
+        for env_var, miljo_navn, ikon_navn, ikon_farge, card_inputs in [
+            ("test", "Testmiljø (tt02)", "science", "text-slate-500", test_card_inputs),
+            ("prod", "Produksjon", "business", "text-slate-700", prod_card_inputs),
+        ]:
+            with ui.card().classes("w-full p-4 border border-slate-200 shadow-none rounded-xl"):
+                # Header
+                with ui.row().classes("items-center gap-2 mb-3"):
+                    ui.icon(ikon_navn).classes(ikon_farge)
+                    ui.label(miljo_navn).classes("font-semibold text-slate-800")
+
+                # --- Credentials-seksjon ---
+                ui.label("Maskinporten-credentials").classes(
+                    "text-xs text-slate-500 uppercase tracking-wide font-medium"
+                )
+                card_inputs["client_id"] = ui.input(
+                    f"Klient-ID ({env_var})",
+                    value=_les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env_var),
+                    placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+                ).classes("w-full")
+                card_inputs["kid"] = ui.input(
+                    f"Nøkkel-ID ({env_var})",
+                    value=_les_konfig_for_milj("MASKINPORTEN_KID", env_var),
+                    placeholder="xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+                ).classes("w-full")
+
+                # --- Systembruker-seksjon ---
+                ui.separator().classes("my-4")
+                ui.label("Systembruker i Altinn").classes(
+                    "text-xs text-slate-500 uppercase tracking-wide font-medium"
+                )
+                status_kontainer[env_var] = ui.column().classes("gap-0 mb-2 mt-1")
+                _vis_status(env_var, None)
+                godkjenn_url_kontainer[env_var] = ui.element("div").classes("mb-2")
+
+                async def sjekk_status_handler(env=env_var):
+                    request_id = _les_request_id(env)
+                    if not request_id:
+                        _vis_status(env, None, "Ingen forespørsel opprettet ennå")
+                        return
+                    n = ui.notification(
+                        f"Sjekker status i {('testmiljø' if env == 'test' else 'produksjon')}...",
+                        spinner=True, timeout=None,
+                    )
+                    try:
+                        token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
+                        svar = await run.io_bound(
+                            lambda: _med_env(
+                                env, systembruker.hent_forespørsel_status, token, request_id,
+                            )
+                        )
+                        _vis_status(env, svar.get("status", "ukjent"))
+                        n.dismiss()
+                    except Exception as e:
+                        n.message = f"Feil ved statussjekk: {e}"
+                        n.spinner = False
+                        n.type = "negative"
+                        n.timeout = 0
+                        n.close_button = "Lukk"
+
+                async def registrer_handler(env=env_var):
+                    n = ui.notification(
+                        f"Registrerer system i {('testmiljø' if env == 'test' else 'produksjon')}...",
+                        spinner=True, timeout=None,
+                    )
+                    try:
+                        token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
+                        orgnr = os.getenv("ORG_NUMMER")
+                        client_id = _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
+                        svar = await run.io_bound(
+                            lambda: _med_env(
+                                env, systembruker.registrer_system, token, orgnr, client_id,
+                            )
+                        )
+                        n.message = "System oppdatert." if svar.get("oppdatert") else "System registrert."
+                        n.spinner = False
+                        n.type = "positive"
+                        n.timeout = 5
+                    except Exception as e:
+                        n.message = f"Feil: {e}"
+                        n.spinner = False
+                        n.type = "negative"
+                        n.timeout = 0
+                        n.close_button = "Lukk"
+
+                async def opprett_handler(env=env_var):
+                    n = ui.notification(
+                        f"Oppretter systembruker-forespørsel i "
+                        f"{('testmiljø' if env == 'test' else 'produksjon')}...",
+                        spinner=True, timeout=None,
+                    )
+                    try:
+                        token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
+                        vendor_orgnr = os.getenv("ORG_NUMMER")
+                        party_orgnr = (
+                            os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr)
+                            if env == "test" else vendor_orgnr
+                        )
+                        svar = await run.io_bound(
+                            lambda: _med_env(
+                                env, systembruker.opprett_forespørsel,
+                                token, vendor_orgnr, party_orgnr,
+                            )
+                        )
+                        request_id = svar.get("id", "")
+                        if request_id:
+                            _lagre_request_id(request_id, env)
+                        confirm_url = svar.get("confirmUrl", "")
+                        godkjenn_url_kontainer[env].clear()
+                        with godkjenn_url_kontainer[env]:
+                            ui.link("Godkjenn i Altinn →", confirm_url, new_tab=True).classes(
+                                "text-blue-600 font-medium text-sm"
+                            )
+                        n.message = f"Forespørsel opprettet (status: {svar.get('status', '')})"
+                        n.spinner = False
+                        n.type = "positive"
+                        n.timeout = 5
+                    except Exception as e:
+                        n.message = f"Feil: {e}"
+                        n.spinner = False
+                        n.type = "negative"
+                        n.timeout = 0
+                        n.close_button = "Lukk"
+
+                async def oppdater_handler(env=env_var):
+                    n = ui.notification(
+                        f"Henter systembrukere i "
+                        f"{('testmiljø' if env == 'test' else 'produksjon')}...",
+                        spinner=True, timeout=None,
+                    )
+                    try:
+                        token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
+                        vendor_orgnr = os.getenv("ORG_NUMMER")
+                        party_orgnr = (
+                            os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr)
+                            if env == "test" else vendor_orgnr
+                        )
+                        brukere = await run.io_bound(
+                            lambda: _med_env(
+                                env, systembruker.hent_systembrukere, token, vendor_orgnr,
+                            )
+                        )
+                        if not brukere:
+                            n.message = "Ingen aktive systembrukere funnet. Opprett ny forespørsel først."
+                            n.spinner = False
+                            n.type = "info"
+                            n.timeout = 6
+                            return
+                        treff = next(
+                            (b for b in brukere if b.get("reporteeOrgNo") == party_orgnr),
+                            brukere[0],
+                        )
+                        bruker_id = treff["id"]
+                        svar = await run.io_bound(
+                            lambda: _med_env(
+                                env, systembruker.opprett_endringsforespørsel,
+                                token, bruker_id, [systembruker._SKATTEMELDING_RETT],
+                            )
+                        )
+                        confirm_url = svar.get("confirmUrl") or svar.get("ConfirmUrl", "")
+                        godkjenn_url_kontainer[env].clear()
+                        with godkjenn_url_kontainer[env]:
+                            ui.link("Godkjenn endring i Altinn →", confirm_url, new_tab=True).classes(
+                                "text-blue-600 font-medium text-sm"
+                            )
+                        n.message = f"Endringsforespørsel opprettet (status: {svar.get('status', '')})"
+                        n.spinner = False
+                        n.type = "positive"
+                        n.timeout = 5
+                    except Exception as e:
+                        n.message = f"Feil: {e}"
+                        n.spinner = False
+                        n.type = "negative"
+                        n.timeout = 0
+                        n.close_button = "Lukk"
+
+                with ui.column().classes("w-full gap-2 mt-2"):
+                    ui.button("Sjekk status", on_click=sjekk_status_handler).props(
+                        "color=primary"
+                    ).classes("w-full")
+                    ui.button("Registrer system", on_click=registrer_handler).props(
+                        "outline color=primary"
+                    ).classes("w-full")
+                    ui.button("Opprett systembruker", on_click=opprett_handler).props(
+                        "outline color=primary"
+                    ).classes("w-full")
+                    with ui.expansion("Avansert").classes("w-full"):
+                        ui.label(
+                            "Oppdater rettigheter sender en endringsforespørsel "
+                            "hvis du har lagt til nye scopes på en allerede godkjent "
+                            "systembruker. Eksisterende rettigheter beholdes."
+                        ).classes("text-sm text-slate-500 mb-2")
+                        ui.button(
+                            "Oppdater rettigheter", on_click=oppdater_handler,
+                        ).props("outline color=primary").classes("w-full")
 
     # --- Felles for begge miljø ---
     ui.separator().classes("my-4")
@@ -1223,224 +1420,6 @@ def _bygg_oppsett_fane() -> None:
                         ui.label(melding).classes(f"text-xs {farge}")
 
     ui.button("Test tilkobling mot Altinn", on_click=test_tilkobling).props("color=primary outline")
-
-    # --- Systembruker-oppsett ---
-    ui.separator().classes("my-4")
-    seksjonstittel("Systembruker-oppsett")
-    ui.label(
-        "Wenche må være registrert som leverandørsystem i Altinn, og "
-        "virksomheten må ha godkjent en systembruker. Hvert miljø har sin egen "
-        "systembruker — settes opp uavhengig og forblir gyldig så lenge "
-        "rettighetene ikke endres."
-    ).classes("text-sm text-slate-500 mb-3")
-
-    # Helper: kjør en operasjon i et bestemt miljø, restorer WENCHE_ENV etterpå.
-    def _med_env(env: str, fn, *args, **kwargs):
-        opprinnelig = os.environ.get("WENCHE_ENV")
-        os.environ["WENCHE_ENV"] = env
-        try:
-            return fn(*args, **kwargs)
-        finally:
-            if opprinnelig is None:
-                os.environ.pop("WENCHE_ENV", None)
-            else:
-                os.environ["WENCHE_ENV"] = opprinnelig
-
-    status_kontainer: dict[str, "ui.column"] = {}
-    godkjenn_url_kontainer: dict[str, "ui.element"] = {}
-
-    def _vis_status(env: str, status: str | None, melding: str | None = None):
-        kontainer = status_kontainer[env]
-        kontainer.clear()
-        if status == "Accepted":
-            ikon, farge, tekst = "check_circle", "text-green-600", "Systembruker godkjent"
-        elif status == "New":
-            ikon, farge, tekst = "schedule", "text-amber-600", "Forespørsel venter på godkjenning"
-        elif status == "Rejected":
-            ikon, farge, tekst = "error", "text-red-600", "Forespørsel avvist — opprett ny"
-        elif status:
-            ikon, farge, tekst = "info", "text-slate-500", f"Status: {status}"
-        else:
-            ikon, farge = "help_outline", "text-slate-400"
-            tekst = melding or "Status ikke sjekket ennå"
-        with kontainer:
-            with ui.element("div").classes("grid grid-cols-[auto_1fr] gap-2 items-center"):
-                ui.icon(ikon).classes(f"{farge} text-base")
-                ui.label(tekst).classes(f"text-sm {farge}")
-
-    with ui.grid(columns=2).classes("w-full gap-4"):
-        for env_var, miljo_navn, ikon_navn, ikon_farge in [
-            ("test", "Testmiljø (tt02)", "science", "text-slate-500"),
-            ("prod", "Produksjon", "business", "text-slate-700"),
-        ]:
-            with ui.card().classes("w-full p-4 border border-slate-200 shadow-none rounded-xl"):
-                with ui.row().classes("items-center gap-2 mb-2"):
-                    ui.icon(ikon_navn).classes(ikon_farge)
-                    ui.label(miljo_navn).classes("font-semibold text-slate-800")
-
-                status_kontainer[env_var] = ui.column().classes("gap-0 mb-2")
-                _vis_status(env_var, None)
-
-                godkjenn_url_kontainer[env_var] = ui.element("div").classes("mb-2 min-h-0")
-
-                # Handlere — bruker env=env_var som default-arg for korrekt closure-capture.
-                async def sjekk_status_handler(env=env_var):
-                    request_id = _les_request_id(env)
-                    if not request_id:
-                        _vis_status(env, None, "Ingen forespørsel opprettet ennå")
-                        return
-                    n = ui.notification(
-                        f"Sjekker status i {('testmiljø' if env == 'test' else 'produksjon')}...",
-                        spinner=True, timeout=None,
-                    )
-                    try:
-                        token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
-                        svar = await run.io_bound(
-                            lambda: _med_env(
-                                env, systembruker.hent_forespørsel_status, token, request_id,
-                            )
-                        )
-                        _vis_status(env, svar.get("status", "ukjent"))
-                        n.dismiss()
-                    except Exception as e:
-                        n.message = f"Feil ved statussjekk: {e}"
-                        n.spinner = False
-                        n.type = "negative"
-                        n.timeout = 0
-                        n.close_button = "Lukk"
-
-                async def registrer_handler(env=env_var):
-                    n = ui.notification(
-                        f"Registrerer system i {('testmiljø' if env == 'test' else 'produksjon')}...",
-                        spinner=True, timeout=None,
-                    )
-                    try:
-                        token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
-                        orgnr = os.getenv("ORG_NUMMER")
-                        client_id = _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
-                        svar = await run.io_bound(
-                            lambda: _med_env(
-                                env, systembruker.registrer_system, token, orgnr, client_id,
-                            )
-                        )
-                        n.message = "System oppdatert." if svar.get("oppdatert") else "System registrert."
-                        n.spinner = False
-                        n.type = "positive"
-                        n.timeout = 5
-                    except Exception as e:
-                        n.message = f"Feil: {e}"
-                        n.spinner = False
-                        n.type = "negative"
-                        n.timeout = 0
-                        n.close_button = "Lukk"
-
-                async def opprett_handler(env=env_var):
-                    n = ui.notification(
-                        f"Oppretter systembruker-forespørsel i {('testmiljø' if env == 'test' else 'produksjon')}...",
-                        spinner=True, timeout=None,
-                    )
-                    try:
-                        token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
-                        vendor_orgnr = os.getenv("ORG_NUMMER")
-                        party_orgnr = (
-                            os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr)
-                            if env == "test" else vendor_orgnr
-                        )
-                        svar = await run.io_bound(
-                            lambda: _med_env(
-                                env, systembruker.opprett_forespørsel,
-                                token, vendor_orgnr, party_orgnr,
-                            )
-                        )
-                        request_id = svar.get("id", "")
-                        if request_id:
-                            _lagre_request_id(request_id, env)
-                        confirm_url = svar.get("confirmUrl", "")
-                        godkjenn_url_kontainer[env].clear()
-                        with godkjenn_url_kontainer[env]:
-                            ui.link("Godkjenn i Altinn →", confirm_url, new_tab=True).classes(
-                                "text-blue-600 font-medium text-sm"
-                            )
-                        n.message = f"Forespørsel opprettet (status: {svar.get('status', '')})"
-                        n.spinner = False
-                        n.type = "positive"
-                        n.timeout = 5
-                    except Exception as e:
-                        n.message = f"Feil: {e}"
-                        n.spinner = False
-                        n.type = "negative"
-                        n.timeout = 0
-                        n.close_button = "Lukk"
-
-                async def oppdater_handler(env=env_var):
-                    n = ui.notification(
-                        f"Henter systembrukere i {('testmiljø' if env == 'test' else 'produksjon')}...",
-                        spinner=True, timeout=None,
-                    )
-                    try:
-                        token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
-                        vendor_orgnr = os.getenv("ORG_NUMMER")
-                        party_orgnr = (
-                            os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr)
-                            if env == "test" else vendor_orgnr
-                        )
-                        brukere = await run.io_bound(
-                            lambda: _med_env(
-                                env, systembruker.hent_systembrukere, token, vendor_orgnr,
-                            )
-                        )
-                        if not brukere:
-                            n.message = "Ingen aktive systembrukere funnet. Opprett ny forespørsel først."
-                            n.spinner = False
-                            n.type = "info"
-                            n.timeout = 6
-                            return
-                        treff = next(
-                            (b for b in brukere if b.get("reporteeOrgNo") == party_orgnr),
-                            brukere[0],
-                        )
-                        bruker_id = treff["id"]
-                        svar = await run.io_bound(
-                            lambda: _med_env(
-                                env, systembruker.opprett_endringsforespørsel,
-                                token, bruker_id, [systembruker._SKATTEMELDING_RETT],
-                            )
-                        )
-                        confirm_url = svar.get("confirmUrl") or svar.get("ConfirmUrl", "")
-                        godkjenn_url_kontainer[env].clear()
-                        with godkjenn_url_kontainer[env]:
-                            ui.link("Godkjenn endring i Altinn →", confirm_url, new_tab=True).classes(
-                                "text-blue-600 font-medium text-sm"
-                            )
-                        n.message = f"Endringsforespørsel opprettet (status: {svar.get('status', '')})"
-                        n.spinner = False
-                        n.type = "positive"
-                        n.timeout = 5
-                    except Exception as e:
-                        n.message = f"Feil: {e}"
-                        n.spinner = False
-                        n.type = "negative"
-                        n.timeout = 0
-                        n.close_button = "Lukk"
-
-                with ui.column().classes("w-full gap-1 mt-2"):
-                    ui.button("Sjekk status", on_click=sjekk_status_handler).props(
-                        "color=primary size=sm"
-                    ).classes("w-full")
-                    ui.button("Registrer system", on_click=registrer_handler).props(
-                        "outline color=primary size=sm"
-                    ).classes("w-full")
-                    ui.button("Opprett systembruker", on_click=opprett_handler).props(
-                        "outline color=primary size=sm"
-                    ).classes("w-full")
-                    with ui.expansion("Avansert").classes("w-full text-xs"):
-                        ui.button(
-                            "Oppdater rettigheter", on_click=oppdater_handler,
-                        ).props("outline color=primary size=sm").classes("w-full")
-                        ui.label(
-                            "Send endringsforespørsel hvis du har lagt til nye scopes "
-                            "på en allerede godkjent systembruker."
-                        ).classes("text-xs text-slate-500 mt-1")
 
 
 # ---------------------------------------------------------------------------

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1288,8 +1288,10 @@ def _bygg_oppsett_fane() -> None:
     ui.separator().classes("my-4")
     seksjonstittel("Tilkoblingstest")
     ui.label(
-        "Tester Maskinporten og Altinn-veksling for hvert miljø som har credentials konfigurert. "
-        "Ingen data sendes inn og tokens lagres ikke."
+        "Sjekker tre ting per miljø: at Maskinporten godtar credentials, at "
+        "Altinn aksepterer instance-scopene, og at systembrukeren er godkjent. "
+        "Alle tre må være OK for at innsending skal fungere. Ingen data sendes "
+        "inn og tokens lagres ikke."
     ).classes("text-sm text-slate-500 mb-2")
 
     test_resultat_container = ui.column().classes("w-full gap-1 mt-3")
@@ -1353,29 +1355,24 @@ def _bygg_oppsett_fane() -> None:
         # Vis bare første linje for å holde meldingen kort.
         return raw.split("\n")[0]
 
-    def _test_for_milj(env: str) -> tuple[bool, str]:
-        """Test tilkobling for ett spesifikt miljø. Returnerer (ok, melding)."""
+    def _test_auth_for_milj(env: str) -> tuple[bool, str]:
+        """Test Maskinporten + Altinn-veksling. Returnerer (ok, melding)."""
         opprinnelig_env = os.environ.get("WENCHE_ENV")
         os.environ["WENCHE_ENV"] = env
         try:
             auth.login(lagre_token=False)
-            return True, "Tilkobling OK"
+            return True, "Maskinporten og Altinn godtok credentials"
         except RuntimeError as e:
             return False, _tolk_feilmelding(env, str(e))
         except httpx.HTTPStatusError as e:
             kode = e.response.status_code
             if kode == 401:
                 return False, (
-                    f"Altinn avviste tokenet (HTTP 401). Maskinporten-tokenet "
-                    f"ble hentet, men Altinn aksepterer det ikke. Vanligste "
-                    f"årsak: scopene altinn:instances.* er ikke aktivert på "
-                    f"klienten din i dette miljøet."
+                    "Altinn avviste tokenet (HTTP 401). Vanligste årsak: "
+                    "altinn:instances.* er ikke aktivert på klienten."
                 )
             if kode == 403:
-                return False, (
-                    f"Altinn avslo tilgangen (HTTP 403). Sjekk at systembruker "
-                    f"er opprettet og godkjent for org.nr. {os.getenv('ORG_NUMMER', '')}."
-                )
+                return False, "Altinn avslo tilgangen (HTTP 403)."
             return False, f"Altinn svarte med HTTP {kode}."
         except Exception as e:
             return False, f"Uventet feil ({type(e).__name__}): {e}"
@@ -1385,39 +1382,146 @@ def _bygg_oppsett_fane() -> None:
             else:
                 os.environ["WENCHE_ENV"] = opprinnelig_env
 
+    def _test_systembruker_for_milj(env: str) -> tuple[str, str]:
+        """Sjekk systembruker-status. Returnerer (status, melding).
+
+        status: 'godkjent' / 'venter' / 'avvist' / 'ikke_opprettet' / 'feil' / 'ukjent'
+        """
+        request_id = _les_request_id(env)
+        if not request_id:
+            return "ikke_opprettet", "Ingen forespørsel opprettet ennå"
+        opprinnelig_env = os.environ.get("WENCHE_ENV")
+        os.environ["WENCHE_ENV"] = env
+        try:
+            token = auth.login_admin()
+            svar = systembruker.hent_forespørsel_status(token, request_id)
+            altinn_status = svar.get("status", "ukjent")
+            if altinn_status == "Accepted":
+                return "godkjent", "Systembruker godkjent"
+            if altinn_status == "New":
+                return "venter", "Forespørsel venter på godkjenning"
+            if altinn_status == "Rejected":
+                return "avvist", "Forespørsel avvist — opprett ny"
+            return "ukjent", f"Status: {altinn_status}"
+        except Exception as e:
+            return "feil", f"Kunne ikke hente status: {type(e).__name__}"
+        finally:
+            if opprinnelig_env is None:
+                os.environ.pop("WENCHE_ENV", None)
+            else:
+                os.environ["WENCHE_ENV"] = opprinnelig_env
+
+    def _test_for_milj(env: str) -> dict:
+        """Kjør alle sjekker for ett miljø og returner samlet resultat."""
+        auth_ok, auth_melding = _test_auth_for_milj(env)
+        if not auth_ok:
+            # Hvis auth feiler, gir ikke systembruker-sjekken ekstra info
+            return {
+                "env": env,
+                "auth": (False, auth_melding),
+                "systembruker": None,
+            }
+        sys_status, sys_melding = _test_systembruker_for_milj(env)
+        return {
+            "env": env,
+            "auth": (True, auth_melding),
+            "systembruker": (sys_status, sys_melding),
+        }
+
     async def test_tilkobling():
         test_resultat_container.clear()
-        n = ui.notification("Tester tilkobling for begge miljø...", spinner=True, timeout=None)
+        n = ui.notification("Tester begge miljø...", spinner=True, timeout=None)
 
         resultater = []
         for env in ["test", "prod"]:
             if not _milj_har_credentials(env):
-                resultater.append((env, None, "Ingen credentials konfigurert"))
+                resultater.append({"env": env, "auth": None, "systembruker": None})
                 continue
-            ok, melding = await run.io_bound(_test_for_milj, env)
-            resultater.append((env, ok, melding))
+            res = await run.io_bound(_test_for_milj, env)
+            resultater.append(res)
 
         n.dismiss()
 
+        def _ikon_for_status(sys_status: str) -> tuple[str, str]:
+            return {
+                "godkjent": ("check_circle", "text-green-600"),
+                "venter": ("schedule", "text-amber-600"),
+                "avvist": ("error", "text-red-600"),
+                "ikke_opprettet": ("info", "text-slate-500"),
+                "feil": ("error_outline", "text-red-600"),
+                "ukjent": ("help_outline", "text-slate-400"),
+            }.get(sys_status, ("help_outline", "text-slate-400"))
+
         with test_resultat_container:
-            for env, ok, melding in resultater:
+            for res in resultater:
+                env = res["env"]
                 miljo_navn = "Testmiljø (tt02)" if env == "test" else "Produksjon"
-                if ok is None:
-                    ikon, farge = "remove_circle_outline", "text-slate-400"
-                elif ok:
-                    ikon, farge = "check_circle", "text-green-600"
-                else:
-                    ikon, farge = "error", "text-red-600"
-                # Grid med fast ikon-kolonne og fleksibel tekst-kolonne så lange
-                # meldinger wrapper i tekstkolonnen i stedet for å skyve ikonet
-                # ned på egen linje.
-                with ui.element("div").classes(
-                    "grid grid-cols-[auto_1fr] gap-2 items-start w-full"
+                with ui.card().classes(
+                    "w-full p-3 border border-slate-200 shadow-none rounded-lg mb-2"
                 ):
-                    ui.icon(ikon).classes(f"{farge} text-base mt-0.5")
-                    with ui.column().classes("gap-0 min-w-0"):
-                        ui.label(miljo_navn).classes("text-sm font-medium text-slate-800")
-                        ui.label(melding).classes(f"text-xs {farge}")
+                    ui.label(miljo_navn).classes("text-sm font-semibold text-slate-800 mb-1")
+
+                    if res["auth"] is None:
+                        # Ingen credentials konfigurert
+                        with ui.element("div").classes("grid grid-cols-[auto_1fr] gap-2 items-start"):
+                            ui.icon("remove_circle_outline").classes("text-slate-400 text-base mt-0.5")
+                            ui.label("Ingen credentials konfigurert for dette miljøet").classes(
+                                "text-sm text-slate-500"
+                            )
+                        continue
+
+                    auth_ok, auth_melding = res["auth"]
+                    auth_ikon = "check_circle" if auth_ok else "error"
+                    auth_farge = "text-green-600" if auth_ok else "text-red-600"
+                    with ui.element("div").classes("grid grid-cols-[auto_1fr] gap-2 items-start"):
+                        ui.icon(auth_ikon).classes(f"{auth_farge} text-base mt-0.5")
+                        with ui.column().classes("gap-0 min-w-0"):
+                            ui.label("Maskinporten og Altinn-veksling").classes(
+                                "text-sm font-medium text-slate-700"
+                            )
+                            ui.label(auth_melding).classes(f"text-xs {auth_farge}")
+
+                    if res["systembruker"] is None:
+                        with ui.element("div").classes(
+                            "grid grid-cols-[auto_1fr] gap-2 items-start mt-1"
+                        ):
+                            ui.icon("help_outline").classes("text-slate-400 text-base mt-0.5")
+                            with ui.column().classes("gap-0 min-w-0"):
+                                ui.label("Systembruker").classes(
+                                    "text-sm font-medium text-slate-700"
+                                )
+                                ui.label("Ikke sjekket (auth må fungere først)").classes(
+                                    "text-xs text-slate-400"
+                                )
+                    else:
+                        sys_status, sys_melding = res["systembruker"]
+                        sys_ikon, sys_farge = _ikon_for_status(sys_status)
+                        with ui.element("div").classes(
+                            "grid grid-cols-[auto_1fr] gap-2 items-start mt-1"
+                        ):
+                            ui.icon(sys_ikon).classes(f"{sys_farge} text-base mt-0.5")
+                            with ui.column().classes("gap-0 min-w-0"):
+                                ui.label("Systembruker").classes(
+                                    "text-sm font-medium text-slate-700"
+                                )
+                                ui.label(sys_melding).classes(f"text-xs {sys_farge}")
+
+                    # Sammendrag-rad
+                    klart = auth_ok and res["systembruker"] and res["systembruker"][0] == "godkjent"
+                    sammendrag_ikon = "check_circle" if klart else "info"
+                    sammendrag_farge = "text-green-700" if klart else "text-slate-500"
+                    sammendrag_tekst = (
+                        "Klar for innsending"
+                        if klart
+                        else "Ikke klar for innsending — fiks det som er rødt eller gult"
+                    )
+                    with ui.element("div").classes(
+                        "grid grid-cols-[auto_1fr] gap-2 items-center mt-2 pt-2 border-t border-slate-200"
+                    ):
+                        ui.icon(sammendrag_ikon).classes(f"{sammendrag_farge} text-base")
+                        ui.label(sammendrag_tekst).classes(
+                            f"text-sm font-medium {sammendrag_farge}"
+                        )
 
     ui.button("Test tilkobling mot Altinn", on_click=test_tilkobling).props("color=primary outline")
 


### PR DESCRIPTION
## Sammendrag

Maskinporten test og prod er separate registre med ulike klient-UUID-er, egne systembrukere, og (for test) syntetiske Tenor-orgnumre. Wenche hadde tidligere ett sett credentials og en uklar miljø-håndtering. Denne PR-en redesigner Oppsett-fanen rundt prinsippet «alt som er miljø-spesifikt hører hjemme i sitt eget kort».

## Nytt design

Oppsett-fanen har nå to kort side om side (Testmiljø og Produksjon), hver med:

- **Maskinporten-credentials**: Klient-ID og Nøkkel-ID
- **Organisasjonsnummer**: test bruker syntetisk Tenor-org, prod bruker ditt eget
- **Systembruker i Altinn**: status, kontekstuelle handlinger, og en Avansert-ekspansjon for re-kjøring og scope-oppdatering

Under: Felles for begge miljø (privat nøkkel-opplasting), Lagre, og en Tilkoblingstest som sjekker tre forutsetninger per miljø (Maskinporten, Altinn-veksling og systembruker) og oppsummerer «klar for innsending» eller hva som mangler.

## Endringer i detalj

### Konfigurasjon

- Miljø-spesifikke `.env`-variabler: `MASKINPORTEN_CLIENT_ID_TEST`, `_PROD`, `MASKINPORTEN_KID_TEST`, `_PROD`. `ORG_NUMMER` (prod) og `SKD_TEST_ORG_NUMMER` (test) brukes per miljø.
- Eksplisitt tom verdi i UI-feltet persisteres (fallback til generisk legacy-verdi skjer ikke etter at brukeren har lagret).
- Tilfeller der bruker har gammel `.env` med generiske navn fungerer fortsatt. Første Lagre i nytt UI migrerer til miljø-spesifikke variabler.

### Auth

- `auth.py` har ny `_les_miljo_env`-helper som leser miljø-spesifikke varianter med generisk fallback.
- Maskinporten- og Altinn-URL-er beregnes ved hvert kall (ikke cachet ved modulinnlastning), så miljø-bytte tar umiddelbar effekt.
- `auth.login(lagre_token=False)` brukes av tilkoblingstesten for å unngå å overskrive aktivt token.
- `auth.login()` bruker nå `SKD_TEST_ORG_NUMMER` som systembruker_org i testmiljø (samme mønster som get_skd_aksjonaer_token og get_skd_skattemelding_tokens), så test-systembrukerens rettigheter faktisk gjelder ved Altinn-instance-opprettelse.

### Oppsett-fanen

- Fjernet «Aktivt miljø»-radio etter brukertesting. Den var villedende fordi Hjem-fanen alltid viser prod-status og Send-fanen har egen test/prod-toggle.
- Systembruker-seksjonen er integrert i hvert kort (ikke lenger gjemt i en sammenfoldet ekspansjon nederst).
- Auto-sjekk av systembruker-status ved sidelasting (silent mode, feil havner kun i status-raden, ikke som popup). Bruker 3 sek delay + ett silent retry etter 5 sek for å unngå race condition ved oppstart. Maks 2 kall per sidelasting (API-vennlig).
- «Jeg har godkjent — sjekk status»-knapp ved siden av godkjenningslenken så brukeren har eksplisitt handling i stedet for aggressiv polling.
- Kontekstuelle handlinger: primær-knappen avhenger av status (Opprett systembruker, Opprett ny, eller ingen). Resten ligger i Avansert.
- Brukervennlige feilmeldinger fra Maskinporten og Altinn med diagnostikk i klartekst.
- Statusoversikt viser komplett/manglende-status per miljø samtidig.

### Hjem-fanen

- Fristsjekken tvinger nå alltid prod, uavhengig av `WENCHE_ENV`.
- Skattemelding-statussjekk gjelder reell prod-status; test-API-et brukes ikke (det ville uansett bare ha avvist ekte org.nr.).

### Send-fanen

- Auth-kallene wrappes med `_med_env(env_valg.value, ...)`, så test/prod-radioen styrer hele flyten (auth, API og party-orgnr).
- Ingen avhengighet av global `WENCHE_ENV`.

### Aksjonær-fanen

- Bug-fiks: navn-input mistet fokus etter hvert tastetrykk pga. on_change-refresh av hele lista. Erstattet med refresh på blur, så fokus opprettholdes mens man skriver og header oppdateres når man klikker bort.

### Persisterte filer

- `~/.wenche/systembruker_request_id_{test,prod}.txt` per miljø.
- `~/.wenche/systembruker_confirm_url_{test,prod}.txt` per miljø.
- Legacy `systembruker_request_id.txt` brukes ikke lenger.

## Verifisert ende-til-ende mot tt02

Hele flyten testet 2026-05-19 mot Tenor-org `310943223`:

- [x] Maskinporten-auth med test-klient
- [x] Altinn-veksling og systembruker-godkjenning via TestID
- [x] Send årsregnskap til Altinn 3, signert i Altinn med TestID
- [x] Send skattemelding via Altinn 3-instansflyt til SKD
- [x] Send aksjonærregister direkte til SKDs API (hovedskjema + underskjema OK, bekreft-kallet feilet med transient GLD_023 fra SKDs test-stack, ikke Wenche-bug)

## Test plan

- [x] 212/212 tester passerer
- [x] `wenche ui` starter og serverer HTTP 200
- [x] Manuell verifisering gjennom flere iterasjoner. Denne PR-en er bygget fra brukerfeedback.

## Versjon

Bumpet til **0.13.0** (MINOR, ny funksjonalitet, backward compatible).