### PR TITLE
fix(ui): tilpass upload-handlere til NiceGUI 3.x sitt nye event-API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.14.0"
+version = "0.14.1"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1458,21 +1458,20 @@ def _bygg_oppsett_fane() -> None:
         "test- og prod-klienten i Digdir."
     ).classes("text-sm text-slate-500 mb-3")
 
+    pem_bytes_holder: list[bytes] = []
+
+    async def pem_mottatt(e):
+        pem_bytes_holder.clear()
+        pem_bytes_holder.append(await e.file.read())
+        ui.notify("Nøkkelfil lastet opp. Klikk 'Lagre konfigurasjon' for å lagre.", type="info")
+
     pem_opplasting = ui.upload(
         label="Last opp privat nøkkel (.pem)",
         auto_upload=True,
+        on_upload=pem_mottatt,
     ).props("flat bordered").classes("w-full").tooltip(
         "Din maskinporten_privat.pem-fil. Lagres lokalt og sendes aldri til noen server."
     )
-
-    pem_bytes_holder: list[bytes] = []
-
-    def pem_mottatt(e):
-        pem_bytes_holder.clear()
-        pem_bytes_holder.append(e.content.read())
-        ui.notify("Nøkkelfil lastet opp. Klikk 'Lagre konfigurasjon' for å lagre.", type="info")
-
-    pem_opplasting.on_upload(pem_mottatt)
 
     async def lagre_konfig():
         from dotenv import set_key
@@ -1795,17 +1794,16 @@ def _bygg_selskap_fane() -> None:
 
         saft_bytes_holder: list[bytes] = []
 
+        async def saft_mottatt(e):
+            saft_bytes_holder.clear()
+            saft_bytes_holder.append(await e.file.read())
+            ui.notify(f"Fil lastet opp: {e.file.name}", type="info")
+
         saft_opplasting = ui.upload(
             label="Last opp SAF-T Financial XML-fil",
             auto_upload=True,
+            on_upload=saft_mottatt,
         ).props("flat bordered").classes("w-full")
-
-        def saft_mottatt(e):
-            saft_bytes_holder.clear()
-            saft_bytes_holder.append(e.content.read())
-            ui.notify(f"Fil lastet opp: {e.name}", type="info")
-
-        saft_opplasting.on_upload(saft_mottatt)
 
         async def importer_saft():
             if not saft_bytes_holder:


### PR DESCRIPTION
## Problem

Brukeren ser SAF-T-filen markert som ferdig opplastet i Quasar-uploaderen (haket av), men «Importer SAF-T»-knappen gir likevel meldingen «Last opp en SAF-T-fil først». Samme symptom finnes i Maskinporten-nøkkelopplastingen i Oppsett-fanen.

## Rotårsak

NiceGUI 3.x endret `UploadEventArguments` fra `(content, name)` til en `(file)`-attributt med en `FileUpload`-klasse:

- `e.content` finnes ikke lenger. Bruk `e.file`.
- `e.name` finnes ikke. Bruk `e.file.name`.
- `read()` er nå async. Bruk `await e.file.read()`.

Wenches handlere brukte 2.x-API-et (`e.content.read()`, `e.name`), så de kastet `AttributeError` stille når Quasar leverte filen til serveren. Byte-holderen ble aldri fylt, og «Importer»-knappen så en tom liste.

`pyproject.toml` har `nicegui>=2.0`, men brukeren har installert 3.9.0 lokalt. Bugen har vært latent siden NiceGUI 3.0 ble sluppet.

## Endringer

- `wenche/ui.py`: SAF-T-handler og PEM-nøkkel-handler oppdatert til 3.x-API. Begge er nå `async`, og `on_upload` er flyttet til `ui.upload(...)`-parameteren (anbefalt form i 3.x).
- `pyproject.toml`: 0.14.0 → 0.14.1

## Test plan

- [x] 226 enhetstester passerer
- [x] `wenche.ui` importerer uten feil
- [x] Manuell test: last opp SAF-T-fil og klikk «Importer SAF-T» — skal nå importere og vise toast med filnavn
- [x] Manuell test: last opp .pem-fil i Oppsett og lagre konfigurasjon