### PR TITLE
fix(ui): legg til Lagre-knapp i Dokumenter-fanen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.14.1"
+version = "0.14.2"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -2171,6 +2171,14 @@ def _bygg_dokumenter_fane() -> None:
                 min_val=0,
             )
 
+    def lagre_dokumenter():
+        state.lagre_config()
+        ui.notify(f"Lagret til {CONFIG_FIL.resolve()}", type="positive")
+
+    ui.button("Lagre innstillinger og noter", on_click=lagre_dokumenter).props(
+        "color=primary"
+    ).classes("mb-4")
+
     ui.separator().classes("my-4")
 
     # Nedlastinger


### PR DESCRIPTION
## Problem

Brukerrapport 2026-05-20: «Jeg har endret verdiene [for framførbart underskudd, fritaksmetoden, eierandel i datterselskap]. Men jeg ser at det ikke er noen lagre-knapp i dette viewet. Så jeg lurer på om det ikke skrives til config.yaml filen?»

Bekreftet: Dokumenter-fanen mangler en Lagre-knapp. Endringer i skattemelding-innstillinger og noter-feltene oppdaterer state i minnet (slik at innsending innenfor samme sesjon bruker riktig verdi), men persisteres ikke til config.yaml. Restart av appen mister verdiene.

Selskap, Regnskap og Aksjonær-fanene har egne Lagre-knapper. Dokumenter-fanen ble glemt.

## Endring

Legger til «Lagre innstillinger og noter»-knapp etter skattemelding-innstillinger-seksjonen, etter samme mønster som de andre fanene. Knappen kaller `state.lagre_config()` og viser en bekreftelsestoast.

## Versjon

`pyproject.toml`: 0.14.1 → 0.14.2 (patch bump, ren bugfix)

## Test plan

- [x] 226 enhetstester passerer
- [x] `wenche.ui` importerer uten feil
- [x] Manuell test: endre skattemelding-innstillinger, klikk Lagre, restart app, verifiser at verdiene er bevart