### PR TITLE
fix(brg_xml): klassifiser lån fra aksjonær som annen langsiktig gjeld, ikke konserngjeld

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.15.0"
+version = "0.15.1"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_brg_xml_fixes.py
+++ b/tests/test_brg_xml_fixes.py
@@ -170,7 +170,6 @@ class TestLinjeEnkel:
         "rentekostnad",
         "annenRenteinntekt",
         "overkursfond",
-        "langsiktigKonserngjeld",
         "leverandoergjeld",
     ]
 
@@ -223,11 +222,24 @@ class TestLinjeEnkel:
         assert el is not None
         assert int(el.text) == 39000
 
-    def test_langsiktig_konserngjeld_value(self, regnskap_med_alle_poster):
+    def test_laan_fra_aksjonaer_klassifisert_som_annen_langsiktig_gjeld(
+        self, regnskap_med_alle_poster
+    ):
+        """Lån fra aksjonær skal ikke klassifiseres som konserngjeld i BRG-XML
+        for et selskap som ikke er morselskap. Skal i stedet være en
+        oevrigLangsiktigGjeld-linje med beskrivelse 'Lån fra aksjonær'."""
         root = _parse(generer_underskjema(regnskap_med_alle_poster))
-        el = root.find(f".//{{{NS}}}langsiktigKonserngjeld/{{{NS}}}aarets")
-        assert el is not None
-        assert int(el.text) == 300000
+        # langsiktigKonserngjeld skal ikke lenger forekomme
+        assert root.find(f".//{{{NS}}}langsiktigKonserngjeld") is None
+        # Lån fra aksjonær skal være en oevrigLangsiktigGjeld med riktig beskrivelse
+        for el in root.findall(f".//{{{NS}}}oevrigLangsiktigGjeld"):
+            besk = el.find(f"{{{NS}}}beskrivelse")
+            if besk is not None and besk.text == "Lån fra aksjonær":
+                aarets = el.find(f"{{{NS}}}aarets")
+                assert aarets is not None
+                assert int(aarets.text) == 300000
+                return
+        assert False, "Fant ikke oevrigLangsiktigGjeld med 'Lån fra aksjonær'-beskrivelse"
 
     def test_zero_values_omitted(self, eksempel_regnskap):
         """linje_enkel with 0 for both years should produce no element."""

--- a/wenche/brg_xml.py
+++ b/wenche/brg_xml.py
@@ -395,7 +395,7 @@ def generer_underskjema(regnskap: Aarsregnskap) -> bytes:
             <fjoraarets orid="7156">{_i(flg.sum)}</fjoraarets>
           </sumLangsiktigGjeld>
           <annenLangsiktigGjeld>
-            {linje_enkel("langsiktigKonserngjeld", lg.laan_fra_aksjonaer, "2256", "7152", flg.laan_fra_aksjonaer)}
+            {linje("oevrigLangsiktigGjeld", lg.laan_fra_aksjonaer, "Lån fra aksjonær", "29036", "242", "7155", flg.laan_fra_aksjonaer)}
             {linje("oevrigLangsiktigGjeld", lg.andre_langsiktige_laan, "Andre langsiktige lån", "29036", "242", "7155", flg.andre_langsiktige_laan)}
             <sumAnnenLangsiktigGjeld>
               <aarets orid="25019">{_i(lg.sum)}</aarets>


### PR DESCRIPTION
## Problem

Wenche mappet `laan_fra_aksjonaer` til BRG-feltet `langsiktigKonserngjeld` i årsregnskap-XML. Det er semantisk uriktig for et selskap som ikke er morselskap. Hovedskjemaet setter `morselskap=nei` for alle Wenche-genererte årsregnskap, så et lån fra personlig aksjonær til et passivt holdingselskap er ikke konserngjeld. Det er annen langsiktig gjeld med spesifikk identifikasjon.

Oppdaget under gjennomgang av OFL Holding sin 2025-årsregnskap-XML 2026-05-20.

## Konsekvens av bug-en

BRG ville sannsynligvis godta XML-en fordi schema-validering passerer (langsiktigKonserngjeld er et gyldig BRG-felt). Men selskapets gjeld ble feilkategorisert i BRG-databasen som «konserngjeld» selv om selskapet ikke er i et konsernforhold. Det kunne være misvisende for revisor, bank eller andre som leser offentlige regnskaper.

## Endring

Mappingen flyttes fra `<langsiktigKonserngjeld>` (orid 2256/7152, single-occurrence) til `<oevrigLangsiktigGjeld>` (orid 242/7155, unbounded med beskrivelse). Bruker beskrivelsen «Lån fra aksjonær» så det fortsatt er tydelig hva posten representerer i den genererte XML-en.

Eksisterende test for langsiktigKonserngjeld er erstattet med en ny test som eksplisitt verifiserer at langsiktigKonserngjeld ikke forekommer, og at lånet i stedet er klassifisert som `oevrigLangsiktigGjeld` med riktig beskrivelse.

## Tradeoff

Mappingen er trygg for Wenches målgruppe (små holdingsselskaper) siden de typisk ikke er i konsernforhold. Hvis fremtidige brukere er morselskap og virkelig trenger konserngjeld-klassifisering, må det legges til en eksplisitt flag som styrer mappingen. For nå er den mer korrekte default-klassifikasjonen «annen langsiktig gjeld».

## Versjon

`pyproject.toml`: 0.15.0 → 0.15.1 (patch bump, ren bugfix)

## Test plan

- [x] 226 enhetstester passerer
- [x] Ny test verifiserer at langsiktigKonserngjeld ikke forekommer
- [x] Ny test verifiserer at lån-fra-aksjonær er en oevrigLangsiktigGjeld-linje med beskrivelse «Lån fra aksjonær»
- [ ] Manuell test: gjenerer årsregnskap-XML for OFL Holding 2025, verifiser at `langsiktigKonserngjeld` ikke forekommer og at to `oevrigLangsiktigGjeld`-linjer kan vises (én for lån fra aksjonær, én for andre langsiktige lån hvis aktuelt)