### PR TITLE
fix(ui): konsolidert prod-onboarding-fix og Hjem-fane prod-orgnr

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.13.0"
+version = "0.13.1"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_fristsjekk.py
+++ b/tests/test_fristsjekk.py
@@ -105,6 +105,16 @@ class TestSjekkSkattemelding:
         assert "ikke innsendt" in result.brukertekst
 
     @patch("wenche.fristsjekk.httpx.get")
+    def test_404_gir_ikke_klargjort(self, mock_get, prod_env):
+        """404 fra Skatteetaten → ingen skattemelding klargjort ennå."""
+        with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
+            mock_get.return_value = _mock_response(status_code=404)
+            result = sjekk_skattemelding("931808869", 2025)
+
+        assert result.innfridd is False
+        assert "klargjort" in result.beskrivelse.lower()
+
+    @patch("wenche.fristsjekk.httpx.get")
     def test_http_feil_gir_beskrivelse(self, mock_get, prod_env):
         """HTTP 500 fra Skatteetaten → innfridd=False med feilmelding."""
         with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
@@ -206,13 +216,23 @@ class TestSjekkAarsregnskap:
         assert result.innfridd is False
 
     @patch("wenche.fristsjekk.httpx.get")
-    def test_http_feil_gir_beskrivelse(self, mock_get):
-        """HTTP-feil fra BRG → innfridd=False med feilmelding."""
+    def test_404_gir_ikke_levert(self, mock_get):
+        """404 fra BRG → orgnr har ingen innleverte regnskap → 'Ikke levert'."""
         mock_get.return_value = _mock_response(status_code=404)
         result = sjekk_aarsregnskap("931808869", 2025)
 
         assert result.innfridd is False
-        assert "kontakte" in result.beskrivelse.lower()
+        assert result.beskrivelse == "Ikke levert"
+        assert "ikke mottatt" in result.brukertekst.lower()
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_http_feil_gir_beskrivelse(self, mock_get):
+        """5xx fra BRG → innfridd=False med HTTP-kode i beskrivelse."""
+        mock_get.return_value = _mock_response(status_code=503)
+        result = sjekk_aarsregnskap("931808869", 2025)
+
+        assert result.innfridd is False
+        assert "HTTP 503" in result.beskrivelse
 
     @patch("wenche.fristsjekk.httpx.get")
     def test_nettverksfeil_gir_beskrivelse(self, mock_get):

--- a/wenche/fristsjekk.py
+++ b/wenche/fristsjekk.py
@@ -110,6 +110,17 @@ def _utfør_skattemelding_sjekk(token: str, orgnr: str, aar: int) -> FristStatus
     except httpx.HTTPError:
         return FristStatus(beskrivelse="Kunne ikke kontakte Skatteetaten")
 
+    # 404 fra Skatteetaten betyr at ingen skattemelding er klargjort for orgnr/år
+    # ennå — det er normal status før forhåndsutfylt utkast publiseres.
+    if resp.status_code == 404:
+        return FristStatus(
+            beskrivelse="Ikke klargjort ennå",
+            brukertekst=(
+                f"Skatteetaten har ikke klargjort skattemelding for {aar} ennå. "
+                "Forhåndsutfylt utkast kommer normalt i mars/april."
+            ),
+        )
+
     if not resp.is_success:
         return FristStatus(beskrivelse=f"Skatteetaten svarte med HTTP {resp.status_code}")
 
@@ -147,8 +158,18 @@ def sjekk_aarsregnskap(orgnr: str, aar: int) -> FristStatus:
     except httpx.HTTPError:
         return FristStatus(beskrivelse="Kunne ikke kontakte Regnskapsregisteret")
 
+    # 404 betyr at orgnr ikke har innleverte regnskap i registeret — det er
+    # samme tilstand som "ikke levert ennå" for inneværende regnskapsår.
+    if resp.status_code == 404:
+        return FristStatus(
+            beskrivelse="Ikke levert",
+            brukertekst=f"Brønnøysundregistrene har ikke mottatt årsregnskapet for {aar} ennå.",
+        )
+
     if not resp.is_success:
-        return FristStatus(beskrivelse="Kunne ikke kontakte Regnskapsregisteret")
+        return FristStatus(
+            beskrivelse=f"Regnskapsregisteret svarte med HTTP {resp.status_code}"
+        )
 
     try:
         data = resp.json()

--- a/wenche/systembruker.py
+++ b/wenche/systembruker.py
@@ -98,7 +98,7 @@ def registrer_system(maskinporten_token: str, vendor_orgnr: str, client_id: str)
         timeout=15,
     )
     if resp.is_success:
-        return resp.json()
+        return _normaliser_svar(resp, sid, oppdatert=False)
 
     # Systemet finnes allerede — oppdater med PUT
     if resp.status_code == 400 and "already exists" in resp.text:
@@ -110,9 +110,26 @@ def registrer_system(maskinporten_token: str, vendor_orgnr: str, client_id: str)
         )
         if not resp.is_success:
             raise RuntimeError(f"{resp.status_code} {resp.reason_phrase}:\n{resp.text}")
-        return resp.json() if resp.text.strip() else {"id": sid, "oppdatert": True}
+        return _normaliser_svar(resp, sid, oppdatert=True)
 
     raise RuntimeError(f"{resp.status_code} {resp.reason_phrase}:\n{resp.text}")
+
+
+def _normaliser_svar(resp, sid: str, oppdatert: bool) -> dict:
+    """Altinn returnerer noen ganger system-ID-en som rå streng i stedet for dict.
+    Normaliser til alltid-dict for konsistent oppstrøms-bruk."""
+    if not resp.text.strip():
+        return {"id": sid, "oppdatert": oppdatert}
+    try:
+        data = resp.json()
+    except Exception:
+        return {"id": sid, "oppdatert": oppdatert}
+    if isinstance(data, dict):
+        data.setdefault("id", sid)
+        data.setdefault("oppdatert", oppdatert)
+        return data
+    # Strengt svar (typisk bare system-ID-en)
+    return {"id": data if isinstance(data, str) else sid, "oppdatert": oppdatert}
 
 
 def opprett_forespørsel(

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -841,7 +841,11 @@ def _bygg_hjem_fane(tabs=None, t_oppsett=None) -> None:
         ui.link("dokumentasjonen", "https://olefredrik.github.io/Wenche/", new_tab=True).classes("text-sm")
         ui.label(", der finner du hjelp til å sette opp alt riktig.").classes("text-sm text-slate-500")
 
-    orgnr_konfigurert = bool(state.org_nummer) and state.org_nummer != "123456789"
+    # Hjem-fanen sjekker status mot offentlige myndigheter for din egen virksomhet,
+    # så vi bruker prod-orgnr (ORG_NUMMER fra .env), ikke config.yaml-orgnr som ofte
+    # er Tenor-testdata. Skattemelding-sjekken tvinger uansett prod-env internt.
+    prod_orgnr = os.getenv("ORG_NUMMER", "").strip()
+    orgnr_konfigurert = bool(prod_orgnr) and prod_orgnr != "123456789"
 
     if not orgnr_konfigurert:
         with ui.card().classes(
@@ -854,8 +858,9 @@ def _bygg_hjem_fane(tabs=None, t_oppsett=None) -> None:
                         "font-semibold text-amber-900"
                     )
                     ui.label(
-                        "Fyll inn organisasjonsnummer i Oppsett-fanen for å aktivere "
-                        "automatisk statussjekk."
+                        "Fyll inn organisasjonsnummer for din virksomhet "
+                        "(prod-kortet i Oppsett-fanen) for å aktivere automatisk "
+                        "statussjekk."
                     ).classes("text-sm text-amber-900")
                 if tabs is not None and t_oppsett is not None:
                     ui.button(
@@ -937,7 +942,9 @@ def _bygg_hjem_fane(tabs=None, t_oppsett=None) -> None:
             sjekk_skattemelding,
         )
 
-        orgnr = state.org_nummer
+        # Bruk alltid prod-orgnr (ORG_NUMMER fra .env) for offentlig statussjekk.
+        # config.yaml kan inneholde Tenor-testdata, som vil gi 4xx mot prod-API-er.
+        orgnr = os.getenv("ORG_NUMMER", "").strip()
 
         # Ikke send API-kall med placeholder eller tomt org.nr.
         # Kortene er allerede bygget i ventende-tilstand når dette er tilfelle.

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1069,7 +1069,7 @@ def _bygg_oppsett_fane() -> None:
                 ui.button("Registrer system", on_click=h["registrer"]).props(
                     "outline color=primary"
                 ).classes("w-full")
-                ui.button("Opprett (ny) systembruker", on_click=h["opprett"]).props(
+                ui.button("Opprett ny forespørsel", on_click=h["opprett"]).props(
                     "outline color=primary"
                 ).classes("w-full")
 
@@ -1283,10 +1283,20 @@ def _bygg_oppsett_fane() -> None:
                         # Altinn returnerer noen ganger bare system-ID-en som
                         # streng på POST i stedet for et dict. Håndter begge.
                         oppdatert = isinstance(svar, dict) and svar.get("oppdatert", False)
-                        n.message = "System oppdatert." if oppdatert else "System registrert."
+                        hva = "System oppdatert." if oppdatert else "System registrert."
+                        # Hvis systembruker ikke er satt opp ennå, dyttene
+                        # brukeren videre til neste logiske handling.
+                        if _siste_status.get(env) in ("ikke_opprettet", None):
+                            n.message = (
+                                f"{hva} Neste steg: klikk «Opprett systembruker» "
+                                "for å lage forespørselen som skal godkjennes."
+                            )
+                            n.timeout = 10
+                        else:
+                            n.message = hva
+                            n.timeout = 5
                         n.spinner = False
                         n.type = "positive"
-                        n.timeout = 5
                     except Exception as e:
                         n.message = f"Feil: {e}"
                         n.spinner = False

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1280,7 +1280,10 @@ def _bygg_oppsett_fane() -> None:
                                 env, systembruker.registrer_system, token, orgnr, client_id,
                             )
                         )
-                        n.message = "System oppdatert." if svar.get("oppdatert") else "System registrert."
+                        # Altinn returnerer noen ganger bare system-ID-en som
+                        # streng på POST i stedet for et dict. Håndter begge.
+                        oppdatert = isinstance(svar, dict) and svar.get("oppdatert", False)
+                        n.message = "System oppdatert." if oppdatert else "System registrert."
                         n.spinner = False
                         n.type = "positive"
                         n.timeout = 5

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1422,17 +1422,18 @@ def _bygg_oppsett_fane() -> None:
                     and _les_request_id(env_var)
                 ):
                     async def _auto_sjekk_med_retry(env=env_var):
+                        import asyncio
+                        if _siste_status.get(env) not in ("New", None):
+                            return
+                        await sjekk_status_handler(env=env, silent=True)
+                        # Hvis fortsatt i venter-tilstand, prøv én gang til
+                        # om 5 sek. asyncio.sleep brukes i stedet for å
+                        # opprette en ny ui.timer (den ville feilet hvis
+                        # parent-slotten er borte, f.eks. ved sidebytte).
                         if _siste_status.get(env) in ("New", None):
-                            await sjekk_status_handler(env=env, silent=True)
-                            # Hvis fortsatt i venter-tilstand, prøv én gang til
-                            # om 5 sek. Da gir vi event-loopen god tid og
-                            # spammer ikke Altinn med flere kall.
+                            await asyncio.sleep(5)
                             if _siste_status.get(env) in ("New", None):
-                                ui.timer(
-                                    5.0,
-                                    lambda e=env: sjekk_status_handler(env=e, silent=True),
-                                    once=True,
-                                )
+                                await sjekk_status_handler(env=env, silent=True)
 
                     ui.timer(3.0, _auto_sjekk_med_retry, once=True)
 


### PR DESCRIPTION
Konsoliderer fiksene fra #66 sammen med Hjem-fane-rettelsen til én PR.

## Endringer

### Prod-onboarding-fikser (tidligere PR #66)
- **`registrer_system` håndterer rå-streng-svar fra Altinn** — Altinn returnerer noen ganger system-ID-en som rå streng i stedet for dict; normaliseres nå konsekvent til dict via `_normaliser_svar`-helperen.
- **Tydeligere neste-steg etter «Registrer system»** — meldingen ved vellykket registrering peker brukeren videre til «Opprett systembruker». Knapp-tekst «Opprett ny forespørsel» i Avansert-ekspansjon (var «Opprett (ny) systembruker»).
- **Auto-sjekk-retry uten nested `ui.timer`** — bruker `asyncio.sleep` i samme korutine, så retry krasjer ikke lenger med «parent element deleted» når brukeren bytter fane før retry-en fyrer.

### Hjem-fane prod-orgnr
Hjem-fanen plukket orgnr fra `config.yaml`, som typisk inneholder Tenor-testdata (syntetisk orgnr som 310943223). Skattemelding-sjekken tvinger uansett prod-env internt, og syntetiske orgnumre finnes ikke i prod-API-ene, så begge sjekkene ga 4xx:
- Skattemelding: «Skatteetaten svarte med HTTP 400»
- Årsregnskap: «Kunne ikke kontakte Regnskapsregisteret»

Endringer:
- `wenche/ui.py`: Hjem-fanen bruker `ORG_NUMMER` fra `.env` (din egen virksomhet) i stedet for `state.org_nummer`. Veiledning ved manglende orgnr peker spesifikt til prod-kortet i Oppsett-fanen.
- `wenche/fristsjekk.py`: BRG 404 → «Ikke levert». SKD 404 → «Ikke klargjort ennå». Andre 4xx/5xx fra BRG viser nå HTTP-koden i stedet for misvisende «Kunne ikke kontakte».

### Versjon
- `pyproject.toml`: 0.13.0 → 0.13.1

## Test plan

- [x] Verifisert `sjekk_aarsregnskap('922020523', 2025)` → «Ikke levert» (ekte orgnr, 2025 ikke levert)
- [x] Verifisert `sjekk_aarsregnskap('310943223', 2025)` → «Ikke levert» i stedet for «Kunne ikke kontakte» (BRG 404 håndteres riktig)
- [x] End-to-end-test mot Tenor org 310943223 i tt02: send årsregnskap, skattemelding, aksjonærregister
- [x] Manuell verifisering av prod-Maskinporten-klient og systembruker-oppsett
- [x] Manuell verifisering i UI: Hjem-fanen viser nå korrekt status mot prod-orgnr