### PR TITLE
feat(aksjonaer): forhåndsvalidering og lenke til Altinn meldingsboks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.13.1"
+version = "0.14.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_aksjonaerregister.py
+++ b/tests/test_aksjonaerregister.py
@@ -5,13 +5,16 @@ Bruker SKDs RF-1086 / RF-1086-U format med grp-/datadef-elementnavn.
 """
 
 import xml.etree.ElementTree as ET
+from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 
 from wenche.aksjonaerregister import (
     generer_hovedskjema_xml,
     generer_underskjema_xml,
     valider,
+    valider_mot_brg,
 )
 from wenche.models import Aksjonaer, Aksjonaerregisteroppgave, Selskap
 
@@ -34,7 +37,7 @@ def eksempel_selskap():
 def eksempel_aksjonaer():
     return Aksjonaer(
         navn="Ola Nordmann",
-        fodselsnummer="01010112345",
+        fodselsnummer="20916997389",
         antall_aksjer=100,
         aksjeklasse="A",
         utbytte_utbetalt=0,
@@ -158,7 +161,7 @@ def test_underskjema_fodselsnummer(eksempel_oppgave):
     root = _parse(generer_underskjema_xml(aksjonaer, eksempel_oppgave))
     fnr = root.find(".//{*}AksjonarFodselsnummer-datadef-1156")
     assert fnr is not None
-    assert fnr.text == "01010112345"
+    assert fnr.text == "20916997389"
 
 
 def test_underskjema_antall_aksjer(eksempel_oppgave):
@@ -281,3 +284,117 @@ def test_valider_ugyldig_fnr(eksempel_selskap):
     )
     feil = valider(oppgave)
     assert any("fødselsnummer" in f.lower() for f in feil)
+
+
+def test_valider_fnr_riktig_lengde_men_feil_kontrollsifre(eksempel_selskap):
+    # 11 siffer, men kontrollsifrene stemmer ikke (modulus-11).
+    aksjonaer = Aksjonaer(
+        navn="Typo Person",
+        fodselsnummer="20916997380",  # siste siffer endret fra 9 til 0
+        antall_aksjer=10,
+        aksjeklasse="A",
+        utbytte_utbetalt=0,
+        innbetalt_kapital_per_aksje=300,
+    )
+    oppgave = Aksjonaerregisteroppgave(
+        selskap=eksempel_selskap,
+        regnskapsaar=2024,
+        aksjonaerer=[aksjonaer],
+    )
+    feil = valider(oppgave)
+    assert any("kontrollsifre" in f.lower() for f in feil)
+
+
+def test_valider_stiftelse_i_inntektsaar_krever_innbetalt_kapital(eksempel_selskap):
+    # Selskapet er stiftet i inntektsåret men aksjonær har 0 i innbetalt kapital.
+    aksjonaer = Aksjonaer(
+        navn="Stifter Nordmann",
+        fodselsnummer="20916997389",
+        antall_aksjer=100,
+        aksjeklasse="A",
+        utbytte_utbetalt=0,
+        innbetalt_kapital_per_aksje=0,
+    )
+    oppgave = Aksjonaerregisteroppgave(
+        selskap=eksempel_selskap,  # stiftelsesaar=2020
+        regnskapsaar=2020,
+        aksjonaerer=[aksjonaer],
+    )
+    feil = valider(oppgave)
+    assert any("innbetalt_kapital_per_aksje" in f for f in feil)
+
+
+def test_valider_innbetalt_kapital_null_ok_etter_stiftelsesaar(eksempel_selskap):
+    # Innbetalt kapital = 0 er OK når selskapet ikke ble stiftet i inntektsåret.
+    aksjonaer = Aksjonaer(
+        navn="Etablert Nordmann",
+        fodselsnummer="20916997389",
+        antall_aksjer=100,
+        aksjeklasse="A",
+        utbytte_utbetalt=0,
+        innbetalt_kapital_per_aksje=0,
+    )
+    oppgave = Aksjonaerregisteroppgave(
+        selskap=eksempel_selskap,  # stiftelsesaar=2020
+        regnskapsaar=2024,
+        aksjonaerer=[aksjonaer],
+    )
+    feil = valider(oppgave)
+    assert not any("innbetalt_kapital_per_aksje" in f for f in feil)
+
+
+# ---------------------------------------------------------------------------
+# valider_mot_brg
+# ---------------------------------------------------------------------------
+
+def _brg_mock(status_code: int = 200, json_data: dict | None = None):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.is_success = 200 <= status_code < 300
+    resp.json.return_value = json_data or {}
+    return resp
+
+
+@patch("wenche.aksjonaerregister.httpx.get")
+def test_valider_mot_brg_samsvar_gir_ingen_advarsel(mock_get, eksempel_oppgave):
+    mock_get.return_value = _brg_mock(json_data={"stiftelsesdato": "2020-06-15"})
+    assert valider_mot_brg(eksempel_oppgave) == []
+
+
+@patch("wenche.aksjonaerregister.httpx.get")
+def test_valider_mot_brg_mismatch_gir_advarsel(mock_get, eksempel_oppgave):
+    # BRG har 2018, config har 2020 → mismatch.
+    mock_get.return_value = _brg_mock(json_data={"stiftelsesdato": "2018-12-11"})
+    advarsler = valider_mot_brg(eksempel_oppgave)
+    assert len(advarsler) == 1
+    assert "MAKS_025" in advarsler[0]
+    assert "2018" in advarsler[0]
+    assert "2020" in advarsler[0]
+
+
+@patch("wenche.aksjonaerregister.httpx.get")
+def test_valider_mot_brg_404_gir_advarsel_om_ukjent_orgnr(mock_get, eksempel_oppgave):
+    mock_get.return_value = _brg_mock(status_code=404)
+    advarsler = valider_mot_brg(eksempel_oppgave)
+    assert len(advarsler) == 1
+    assert "ikke funnet" in advarsler[0].lower()
+
+
+@patch("wenche.aksjonaerregister.httpx.get")
+def test_valider_mot_brg_nettverksfeil_returnerer_tom_liste(mock_get, eksempel_oppgave):
+    # Transient feil skal ikke blokkere innsending.
+    mock_get.side_effect = httpx.ConnectError("Connection refused")
+    assert valider_mot_brg(eksempel_oppgave) == []
+
+
+@patch("wenche.aksjonaerregister.httpx.get")
+def test_valider_mot_brg_5xx_returnerer_tom_liste(mock_get, eksempel_oppgave):
+    mock_get.return_value = _brg_mock(status_code=503)
+    assert valider_mot_brg(eksempel_oppgave) == []
+
+
+@patch("wenche.aksjonaerregister.httpx.get")
+def test_valider_mot_brg_uten_stiftelsesdato_i_svar(mock_get, eksempel_oppgave):
+    # BRG-svar uten stiftelsesdato (uvanlig, men håndteres trygt).
+    mock_get.return_value = _brg_mock(json_data={"navn": "TEST AS"})
+    assert valider_mot_brg(eksempel_oppgave) == []

--- a/tests/test_aksjonaerregister.py
+++ b/tests/test_aksjonaerregister.py
@@ -324,6 +324,65 @@ def test_valider_stiftelse_i_inntektsaar_krever_innbetalt_kapital(eksempel_selsk
     assert any("innbetalt_kapital_per_aksje" in f for f in feil)
 
 
+def test_valider_sum_innbetalt_matcher_aksjekapital_ved_nyemisjon(eksempel_selskap):
+    # Selskap stiftet i regnskapsåret med aksjekapital 30000, men aksjonæren bidrar
+    # bare 30 * 100 = 3000. Det skal trigge MAKH_053-sjekken.
+    aksjonaer = Aksjonaer(
+        navn="Underdekkende Nordmann",
+        fodselsnummer="20916997389",
+        antall_aksjer=100,
+        aksjeklasse="A",
+        utbytte_utbetalt=0,
+        innbetalt_kapital_per_aksje=30,
+    )
+    oppgave = Aksjonaerregisteroppgave(
+        selskap=eksempel_selskap,  # aksjekapital=30000, stiftelsesaar=2020
+        regnskapsaar=2020,
+        aksjonaerer=[aksjonaer],
+    )
+    feil = valider(oppgave)
+    assert any("Sum innbetalt kapital" in f for f in feil)
+
+
+def test_valider_sum_innbetalt_lik_aksjekapital_ok(eksempel_selskap):
+    # 100 aksjer * 300 = 30000, matcher selskapets aksjekapital.
+    aksjonaer = Aksjonaer(
+        navn="Korrekt Nordmann",
+        fodselsnummer="20916997389",
+        antall_aksjer=100,
+        aksjeklasse="A",
+        utbytte_utbetalt=0,
+        innbetalt_kapital_per_aksje=300,
+    )
+    oppgave = Aksjonaerregisteroppgave(
+        selskap=eksempel_selskap,
+        regnskapsaar=2020,
+        aksjonaerer=[aksjonaer],
+    )
+    feil = valider(oppgave)
+    assert not any("Sum innbetalt kapital" in f for f in feil)
+
+
+def test_valider_sum_innbetalt_ikke_sjekket_etter_stiftelsesaar(eksempel_selskap):
+    # Mismatch er OK når selskapet ikke ble stiftet i inntektsåret —
+    # da brukes ikke feltet i stiftelsestransaksjonen.
+    aksjonaer = Aksjonaer(
+        navn="Etablert Nordmann",
+        fodselsnummer="20916997389",
+        antall_aksjer=100,
+        aksjeklasse="A",
+        utbytte_utbetalt=0,
+        innbetalt_kapital_per_aksje=30,  # Mismatch, men ikke stiftelsesår
+    )
+    oppgave = Aksjonaerregisteroppgave(
+        selskap=eksempel_selskap,  # stiftelsesaar=2020
+        regnskapsaar=2024,
+        aksjonaerer=[aksjonaer],
+    )
+    feil = valider(oppgave)
+    assert not any("Sum innbetalt kapital" in f for f in feil)
+
+
 def test_valider_innbetalt_kapital_null_ok_etter_stiftelsesaar(eksempel_selskap):
     # Innbetalt kapital = 0 er OK når selskapet ikke ble stiftet i inntektsåret.
     aksjonaer = Aksjonaer(

--- a/wenche/aksjonaerregister.py
+++ b/wenche/aksjonaerregister.py
@@ -308,6 +308,19 @@ def valider(oppgave: Aksjonaerregisteroppgave) -> list[str]:
                     f"når selskapet er stiftet i inntektsåret ({oppgave.regnskapsaar})."
                 )
 
+        # Sum av aksjonærenes innbetalte kapital må matche selskapets aksjekapital
+        # ved nyemisjon. SKDs MAKH_053-regel: post 9 (selskap) = post 23 (aksjonærer).
+        sum_innbetalt = sum(
+            a.innbetalt_kapital_per_aksje * a.antall_aksjer for a in oppgave.aksjonaerer
+        )
+        if round(sum_innbetalt) != round(oppgave.selskap.aksjekapital):
+            feil.append(
+                f"Sum innbetalt kapital fra aksjonærer ({round(sum_innbetalt):,} kr) "
+                f"må matche selskapets aksjekapital ({round(oppgave.selskap.aksjekapital):,} kr) "
+                "ved nyemisjon. Juster antall_aksjer eller innbetalt_kapital_per_aksje per "
+                "aksjonær slik at summen blir lik aksjekapital."
+            )
+
     return feil
 
 

--- a/wenche/aksjonaerregister.py
+++ b/wenche/aksjonaerregister.py
@@ -14,10 +14,15 @@ Innsendingsflyt (SKDs eget REST-API, ikke Altinn-instansflyt):
 import os
 from xml.sax.saxutils import escape
 
+import httpx
 import yaml
 
 from wenche.models import Aksjonaer, Aksjonaerregisteroppgave, Selskap
 from wenche.skd_client import SkdAksjonaerClient
+
+# Brønnøysundregistrenes åpne Enhetsregister-API.
+# Brukes for å verifisere stiftelsesår mot SKDs forventning (MAKS_025-klassen).
+_BRG_ENHET_URL = "https://data.brreg.no/enhetsregisteret/api/enheter"
 
 
 def les_config(config_fil: str) -> Aksjonaerregisteroppgave:
@@ -247,6 +252,20 @@ def generer_underskjema_xml(
     return xml.encode("UTF-8")
 
 
+def _fnr_modulus11_ok(fnr: str) -> bool:
+    """Sjekker modulus-11-kontrollsifrene i et 11-sifret norsk fødselsnummer.
+
+    Returnerer False hvis kontrollsifrene ikke stemmer. Forutsetter at fnr
+    allerede er 11 siffer (kallsiden sjekker det først).
+    """
+    vekter1 = [3, 7, 6, 1, 8, 9, 4, 5, 2]
+    vekter2 = [5, 4, 3, 2, 7, 6, 5, 4, 3, 2]
+    siffer = [int(c) for c in fnr]
+    k1 = (11 - sum(v * d for v, d in zip(vekter1, siffer[:9])) % 11) % 11
+    k2 = (11 - sum(v * d for v, d in zip(vekter2, siffer[:10])) % 11) % 11
+    return k1 < 10 and k2 < 10 and k1 == siffer[9] and k2 == siffer[10]
+
+
 def valider(oppgave: Aksjonaerregisteroppgave) -> list[str]:
     feil = []
 
@@ -263,6 +282,11 @@ def valider(oppgave: Aksjonaerregisteroppgave) -> list[str]:
         fnr = a.fodselsnummer.replace(" ", "")
         if len(fnr) != 11 or not fnr.isdigit():
             feil.append(f"Ugyldig fødselsnummer for {a.navn}: må være 11 siffer.")
+        elif not _fnr_modulus11_ok(fnr):
+            feil.append(
+                f"Fødselsnummeret for {a.navn} har ugyldige kontrollsifre. "
+                "Dobbeltsjekk at sifrene er korrekt skrevet inn."
+            )
 
     total_aksjer = oppgave.totalt_antall_aksjer
     if total_aksjer <= 0:
@@ -274,7 +298,72 @@ def valider(oppgave: Aksjonaerregisteroppgave) -> list[str]:
             f"regnskapsåret ({oppgave.regnskapsaar})."
         )
 
+    # Ved stiftelse i inntektsåret må innbetalt_kapital_per_aksje være > 0,
+    # ellers blir AnskaffelsesverdiSamlet i stiftelsestransaksjonen 0 og SKD avviser.
+    if oppgave.selskap.stiftelsesaar == oppgave.regnskapsaar:
+        for a in oppgave.aksjonaerer:
+            if a.innbetalt_kapital_per_aksje <= 0:
+                feil.append(
+                    f"innbetalt_kapital_per_aksje må være > 0 for {a.navn} "
+                    f"når selskapet er stiftet i inntektsåret ({oppgave.regnskapsaar})."
+                )
+
     return feil
+
+
+def valider_mot_brg(
+    oppgave: Aksjonaerregisteroppgave, *, timeout: float = 5.0
+) -> list[str]:
+    """
+    Sjekker stiftelsesår mot Brønnøysundregistrene som ekstra forhåndsvalidering.
+
+    Returnerer liste med advarsler hvis stiftelsesåret i config ikke stemmer
+    med BRGs registrering. Tom liste hvis alt stemmer eller hvis BRG ikke
+    kan kontaktes (transient feil skal ikke blokkere innsending).
+
+    Brukes kun mot reelle org.nr. — syntetiske Tenor-orger finnes ikke i BRG.
+    """
+    orgnr = oppgave.selskap.org_nummer
+    try:
+        resp = httpx.get(
+            f"{_BRG_ENHET_URL}/{orgnr}",
+            headers={"Accept": "application/json"},
+            timeout=timeout,
+        )
+    except httpx.HTTPError:
+        return []
+
+    if resp.status_code == 404:
+        return [
+            f"Org.nr. {orgnr} ble ikke funnet i Brønnøysundregistrene. "
+            "Sjekk at org.nr. er korrekt."
+        ]
+    if not resp.is_success:
+        return []
+
+    try:
+        data = resp.json()
+    except ValueError:
+        return []
+
+    stiftelsesdato = data.get("stiftelsesdato")
+    if not stiftelsesdato or len(stiftelsesdato) < 4:
+        return []
+
+    try:
+        brg_stiftelsesaar = int(stiftelsesdato[:4])
+    except ValueError:
+        return []
+
+    if brg_stiftelsesaar != oppgave.selskap.stiftelsesaar:
+        return [
+            f"stiftelsesaar i config ({oppgave.selskap.stiftelsesaar}) stemmer "
+            f"ikke med Brønnøysundregistrenes registrering ({brg_stiftelsesaar}). "
+            "Dette er en vanlig årsak til avvikskode MAKS_025 fra Skatteetaten. "
+            "Oppdater stiftelsesaar i config.yaml før innsending."
+        ]
+
+    return []
 
 
 def send_inn(

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -2362,6 +2362,15 @@ def _bygg_send_fane() -> None:
             for f in feil:
                 ui.notify(f, type="negative")
             return
+
+        # BRG-stiftelsesårssjekk kun mot prod — Tenor-orger finnes ikke i BRG.
+        if env_valg.value == "prod":
+            brg_advarsler = await run.io_bound(akr_modul.valider_mot_brg, oppgave)
+            if brg_advarsler:
+                for advarsel in brg_advarsler:
+                    ui.notify(advarsel, type="negative", timeout=0, close_button="Lukk")
+                return
+
         n = ui.notification("Henter Maskinporten-token med SKD-scope...", spinner=True, timeout=None)
         try:
             skd_token = await run.io_bound(lambda: _med_env(env_valg.value, auth.get_skd_aksjonaer_token))
@@ -2377,8 +2386,25 @@ def _bygg_send_fane() -> None:
             n.type = "positive"
             n.timeout = 0
             n.close_button = "Lukk"
-            if svar:
-                ui.notify(f"Forsendelse-ID: {svar.get('forsendelseId')}", type="info")
+            aksjonaer_resultat.clear()
+            with aksjonaer_resultat:
+                if svar and svar.get("forsendelseId"):
+                    ui.label(f"Forsendelse-ID: {svar['forsendelseId']}").classes(
+                        "text-xs text-slate-500"
+                    )
+                ui.label(
+                    "Skatteetaten kontrollerer oppgaven og sender en tilbakemelding i "
+                    "Altinn meldingsboks i løpet av minutter. Hvis oppgaven blir avvist, "
+                    "vil tilbakemeldingen forklare hva som må rettes."
+                ).classes("text-sm text-slate-600 mt-1")
+                altinn_base = "https://tt02.altinn.no" if env_valg.value == "test" else "https://af.altinn.no"
+                meldingsboks_url = (
+                    f"{altinn_base}/?party=urn%3Aaltinn%3Aorganization%3Aidentifier-no%3A"
+                    f"{oppgave.selskap.org_nummer}"
+                )
+                ui.link("Åpne Altinn meldingsboks →", meldingsboks_url, new_tab=True).classes(
+                    "text-blue-600 font-medium"
+                )
         except Exception as e:
             n.message = f"Innsending feilet: {e}"
             n.spinner = False
@@ -2442,6 +2468,7 @@ def _bygg_send_fane() -> None:
         ).props("color=primary").classes("w-full")
 
     aarsregnskap_resultat = ui.column().classes("mt-3")
+    aksjonaer_resultat = ui.column().classes("mt-3")
 
 
 # ---------------------------------------------------------------------------

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -598,6 +598,11 @@ class AppState:
 
 # Globalt tilstandsobjekt — initialisert fra config.yaml ved oppstart
 state = AppState()
+
+# Refresh-callback for aksjonær-konsistens-indikatoren. Settes når Aksjonær-
+# fanen bygges, og kalles fra Selskap-fanen når aksjekapital eller stiftelses-
+# år endres, så indikatoren reflekterer ny verdi når brukeren bytter tilbake.
+_aksjonaer_liste_refresh: callable | None = None
 state.les_config()
 
 
@@ -1840,19 +1845,26 @@ def _bygg_selskap_fane() -> None:
     ui.separator().classes("my-2")
 
     with ui.grid(columns=2).classes("w-full gap-4"):
+        # Endringer på disse feltene må også refreshe Aksjonær-fanens
+        # konsistens-indikator, slik at den reflekterer ny verdi når brukeren
+        # bytter tilbake.
+        def oppdater_aksjonaer_indikator():
+            if _aksjonaer_liste_refresh is not None:
+                _aksjonaer_liste_refresh()
+
         txt("Selskapsnavn", "navn")
         txt("Forretningsadresse", "forretningsadresse")
         txt("Organisasjonsnummer (9 siffer)", "org_nummer", placeholder="123456789")
-        num("Stiftelsesår", "stiftelsesaar", step=1, min_val=1900)
+        num("Stiftelsesår", "stiftelsesaar", step=1, min_val=1900, on_change=oppdater_aksjonaer_indikator)
         txt("Daglig leder", "daglig_leder")
-        num("Aksjekapital (NOK)", "aksjekapital", step=1000)
+        num("Aksjekapital (NOK)", "aksjekapital", step=1000, on_change=oppdater_aksjonaer_indikator)
         txt("Styreleder", "styreleder")
         txt(
             "Kontakt-e-post",
             "kontakt_epost",
             tooltip="Påkrevd for aksjonærregisteroppgave (RF-1086).",
         )
-        num("Regnskapsår", "regnskapsaar", step=1, min_val=2000)
+        num("Regnskapsår", "regnskapsaar", step=1, min_val=2000, on_change=oppdater_aksjonaer_indikator)
 
     ui.separator().classes("my-4")
 
@@ -2030,6 +2042,42 @@ def _bygg_aksjonaer_fane() -> None:
 
     @ui.refreshable
     def aksjonaer_liste() -> None:
+        # Konsistens-indikator: ved stiftelse i inntektsåret må sum av
+        # (antall_aksjer * innbetalt_kapital_per_aksje) matche selskapets
+        # aksjekapital, ellers avvises oppgaven av SKD (avvikskode MAKH_053).
+        if state.stiftelsesaar == state.regnskapsaar:
+            sum_innbetalt = sum(
+                a.innbetalt_kapital_per_aksje * a.antall_aksjer for a in state.aksjonaerer
+            )
+            stemmer = round(sum_innbetalt) == round(state.aksjekapital)
+            if stemmer:
+                with ui.row().classes(
+                    "items-center gap-2 p-3 mb-3 bg-emerald-50 "
+                    "border border-emerald-200 rounded-lg"
+                ):
+                    ui.icon("check_circle").classes("text-emerald-600")
+                    ui.label(
+                        f"Sum innbetalt kapital ({round(sum_innbetalt):,} kr) matcher "
+                        f"selskapets aksjekapital."
+                    ).classes("text-sm text-emerald-900")
+            else:
+                diff = round(state.aksjekapital) - round(sum_innbetalt)
+                with ui.row().classes(
+                    "items-start gap-2 p-3 mb-3 bg-amber-50 "
+                    "border border-amber-200 rounded-lg"
+                ):
+                    ui.icon("warning").classes("text-amber-600 mt-0.5")
+                    with ui.column().classes("gap-1"):
+                        ui.label("Sum innbetalt kapital matcher ikke aksjekapital").classes(
+                            "text-sm font-medium text-amber-900"
+                        )
+                        ui.label(
+                            f"Selskapets aksjekapital er {round(state.aksjekapital):,} kr, "
+                            f"men sum innbetalt fra aksjonærer er {round(sum_innbetalt):,} kr "
+                            f"(diff: {diff:+,} kr). SKD avviser oppgaven ved stiftelse "
+                            "hvis tallene ikke matcher."
+                        ).classes("text-xs text-amber-800")
+
         for i, a in enumerate(state.aksjonaerer):
             with ui.expansion(
                 f"Aksjonær {i + 1}" + (f", {a.navn}" if a.navn else ""),
@@ -2041,11 +2089,12 @@ def _bygg_aksjonaer_fane() -> None:
                     # ødelegge fokus mens brukeren skriver.
                     navn_inp = txt("Navn", "navn", obj=a)
                     navn_inp.on("blur", lambda _: aksjonaer_liste.refresh())
-                    num("Antall aksjer", "antall_aksjer", obj=a, step=1, min_val=1)
+                    antall_inp = num("Antall aksjer", "antall_aksjer", obj=a, step=1, min_val=1)
+                    antall_inp.on("blur", lambda _: aksjonaer_liste.refresh())
                     txt("Fødselsnummer (11 siffer)", "fodselsnummer", obj=a)
                     num("Utbytte utbetalt (NOK)", "utbytte_utbetalt", obj=a, min_val=0)
                     txt("Aksjeklasse", "aksjeklasse", obj=a)
-                    num(
+                    innbetalt_inp = num(
                         "Innbetalt kapital per aksje (NOK)",
                         "innbetalt_kapital_per_aksje",
                         obj=a,
@@ -2053,6 +2102,7 @@ def _bygg_aksjonaer_fane() -> None:
                         min_val=0,
                         tooltip="Aksjekapital delt på antall aksjer. Eks: 30 000 kr / 100 aksjer = 300 kr per aksje.",
                     )
+                    innbetalt_inp.on("blur", lambda _: aksjonaer_liste.refresh())
 
                 if len(state.aksjonaerer) > 1:
                     def fjern(idx=i):
@@ -2061,6 +2111,9 @@ def _bygg_aksjonaer_fane() -> None:
                     ui.button("Fjern aksjonær", on_click=fjern).props("flat color=negative size=sm").classes("mt-2")
 
     aksjonaer_liste()
+
+    global _aksjonaer_liste_refresh
+    _aksjonaer_liste_refresh = aksjonaer_liste.refresh
 
     def legg_til():
         state.aksjonaerer.append(AksjonaerState())


### PR DESCRIPTION
## Bakgrunn

Test-innsending av aksjonærregisteroppgave 2026-05-20 ble avvist av Skatteetaten med avvikskode `MAKS_025`: «Selskapet har aksjekapital eller aksjer per 01.01, men er enten stiftet i inntektsåret eller var ikke skattepliktig ifjor.» Wenche fikk grønt svar på innledende `bekreft`-kallet, og brukeren oppdaget feilen først ved manuelt å logge inn i Altinn meldingsboks.

Den konkrete trigeren var at `config.yaml` hadde feil `stiftelsesaar` for Tenor-orgen, men samme klasse av feil kan ramme reelle innsendinger hvis brukeren har lagt inn feil verdi.

## Endringer

### Utvidet `valider()` i `wenche/aksjonaerregister.py`

- **Modulus-11 kontrollsifre på fødselsnummer.** Fanger reelle typos, ikke bare manglende siffer.
- **Krav om `innbetalt_kapital_per_aksje > 0` kun når selskapet er stiftet i inntektsåret.** Feltet brukes i stiftelsestransaksjonen, så 0 her gir XML som SKD avviser. Etablerte selskaper kan fortsatt ha 0 uten å bli blokkert.

### Ny `valider_mot_brg(oppgave)`

- Slår opp `stiftelsesdato` i Brønnøysundregistrenes Enhetsregister og sammenligner med `stiftelsesaar` i config. Mismatch er en av de vanligste trigerne for `MAKS_025`.
- Transient feil mot BRG eller manglende `stiftelsesdato` returnerer tom liste, så det aldri blokkerer innsending.
- Kalles fra UI kun mot prod, siden Tenor-orger ikke finnes i BRG.

### Altinn meldingsboks-lenke i UI

Etter vellykket innsending vises et infoavsnitt med direktelink til Altinn meldingsboks for orgnr. Test-modus peker til `tt02.altinn.no`, prod til `af.altinn.no`. SKDs tilbakemelding kommer typisk innen minutter, så lenken gjør det enkelt å verifisere godkjenning eller se avvikskoder.

### Versjon

`pyproject.toml`: 0.13.1 → 0.14.0 (minor bump, ny synlig validerings- og UX-funksjonalitet).

## Bevisst utelatt

Forhåndsvalidering av SKD-regler generelt (f.eks. balanse-konsistens, kompliserte aksjeklasse-regler) er ikke forsøkt. SKD har dusinvis av kontrollregler som endres uavhengig av Wenche, så det er bedre å la SKD være autoritativ kilde og gjøre tilbakemeldingen lett tilgjengelig.

## Test plan

- [x] 223 enhetstester passerer, inkludert 6 nye for `valider()`-utvidelsene og 5 nye for `valider_mot_brg`
- [x] Modulus-11 verifisert mot kjent Tenor-fnr `20916997389` (valid) og bevisst korrupt `20916997380` (invalid)
- [x] BRG-test verifiserer at HTTP 404, 5xx og nettverksfeil aldri blokkerer
- [x] Manuell test: korriger `config.yaml stiftelsesaar` for Tenor-org og send på nytt mot tt02 for å verifisere at innsendingen nå går gjennom uten avvik
- [x] Manuell test: trigger BRG-mismatch i prod-modus mot egen org og verifiser at advarselen vises