### PR TITLE
feat(ui): SAF-T-import for foregående år sine sammenligningstall

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.14.2"
+version = "0.15.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -2052,6 +2052,7 @@ def _bygg_regnskap_fane() -> None:
                         yaml.dump(eks, f, allow_unicode=True, sort_keys=False)
 
                     state.les_config()
+                    foregaaende_aar_felter.refresh()
 
                     r = data["resultatregnskap"]
                     rentekost = r["finansposter"]["rentekostnader"]
@@ -2059,8 +2060,7 @@ def _bygg_regnskap_fane() -> None:
                     ui.notify(
                         f"Sammenligningstall importert fra SAF-T {saft_aar}: "
                         f"andre driftskostnader {andre_drift:.0f} kr, "
-                        f"rentekostnader {rentekost:.0f} kr. "
-                        "Naviger bort og tilbake for å se de oppdaterte feltene under.",
+                        f"rentekostnader {rentekost:.0f} kr.",
                         type="positive",
                         timeout=0,
                         close_button="Lukk",
@@ -2077,36 +2077,42 @@ def _bygg_regnskap_fane() -> None:
                 "color=primary outline"
             ).classes("mt-2")
 
-        ui.label("Resultatregnskap").classes("text-base font-semibold mt-2 mb-2")
-        with ui.grid(columns=2).classes("w-full gap-4"):
-            num("Salgsinntekter", "f_salgsinntekter")
-            num("Utbytte fra datterselskap", "f_utbytte_fra_datterselskap")
-            num("Andre driftsinntekter", "f_andre_driftsinntekter")
-            num("Andre finansinntekter", "f_andre_finansinntekter")
-            num("Lønnskostnader", "f_loennskostnader")
-            num("Rentekostnader", "f_rentekostnader")
-            num("Avskrivninger", "f_avskrivninger")
-            num("Andre finanskostnader", "f_andre_finanskostnader")
-            num("Andre driftskostnader", "f_andre_driftskostnader")
+        # Inntastingsfeltene pakkes i en refreshable så de kan re-rendres
+        # med oppdaterte verdier etter SAF-T-import for foregående år.
+        @ui.refreshable
+        def foregaaende_aar_felter() -> None:
+            ui.label("Resultatregnskap").classes("text-base font-semibold mt-2 mb-2")
+            with ui.grid(columns=2).classes("w-full gap-4"):
+                num("Salgsinntekter", "f_salgsinntekter")
+                num("Utbytte fra datterselskap", "f_utbytte_fra_datterselskap")
+                num("Andre driftsinntekter", "f_andre_driftsinntekter")
+                num("Andre finansinntekter", "f_andre_finansinntekter")
+                num("Lønnskostnader", "f_loennskostnader")
+                num("Rentekostnader", "f_rentekostnader")
+                num("Avskrivninger", "f_avskrivninger")
+                num("Andre finanskostnader", "f_andre_finanskostnader")
+                num("Andre driftskostnader", "f_andre_driftskostnader")
 
-        ui.label("Balanse").classes("text-base font-semibold mt-4 mb-2")
-        with ui.grid(columns=2).classes("w-full gap-4"):
-            num("Aksjer i datterselskap", "f_aksjer_i_datterselskap")
-            num("Aksjekapital", "f_ek_aksjekapital")
-            num("Andre aksjer", "f_andre_aksjer")
-            num("Overkursfond", "f_overkursfond", min_val=None)
-            num("Langsiktige fordringer", "f_langsiktige_fordringer")
-            num("Annen egenkapital", "f_annen_egenkapital", min_val=None)
-            num("Kortsiktige fordringer", "f_kortsiktige_fordringer")
-            num("Lån fra aksjonær", "f_laan_fra_aksjonaer")
-            num("Bankinnskudd", "f_bankinnskudd", step=100)
-            num("Andre langsiktige lån", "f_andre_langsiktige_laan")
-            ui.label("").classes("w-full")
-            num("Leverandørgjeld", "f_leverandoergjeld")
-            ui.label("").classes("w-full")
-            num("Skyldige offentlige avgifter", "f_skyldige_offentlige_avgifter")
-            ui.label("").classes("w-full")
-            num("Annen kortsiktig gjeld", "f_annen_kortsiktig_gjeld")
+            ui.label("Balanse").classes("text-base font-semibold mt-4 mb-2")
+            with ui.grid(columns=2).classes("w-full gap-4"):
+                num("Aksjer i datterselskap", "f_aksjer_i_datterselskap")
+                num("Aksjekapital", "f_ek_aksjekapital")
+                num("Andre aksjer", "f_andre_aksjer")
+                num("Overkursfond", "f_overkursfond", min_val=None)
+                num("Langsiktige fordringer", "f_langsiktige_fordringer")
+                num("Annen egenkapital", "f_annen_egenkapital", min_val=None)
+                num("Kortsiktige fordringer", "f_kortsiktige_fordringer")
+                num("Lån fra aksjonær", "f_laan_fra_aksjonaer")
+                num("Bankinnskudd", "f_bankinnskudd", step=100)
+                num("Andre langsiktige lån", "f_andre_langsiktige_laan")
+                ui.label("").classes("w-full")
+                num("Leverandørgjeld", "f_leverandoergjeld")
+                ui.label("").classes("w-full")
+                num("Skyldige offentlige avgifter", "f_skyldige_offentlige_avgifter")
+                ui.label("").classes("w-full")
+                num("Annen kortsiktig gjeld", "f_annen_kortsiktig_gjeld")
+
+        foregaaende_aar_felter()
 
     ui.separator().classes("my-4")
 

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1989,6 +1989,94 @@ def _bygg_regnskap_fane() -> None:
             "Disse brukes som sammenligningstall i årsregnskapet til Brønnøysundregistrene."
         ).classes("text-sm text-slate-500 mb-3")
 
+        # SAF-T-import for foregående år
+        with ui.card().classes("w-full p-3 mb-4 bg-slate-50 shadow-none border border-slate-200 rounded-lg"):
+            ui.label("Importer fra SAF-T (foregående år)").classes(
+                "text-sm font-semibold text-slate-700 mb-1"
+            )
+            ui.label(
+                "Last opp en SAF-T Financial-fil for fjoråret for å fylle inn "
+                "resultatregnskap og balanse automatisk."
+            ).classes("text-xs text-slate-500 mb-2")
+
+            fjor_saft_holder: list[bytes] = []
+
+            async def fjor_saft_mottatt(e):
+                fjor_saft_holder.clear()
+                fjor_saft_holder.append(await e.file.read())
+                ui.notify(f"Fil lastet opp: {e.file.name}", type="info")
+
+            ui.upload(
+                label="Last opp SAF-T-fil for foregående år",
+                auto_upload=True,
+                on_upload=fjor_saft_mottatt,
+            ).props("flat bordered").classes("w-full")
+
+            async def importer_fjor_saft():
+                if not fjor_saft_holder:
+                    ui.notify("Last opp en SAF-T-fil først.", type="warning")
+                    return
+                from wenche.saft import importer as importer_saft_fil
+                try:
+                    with tempfile.NamedTemporaryFile(suffix=".xml", delete=False) as tmp:
+                        tmp.write(fjor_saft_holder[0])
+                        tmp_sti = tmp.name
+
+                    data = await run.io_bound(importer_saft_fil, tmp_sti)
+                    Path(tmp_sti).unlink(missing_ok=True)
+
+                    saft_aar = int(data.get("regnskapsaar", 0))
+                    forventet_aar = int(state.regnskapsaar) - 1
+                    if saft_aar != forventet_aar:
+                        ui.notify(
+                            f"Advarsel: SAF-T er for år {saft_aar}, forventet {forventet_aar}. "
+                            "Verdier ble likevel importert som foregående år.",
+                            type="warning",
+                            timeout=0,
+                            close_button="Lukk",
+                        )
+
+                    eks = {}
+                    if CONFIG_FIL.exists():
+                        with open(CONFIG_FIL, encoding="utf-8") as f_eks:
+                            eks = yaml.safe_load(f_eks) or {}
+
+                    # SAF-T-en for fjoråret har fjorårets resultat og fjorårets closing balanse.
+                    # Disse er nettopp det vi trenger som sammenligningstall i inneværende år.
+                    eks["foregaaende_aar"] = {
+                        "resultatregnskap": data["resultatregnskap"],
+                        "balanse": data["balanse"],
+                    }
+
+                    with open(CONFIG_FIL, "w", encoding="utf-8") as f:
+                        yaml.dump(eks, f, allow_unicode=True, sort_keys=False)
+
+                    state.les_config()
+
+                    r = data["resultatregnskap"]
+                    rentekost = r["finansposter"]["rentekostnader"]
+                    andre_drift = r["driftskostnader"]["andre_driftskostnader"]
+                    ui.notify(
+                        f"Sammenligningstall importert fra SAF-T {saft_aar}: "
+                        f"andre driftskostnader {andre_drift:.0f} kr, "
+                        f"rentekostnader {rentekost:.0f} kr. "
+                        "Naviger bort og tilbake for å se de oppdaterte feltene under.",
+                        type="positive",
+                        timeout=0,
+                        close_button="Lukk",
+                    )
+                except Exception as e:
+                    ui.notify(
+                        f"Feil ved import: {e}",
+                        type="negative",
+                        timeout=0,
+                        close_button="Lukk",
+                    )
+
+            ui.button("Importer SAF-T for foregående år", on_click=importer_fjor_saft).props(
+                "color=primary outline"
+            ).classes("mt-2")
+
         ui.label("Resultatregnskap").classes("text-base font-semibold mt-2 mb-2")
         with ui.grid(columns=2).classes("w-full gap-4"):
             num("Salgsinntekter", "f_salgsinntekter")


### PR DESCRIPTION
## Bakgrunn

Regnskapsloven §6-6 krever at årsregnskap inneholder sammenligningstall fra foregående år. SAF-T-importen for inneværende år henter kun balanse-åpning fra forrige år (siden P&L-kontoer nullstilles ved årsavslutning), så foregående års resultatregnskap måtte fylles inn manuelt.

Brukerrapport 2026-05-20: hadde 2024 SAF-T tilgjengelig, ønsket å laste opp denne for å fylle inn sammenligningstall automatisk.

## Endring

Legger til en ny SAF-T-import-seksjon i Regnskap-fanen, plassert som et kort øverst i Sammenligningstall-ekspansjonen. Bruker laster opp en separat SAF-T-fil for fjoråret.

- Gjenbruker eksisterende `saft.importer()`-funksjon
- Mapper fjorårets resultatregnskap og balanse til `foregaaende_aar` i config.yaml
- Bevarer andre felt i config.yaml (selskap, aksjonærer, noter, etc.)
- Inkluderer årsverifikasjon: hvis SAF-T ikke er for regnskapsår - 1, vises en advarsel men import gjennomføres uansett
- Notification etter import oppsummerer nøkkeltall (andre driftskostnader, rentekostnader) så bruker kan verifisere uten å bytte fane

## Versjon

`pyproject.toml`: 0.14.2 → 0.15.0 (minor bump, ny synlig funksjonalitet)

## Test plan

- [x] 226 enhetstester passerer
- [x] `wenche.ui` importerer uten feil
- [x] Manuell test: last opp 2024 SAF-T, verifiser at foregaaende_aar i config.yaml oppdateres med fjorårets resultatregnskap (spesielt rentekostnader 1550 for OFL Holding) og balanse
- [x] Manuell test: last opp feil-år SAF-T (f.eks. 2023), verifiser at advarsel vises men import gjennomføres