### PR TITLE
fix(skd): parse tilbakemelding og rais feilmelding ved avvisning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.15.1"
+version = "0.15.2"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_skd_skattemelding_client.py
+++ b/tests/test_skd_skattemelding_client.py
@@ -1,0 +1,81 @@
+"""Tester for parsing av Skatteetatens tilbakemelding etter skattemelding-innsending."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from wenche.skd_skattemelding_client import _verifiser_tilbakemelding
+
+NS = "no:skatteetaten:fastsetting:formueinntekt:skattemeldingognaeringsspesifikasjon:response:v2"
+
+
+def _mock_altinn_med_tilbakemelding(xml: bytes | None):
+    altinn = MagicMock()
+    altinn.hent_data_element_bytes.return_value = xml
+    return altinn
+
+
+def test_godkjent_tilbakemelding_raises_ikke(capsys):
+    xml = (
+        f'<skattemeldingOgNaeringsspesifikasjonResponse xmlns="{NS}">'
+        '<resultatAvValidering>validertUtenFeil</resultatAvValidering>'
+        '</skattemeldingOgNaeringsspesifikasjonResponse>'
+    ).encode()
+    altinn = _mock_altinn_med_tilbakemelding(xml)
+    _verifiser_tilbakemelding(altinn, {"id": "test/abc"})
+    out = capsys.readouterr().out
+    assert "godkjent" in out.lower()
+
+
+def test_avvist_med_aarsak_raises_runtimeerror():
+    # Eksempel fra OFL Holding 2026-05-20 avvisning.
+    xml = (
+        f'<skattemeldingOgNaeringsspesifikasjonResponse xmlns="{NS}">'
+        '<resultatAvValidering>validertMedFeil</resultatAvValidering>'
+        '<aarsakTilValidertMedFeil>innkommendeForespoerselManglerSporTilUtfoerende</aarsakTilValidertMedFeil>'
+        '</skattemeldingOgNaeringsspesifikasjonResponse>'
+    ).encode()
+    altinn = _mock_altinn_med_tilbakemelding(xml)
+    with pytest.raises(RuntimeError) as exc:
+        _verifiser_tilbakemelding(altinn, {"id": "test/abc"})
+    assert "avviste" in str(exc.value).lower()
+    assert "innkommendeForespoerselManglerSporTilUtfoerende" in str(exc.value)
+    assert "validertMedFeil" in str(exc.value)
+
+
+def test_avvist_uten_aarsak_raises_likevel():
+    xml = (
+        f'<skattemeldingOgNaeringsspesifikasjonResponse xmlns="{NS}">'
+        '<resultatAvValidering>validertMedFeil</resultatAvValidering>'
+        '</skattemeldingOgNaeringsspesifikasjonResponse>'
+    ).encode()
+    altinn = _mock_altinn_med_tilbakemelding(xml)
+    with pytest.raises(RuntimeError) as exc:
+        _verifiser_tilbakemelding(altinn, {"id": "test/abc"})
+    assert "validertMedFeil" in str(exc.value)
+
+
+def test_manglende_tilbakemelding_gir_advarsel_uten_exception(capsys):
+    altinn = _mock_altinn_med_tilbakemelding(None)
+    _verifiser_tilbakemelding(altinn, {"id": "test/abc"})
+    out = capsys.readouterr().out
+    assert "advarsel" in out.lower()
+
+
+def test_ugyldig_xml_raiser_runtimeerror():
+    altinn = _mock_altinn_med_tilbakemelding(b"dette er ikke xml")
+    with pytest.raises(RuntimeError) as exc:
+        _verifiser_tilbakemelding(altinn, {"id": "test/abc"})
+    assert "parse" in str(exc.value).lower()
+
+
+def test_manglende_resultatfelt_gir_advarsel(capsys):
+    xml = (
+        f'<skattemeldingOgNaeringsspesifikasjonResponse xmlns="{NS}">'
+        '<dokumenter/>'
+        '</skattemeldingOgNaeringsspesifikasjonResponse>'
+    ).encode()
+    altinn = _mock_altinn_med_tilbakemelding(xml)
+    _verifiser_tilbakemelding(altinn, {"id": "test/abc"})
+    out = capsys.readouterr().out
+    assert "advarsel" in out.lower()

--- a/wenche/altinn_client.py
+++ b/wenche/altinn_client.py
@@ -239,6 +239,28 @@ class AltinnClient:
         resp.raise_for_status()
         return resp.json()
 
+    def hent_data_element_bytes(
+        self, app_key: str, instans: dict, data_type: str
+    ) -> bytes | None:
+        """
+        Henter rå bytes for et data-element av gitt dataType.
+
+        Returnerer None hvis dataType ikke finnes i instansen. Nyttig for å
+        plukke ut Skatteetatens tilbakemelding etter at instansen har
+        avansert gjennom prosesstegene.
+        """
+        instance_id = instans["id"]
+        for element in instans.get("data", []):
+            if element.get("dataType") == data_type:
+                url = (
+                    f"{self._app_base(app_key)}/instances/{instance_id}"
+                    f"/data/{element['id']}"
+                )
+                resp = self._http.get(url)
+                resp.raise_for_status()
+                return resp.content
+        return None
+
     def close(self):
         self._http.close()
 

--- a/wenche/skd_skattemelding_client.py
+++ b/wenche/skd_skattemelding_client.py
@@ -168,6 +168,14 @@ class SkdSkattemeldingClient:
             print("Tilbakemelding...")
             altinn.neste_prosesssteg("skattemelding", instans)
 
+            # Skatteetaten legger valideringsresultat i data-elementet «tilbakemelding»
+            # etter at instansen har avansert gjennom prosesstegene. Hent og verifiser
+            # at innsendingen faktisk ble akseptert. Hvis Skatteetaten avviser
+            # innsendingen settes prosessen fortsatt som «fullført» i Altinn, men
+            # tilbakemeldingen inneholder en valideringsfeil.
+            oppdatert = altinn.hent_status("skattemelding", instans)
+            _verifiser_tilbakemelding(altinn, oppdatert)
+
         return instans["id"]
 
     def close(self):
@@ -178,6 +186,69 @@ class SkdSkattemeldingClient:
 
     def __exit__(self, *args):
         self.close()
+
+
+_RESPONSE_NS = (
+    "no:skatteetaten:fastsetting:formueinntekt:"
+    "skattemeldingognaeringsspesifikasjon:response:v2"
+)
+
+
+def _verifiser_tilbakemelding(altinn: AltinnClient, instans: dict) -> None:
+    """
+    Henter Skatteetatens tilbakemelding fra instansen og raiser RuntimeError
+    hvis innsendingen ble avvist.
+
+    Skatteetatens prosess ender alltid med en tilbakemelding-XML, selv ved
+    avvisning. Tilbakemeldingen ligger som data-element 'tilbakemelding'.
+    """
+    raw = altinn.hent_data_element_bytes("skattemelding", instans, "tilbakemelding")
+    if raw is None:
+        print(
+            "Advarsel: kunne ikke finne tilbakemelding-data-element. "
+            "Sjekk Altinn meldingsboks for å bekrefte at innsendingen ble akseptert."
+        )
+        return
+
+    try:
+        root = fromstring(raw)
+    except ParseError as e:
+        raise RuntimeError(
+            f"Kunne ikke parse tilbakemelding fra Skatteetaten: {e}"
+        ) from e
+
+    resultat_el = root.find(f"{{{_RESPONSE_NS}}}resultatAvValidering")
+    if resultat_el is None or resultat_el.text is None:
+        # Eldre eller annerledes respons. Klassifiser som ukjent og gi videre.
+        print("Advarsel: tilbakemelding mangler resultatAvValidering-felt.")
+        return
+
+    resultat = resultat_el.text.strip()
+    if resultat == "validertUtenFeil":
+        print(f"Skatteetaten har godkjent skattemeldingen ({resultat}).")
+        return
+
+    aarsak_el = root.find(f"{{{_RESPONSE_NS}}}aarsakTilValidertMedFeil")
+    aarsak = aarsak_el.text.strip() if aarsak_el is not None and aarsak_el.text else ""
+
+    avvik_tekster = []
+    for avvik in root.iter(f"{{{_RESPONSE_NS}}}avvik"):
+        kode_el = avvik.find(f"{{{_RESPONSE_NS}}}avvikstype")
+        besk_el = avvik.find(f"{{{_RESPONSE_NS}}}beskrivelse")
+        kode = kode_el.text if kode_el is not None and kode_el.text else "(uten kode)"
+        besk = besk_el.text if besk_el is not None and besk_el.text else ""
+        avvik_tekster.append(f"  - {kode}: {besk}".rstrip(": "))
+
+    detaljer = ""
+    if aarsak:
+        detaljer += f"\n  Årsak: {aarsak}"
+    if avvik_tekster:
+        detaljer += "\n  Avvik:\n" + "\n".join(avvik_tekster)
+
+    raise RuntimeError(
+        f"Skatteetaten avviste skattemeldingen (resultatAvValidering={resultat}).{detaljer}\n"
+        "Sjekk tilbakemelding-XML i Altinn meldingsboks for full kontekst."
+    )
 
 
 def bygg_og_valider_konvolutt(


### PR DESCRIPTION
## Problem

Wenche fullførte skattemelding-innsendingen uten å sjekke hva Skatteetaten faktisk svarte. Skatteetaten kan validere innsendingen til `validertMedFeil` og oppgi årsak i tilbakemelding-XML, mens Altinn-prosessen fortsatt avsluttes som fullført. Da rapporterer Wenche innsendingen som vellykket selv om Skatteetaten har avvist den.

Oppdaget 2026-05-20 for OFL Holding sin første prod-innsending. Terminalen viste:
```
Bekreftelse...
Tilbakemelding...
```
og avsluttet uten feil, mens tilbakemeldingen i Altinn meldingsboks viste:
```xml
<resultatAvValidering>validertMedFeil</resultatAvValidering>
<aarsakTilValidertMedFeil>innkommendeForespoerselManglerSporTilUtfoerende</aarsakTilValidertMedFeil>
```

## Endring

Etter siste prosesssteg henter `skd_skattemelding_client.send()` nå data-elementet `tilbakemelding` (Skatteetatens response v2) og parser `resultatAvValidering`. 

- `validertUtenFeil`: print bekreftelse, fortsetter normalt
- `validertMedFeil`: raises `RuntimeError` med årsak og eventuelle avvik
- Manglende tilbakemelding eller manglende felt: advarsel, men ikke exception (toleranse for fremtidige API-endringer)
- Ugyldig XML: RuntimeError

Legger samtidig til `AltinnClient.hent_data_element_bytes()` som hjelper med å hente rå bytes for et data-element av gitt dataType. Returnerer `None` hvis typen ikke finnes.

## Versjon

`pyproject.toml`: 0.15.1 → 0.15.2 (patch bump, ren bugfix)

## Test plan

- [x] 232 enhetstester passerer (6 nye for `_verifiser_tilbakemelding`)
- [x] Verifisert at OFL Holdings faktiske avvisningsrespons (`innkommendeForespoerselManglerSporTilUtfoerende`) trigger `RuntimeError`