### PR TITLE
docs(oppsett): avklar API-tilbyder-spørsmål i Digdir-skjemaet

### DIFF
--- a/docs/oppsett.md
+++ b/docs/oppsett.md
@@ -43,6 +43,9 @@ Du skal nå ha to filer: `maskinporten_privat.pem` og `maskinporten_offentlig.pe
 
 Fyll ut [informasjonsskjemaet for Maskinporten-konsumenter](https://samarbeid.digdir.no/maskinporten/konsument/119) på Digdirs nettside. Digdir behandler søknaden og sender deg en e-post med instruksjoner om å signere bruksvilkårene («Bruksvilkår for private verksemder»).
 
+!!! tip "Hva skal stå under «Hvilken API-tilbyder skal dere konsumere fra?»"
+    Oppgi **Altinn 3** og **Skatteetaten**. Wenche bruker scopes fra begge: Altinn 3 for `altinn:instances.*` og `altinn:authentication/*`, og Skatteetaten for skattemelding og aksjonærregister. Årsregnskap til Brønnøysundregistrene går via Altinn 3 og krever ikke separat brreg-tilgang.
+
 !!! info "Behandlingstid"
     Dette kan ta noen virkedager. Maskinporten er gratis for konsumenter.
 


### PR DESCRIPTION
## Sammendrag

Avklarer hva brukere skal svare på spørsmålet «Hvilken API-tilbyder skal dere konsumere fra?» i Digdirs informasjonsskjema for Maskinporten-konsumenter (steg 2a i oppsettsdokumentasjonen).

Legger til en `!!! tip`-boks rett under linja som lenker til skjemaet, og spesifiserer:

- **Altinn 3** og **Skatteetaten** som API-tilbydere
- Hvilke scopes som hentes fra hver av dem
- At Brønnøysundregistrene ikke trenger oppgis (årsregnskap går via Altinn 3)

## Bakgrunn

Issue rapportert av @jmyrland: brukere er usikre på hva som skal stå i feltet siden Wenches dokumentasjon ikke kommenterer det.

Refs #77

## Testplan

- [x] Verifiser at info-boksen rendres riktig i mkdocs (lokalt eller via GitHub Pages-deploy etter merge)
- [x] Sjekk at linja kommer i logisk rekkefølge (mellom skjema-lenken og «Behandlingstid»-boksen)