### PR TITLE
feat(ui,saft): fjern misvisende defaults og hent ut mer data fra SAF-T

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -28,10 +28,10 @@ resultatregnskap:
   driftskostnader:
     loennskostnader: 0              # Lønn, arbeidsgiveravgift og lignende
     avskrivninger: 0                # Planmessige avskrivninger på anleggsmidler
-    andre_driftskostnader: 5500     # Bank- og regnskapsgebyrer, kontorkostnader o.l.
+    andre_driftskostnader: 0        # Bank- og regnskapsgebyrer, kontorkostnader o.l.
 
   finansposter:
-    utbytte_fra_datterselskap: 250000 # Utbytte mottatt fra datterselskaper (fritaksmetoden)
+    utbytte_fra_datterselskap: 0      # Utbytte mottatt fra datterselskaper (fritaksmetoden)
     andre_finansinntekter: 0          # Renteinntekter og andre finansinntekter
     rentekostnader: 0                 # Renter på lån
     andre_finanskostnader: 0          # Andre finanskostnader
@@ -43,25 +43,25 @@ resultatregnskap:
 balanse:
   eiendeler:
     anleggsmidler:
-      aksjer_i_datterselskap: 100000  # Kostpris for aksjer i heleide datterselskaper
+      aksjer_i_datterselskap: 0       # Kostpris for aksjer i heleide datterselskaper
       andre_aksjer: 0                 # Aksjer i selskaper der du eier under 90 %
       langsiktige_fordringer: 0       # Lån gitt til andre med løpetid over 1 år
     omloepmidler:
       kortsiktige_fordringer: 0       # Kundefordringer og andre kortsiktige krav
-      bankinnskudd: 1200              # Saldo på driftskonto per 31.12
+      bankinnskudd: 0                 # Saldo på driftskonto per 31.12
 
   egenkapital_og_gjeld:
     egenkapital:
       aksjekapital: 30000             # Innbetalt aksjekapital (fra stiftelsesdokumentene)
       overkursfond: 0                 # Innbetalt over pålydende ved emisjon
-      annen_egenkapital: 213700       # Akkumulert overskudd/underskudd. Negativ = underskudd
+      annen_egenkapital: 0            # Akkumulert overskudd/underskudd. Negativ = underskudd
     langsiktig_gjeld:
       laan_fra_aksjonaer: 0           # Lån fra eier med avtalt løpetid over 1 år
       andre_langsiktige_laan: 0       # Banklån og andre lån med løpetid over 1 år
     kortsiktig_gjeld:
       leverandoergjeld: 0             # Ubetalte fakturaer per 31.12
       skyldige_offentlige_avgifter: 0 # Skyldig mva, arbeidsgiveravgift o.l.
-      annen_kortsiktig_gjeld: 52000   # Annen gjeld med forfall innen 1 år
+      annen_kortsiktig_gjeld: 0       # Annen gjeld med forfall innen 1 år
 
 # --- Foregående år (sammenligningstall) ---
 # Obligatorisk etter regnskapslovens § 6-6.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -8,12 +8,12 @@
 selskap:
   navn: "Eksempel Holding AS"
   org_nummer: "123456789"           # 9 siffer uten mellomrom
-  daglig_leder: "Kari Nordmann"
-  styreleder: "Kari Nordmann"       # Kan være samme person som daglig leder
+  daglig_leder: ""                  # Navn på daglig leder
+  styreleder: ""                    # Kan være samme person som daglig leder
   forretningsadresse: "Eksempelgata 1, 0001 Oslo"
   stiftelsesaar: 2022
   aksjekapital: 30000               # NOK — fra stiftelsesdokumentene
-  kontakt_epost: "post@eksempel.no" # Påkrevd for aksjonærregisteroppgave (RF-1086)
+  kontakt_epost: ""                 # Påkrevd for aksjonærregisteroppgave (RF-1086)
 
 regnskapsaar: 2025                  # Året regnskapet gjelder for
 
@@ -109,7 +109,7 @@ foregaaende_aar:
 skattemelding:
   underskudd_til_fremfoering: 0     # Fremførbart underskudd fra tidligere år (NOK).
                                     # Finnes i fjorårets skattemelding (RF-1028).
-  anvend_fritaksmetoden: true       # true for holdingselskaper som eier aksjer i
+  anvend_fritaksmetoden: false      # true for holdingselskaper som eier aksjer i
                                     # datterselskaper (skatteloven § 2-38).
   eierandel_datterselskap: 100      # Eierandel i datterselskapet (prosent, 0–100).
                                     # ≥ 90 %: hele utbyttet er skattefritt.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.15.2"
+version = "0.16.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/wenche/saft.py
+++ b/wenche/saft.py
@@ -226,10 +226,16 @@ def importer(saft_fil: str | Path) -> dict:
 
     Feltene daglig_leder, styreleder, stiftelsesaar og aksjonaerer
     er ikke tilgjengelig i SAF-T og må fylles inn manuelt etterpå.
+    kontakt_epost hentes fra Company/Contact/Email hvis SAF-T-fila
+    inneholder det, ellers tom streng.
 
     Foregående års resultatregnskap er ikke tilgjengelig i SAF-T
     (P&L-kontoer nullstilles ved årsavslutning) og settes til 0.
     Foregående års balanse hentes fra åpningssaldoene.
+
+    Lån fra aksjonær (konto 2250) gir en stub-noteoppføring i
+    noter.laan_til_naerstaaende med saldoen ferdig utfylt. Motpart,
+    rentesats og sikkerhet finnes ikke i SAF-T og må fylles inn manuelt.
     """
     tree = ET.parse(str(saft_fil))
     root = tree.getroot()
@@ -254,6 +260,14 @@ def importer(saft_fil: str | Path) -> dict:
         deler = [d for d in [gate, f"{postnr} {by}".strip()] if d]
         adresse = ", ".join(deler)
 
+    # SAF-T Company/Contact er valgfri; bruk første Email hvis tilgjengelig.
+    kontakt_epost = ""
+    contact_el = company.find(_tag("Contact"))
+    if contact_el is not None:
+        email_el = contact_el.find(_tag("Email"))
+        if email_el is not None and email_el.text:
+            kontakt_epost = email_el.text.strip()
+
     sel_crit = header.find(_tag("SelectionCriteria"))
     regnskapsaar = int(_tekst(sel_crit, "PeriodStartYear", "0")) if sel_crit is not None else 0
 
@@ -270,6 +284,20 @@ def importer(saft_fil: str | Path) -> dict:
 
     aksjekapital = nar["aksjekapital_balanse"]
 
+    # Stub-noteoppføring for lån fra aksjonær: saldoen hentes fra konto 2250,
+    # men motpart, rentesats og sikkerhet finnes ikke i SAF-T og må fylles
+    # inn manuelt av brukeren. retning="låntaker" fordi selskapet er den som
+    # har lånt penger fra eieren (nærstående part er långiver).
+    laan_til_naerstaaende: list[dict] = []
+    if nar["laan_fra_aksjonaer"] > 0:
+        laan_til_naerstaaende.append({
+            "motpart": "",
+            "saldo": nar["laan_fra_aksjonaer"],
+            "retning": "låntaker",
+            "rente_prosent": 0.0,
+            "sikkerhet": "",
+        })
+
     return {
         "selskap": {
             "navn": navn,
@@ -279,7 +307,7 @@ def importer(saft_fil: str | Path) -> dict:
             "forretningsadresse": adresse,
             "stiftelsesaar": 0,
             "aksjekapital": aksjekapital,
-            "kontakt_epost": "",
+            "kontakt_epost": kontakt_epost,
         },
         "regnskapsaar": regnskapsaar,
         "resultatregnskap": _bygg_resultat(nar),
@@ -298,6 +326,6 @@ def importer(saft_fil: str | Path) -> dict:
         "aksjonaerer": [],
         "noter": {
             "antall_ansatte": 0,
-            "laan_til_naerstaaende": [],
+            "laan_til_naerstaaende": laan_til_naerstaaende,
         },
     }

--- a/wenche/saft.py
+++ b/wenche/saft.py
@@ -236,6 +236,12 @@ def importer(saft_fil: str | Path) -> dict:
     Lån fra aksjonær (konto 2250) gir en stub-noteoppføring i
     noter.laan_til_naerstaaende med saldoen ferdig utfylt. Motpart,
     rentesats og sikkerhet finnes ikke i SAF-T og må fylles inn manuelt.
+
+    Fremførbart underskudd (skattemelding.underskudd_til_fremfoering)
+    estimeres fra åpningssaldoen på konto 2080 (udekket tap). For
+    selskaper med ikke-fradragsberettigede kostnader vil regnskapsmessig
+    underskudd avvike fra det skattemessige; verifiser mot fjorårets
+    RF-1028 hvis det er aktuelt.
     """
     tree = ET.parse(str(saft_fil))
     root = tree.getroot()
@@ -284,6 +290,15 @@ def importer(saft_fil: str | Path) -> dict:
 
     aksjekapital = nar["aksjekapital_balanse"]
 
+    # Fremførbart underskudd (estimat): åpningssaldoen på konto 2080
+    # representerer akkumulert udekket tap inn i regnskapsåret. Tallet
+    # er regnskapsmessig og kan avvike fra det skattemessige fremførbare
+    # underskuddet i fjorårets RF-1028; brukeren bør verifisere.
+    underskudd_aapning = 0.0
+    for account in gl.findall(_tag("Account")):
+        if _tekst(account, "GroupingCode") == "2080":
+            underskudd_aapning += _aapning_netto(account)
+
     # Stub-noteoppføring for lån fra aksjonær: saldoen hentes fra konto 2250,
     # men motpart, rentesats og sikkerhet finnes ikke i SAF-T og må fylles
     # inn manuelt av brukeren. retning="låntaker" fordi selskapet er den som
@@ -319,7 +334,7 @@ def importer(saft_fil: str | Path) -> dict:
             "balanse": _bygg_balanse(fjor_b),
         },
         "skattemelding": {
-            "underskudd_til_fremfoering": 0.0,
+            "underskudd_til_fremfoering": underskudd_aapning,
             "anvend_fritaksmetoden": False,
             "eierandel_datterselskap": 100,
         },

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -2312,20 +2312,25 @@ def _bygg_dokumenter_fane() -> None:
             tooltip="Finnes i fjorårets skattemelding (RF-1028). Sett til 0 hvis selskapet er nytt.",
         )
         with ui.column():
+            def toggle_fritaksmetoden(e):
+                setattr(state, "fritaksmetoden", e.value)
+                eierandel_el.set_visibility(e.value)
+
             fritaks_sjekkboks = ui.checkbox(
                 "Anvend fritaksmetoden",
                 value=state.fritaksmetoden,
-                on_change=lambda e: setattr(state, "fritaksmetoden", e.value),
+                on_change=toggle_fritaksmetoden,
             ).tooltip(
                 "Gjelder dersom selskapet har mottatt utbytte fra datterselskaper. "
                 "Ved eierandel ≥ 90 % er hele utbyttet skattefritt."
             )
-            num(
+            eierandel_el = num(
                 "Eierandel i datterselskap (%)",
                 "eierandel_datterselskap",
                 step=1,
                 min_val=0,
             )
+            eierandel_el.set_visibility(state.fritaksmetoden)
 
     def lagre_dokumenter():
         state.lagre_config()

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -2336,10 +2336,6 @@ def _bygg_dokumenter_fane() -> None:
         state.lagre_config()
         ui.notify(f"Lagret til {CONFIG_FIL.resolve()}", type="positive")
 
-    ui.button("Lagre innstillinger og noter", on_click=lagre_dokumenter).props(
-        "color=primary"
-    ).classes("mb-4")
-
     ui.separator().classes("my-4")
 
     # Nedlastinger
@@ -2501,6 +2497,11 @@ def _bygg_dokumenter_fane() -> None:
                 ui.notify(f"Feil: {e}", type="negative", timeout=0)
 
         ui.button("Last ned noter", on_click=last_ned_noter).props("color=primary outline")
+
+    ui.separator().classes("my-4")
+    ui.button("Lagre innstillinger og noter", on_click=lagre_dokumenter).props(
+        "color=primary"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -613,6 +613,11 @@ _input_elements: dict[str, object] = {}
 # driftsinntekter, driftsresultat, sum eiendeler m.fl.). Settes når
 # regnskap-fanen bygges.
 _oppdater_regnskap_metrikker: callable | None = None
+
+# Refresh-callback for lån-listen i Dokumenter-fanen. Settes når
+# dokumenter-fanen bygges, og kalles etter SAF-T-import slik at
+# auto-genererte lån-stubs blir synlige.
+_laan_liste_refresh: callable | None = None
 state.les_config()
 
 
@@ -782,6 +787,8 @@ def oppdater_alle_inntastingsfelter() -> None:
         el.set_value(getattr(state, attr))
     if _oppdater_regnskap_metrikker is not None:
         _oppdater_regnskap_metrikker()
+    if _laan_liste_refresh is not None:
+        _laan_liste_refresh()
 
 
 # ---------------------------------------------------------------------------
@@ -1844,7 +1851,9 @@ def _bygg_selskap_fane() -> None:
                 data = await run.io_bound(importer_saft_fil, tmp_sti)
                 Path(tmp_sti).unlink(missing_ok=True)
 
-                # Bevar felt SAF-T ikke dekker
+                # Bevar felt SAF-T ikke dekker. kontakt_epost hentes fra
+                # SAF-T Contact/Email hvis tilgjengelig, men brukerens
+                # eksisterende verdi vinner hvis han allerede har fylt den ut.
                 if CONFIG_FIL.exists():
                     with open(CONFIG_FIL, encoding="utf-8") as f_eks:
                         eks = yaml.safe_load(f_eks) or {}
@@ -1852,9 +1861,18 @@ def _bygg_selskap_fane() -> None:
                         eks_verdi = eks.get("selskap", {}).get(felt)
                         if eks_verdi:
                             data["selskap"][felt] = eks_verdi
-                    for bevar in ("aksjonaerer", "skattemelding", "noter"):
+                    for bevar in ("aksjonaerer", "skattemelding"):
                         if eks.get(bevar):
                             data[bevar] = eks[bevar]
+                    # Noter: bevar antall_ansatte hvis satt, og bevar
+                    # laan_til_naerstaaende hvis brukeren har fylt ut detaljer
+                    # (ellers brukes SAF-T-genererte stub-oppføringer).
+                    eks_noter = eks.get("noter") or {}
+                    if eks_noter.get("antall_ansatte"):
+                        data["noter"]["antall_ansatte"] = eks_noter["antall_ansatte"]
+                    eks_laan = eks_noter.get("laan_til_naerstaaende") or []
+                    if eks_laan:
+                        data["noter"]["laan_til_naerstaaende"] = eks_laan
 
                 with open(CONFIG_FIL, "w", encoding="utf-8") as f:
                     yaml.dump(data, f, allow_unicode=True, sort_keys=False)
@@ -2447,6 +2465,8 @@ def _bygg_dokumenter_fane() -> None:
                 ui.button("Fjern lån", on_click=fjern_laan).props("flat color=negative size=sm").classes("mt-2")
 
     laan_liste()
+    global _laan_liste_refresh
+    _laan_liste_refresh = laan_liste.refresh
 
     def legg_til_laan():
         state.laan_til_naerstaaende.append(LaanState())

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1861,9 +1861,19 @@ def _bygg_selskap_fane() -> None:
                         eks_verdi = eks.get("selskap", {}).get(felt)
                         if eks_verdi:
                             data["selskap"][felt] = eks_verdi
-                    for bevar in ("aksjonaerer", "skattemelding"):
-                        if eks.get(bevar):
-                            data[bevar] = eks[bevar]
+                    if eks.get("aksjonaerer"):
+                        data["aksjonaerer"] = eks["aksjonaerer"]
+                    # Skattemelding: bevar fritaksmetoden- og eierandel-
+                    # innstillinger som er brukerens valg, og bevar manuelt
+                    # satt underskudd_til_fremfoering (ellers brukes SAF-T-
+                    # estimatet basert på åpningssaldo konto 2080).
+                    eks_sm = eks.get("skattemelding") or {}
+                    if "anvend_fritaksmetoden" in eks_sm:
+                        data["skattemelding"]["anvend_fritaksmetoden"] = eks_sm["anvend_fritaksmetoden"]
+                    if "eierandel_datterselskap" in eks_sm:
+                        data["skattemelding"]["eierandel_datterselskap"] = eks_sm["eierandel_datterselskap"]
+                    if eks_sm.get("underskudd_til_fremfoering"):
+                        data["skattemelding"]["underskudd_til_fremfoering"] = eks_sm["underskudd_til_fremfoering"]
                     # Noter: bevar antall_ansatte hvis satt, og bevar
                     # laan_til_naerstaaende hvis brukeren har fylt ut detaljer
                     # (ellers brukes SAF-T-genererte stub-oppføringer).

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -110,12 +110,12 @@ class LaanState:
 @dataclass
 class AppState:
     # Selskap
-    navn: str = "Mitt Holding AS"
-    org_nummer: str = "123456789"
-    daglig_leder: str = "Ola Nordmann"
-    styreleder: str = "Ola Nordmann"
-    forretningsadresse: str = "Gateveien 1, 0001 Oslo"
-    stiftelsesaar: int = 2020
+    navn: str = ""
+    org_nummer: str = ""
+    daglig_leder: str = ""
+    styreleder: str = ""
+    forretningsadresse: str = ""
+    stiftelsesaar: int = 0
     aksjekapital: float = 30000.0
     kontakt_epost: str = ""
     regnskapsaar: int = 2025
@@ -125,24 +125,24 @@ class AppState:
     andre_driftsinntekter: float = 0.0
     loennskostnader: float = 0.0
     avskrivninger: float = 0.0
-    andre_driftskostnader: float = 5500.0
+    andre_driftskostnader: float = 0.0
     utbytte_fra_datterselskap: float = 0.0
     andre_finansinntekter: float = 0.0
     rentekostnader: float = 0.0
     andre_finanskostnader: float = 0.0
 
     # Balanse — Eiendeler
-    aksjer_i_datterselskap: float = 100000.0
+    aksjer_i_datterselskap: float = 0.0
     andre_aksjer: float = 0.0
     langsiktige_fordringer: float = 0.0
     kortsiktige_fordringer: float = 0.0
-    bankinnskudd: float = 1200.0
+    bankinnskudd: float = 0.0
 
     # Balanse — Egenkapital og gjeld
     ek_aksjekapital: float = 30000.0
     overkursfond: float = 0.0
-    annen_egenkapital: float = -34300.0
-    laan_fra_aksjonaer: float = 105500.0
+    annen_egenkapital: float = 0.0
+    laan_fra_aksjonaer: float = 0.0
     andre_langsiktige_laan: float = 0.0
     leverandoergjeld: float = 0.0
     skyldige_offentlige_avgifter: float = 0.0
@@ -360,7 +360,7 @@ class AppState:
             self.andre_driftsinntekter = float(di.get("andre_driftsinntekter", 0))
             self.loennskostnader = float(dk.get("loennskostnader", 0))
             self.avskrivninger = float(dk.get("avskrivninger", 0))
-            self.andre_driftskostnader = float(dk.get("andre_driftskostnader", 5500))
+            self.andre_driftskostnader = float(dk.get("andre_driftskostnader", 0))
             self.utbytte_fra_datterselskap = float(fp.get("utbytte_fra_datterselskap", 0))
             self.andre_finansinntekter = float(fp.get("andre_finansinntekter", 0))
             self.rentekostnader = float(fp.get("rentekostnader", 0))
@@ -372,15 +372,15 @@ class AppState:
             ek = b.get("egenkapital_og_gjeld", {}).get("egenkapital", {})
             lg = b.get("egenkapital_og_gjeld", {}).get("langsiktig_gjeld", {})
             kg = b.get("egenkapital_og_gjeld", {}).get("kortsiktig_gjeld", {})
-            self.aksjer_i_datterselskap = float(anl.get("aksjer_i_datterselskap", 100000))
+            self.aksjer_i_datterselskap = float(anl.get("aksjer_i_datterselskap", 0))
             self.andre_aksjer = float(anl.get("andre_aksjer", 0))
             self.langsiktige_fordringer = float(anl.get("langsiktige_fordringer", 0))
             self.kortsiktige_fordringer = float(oml.get("kortsiktige_fordringer", 0))
-            self.bankinnskudd = float(oml.get("bankinnskudd", 1200))
+            self.bankinnskudd = float(oml.get("bankinnskudd", 0))
             self.ek_aksjekapital = float(ek.get("aksjekapital", 30000))
             self.overkursfond = float(ek.get("overkursfond", 0))
-            self.annen_egenkapital = float(ek.get("annen_egenkapital", -34300))
-            self.laan_fra_aksjonaer = float(lg.get("laan_fra_aksjonaer", 105500))
+            self.annen_egenkapital = float(ek.get("annen_egenkapital", 0))
+            self.laan_fra_aksjonaer = float(lg.get("laan_fra_aksjonaer", 0))
             self.andre_langsiktige_laan = float(lg.get("andre_langsiktige_laan", 0))
             self.leverandoergjeld = float(kg.get("leverandoergjeld", 0))
             self.skyldige_offentlige_avgifter = float(kg.get("skyldige_offentlige_avgifter", 0))
@@ -603,6 +603,16 @@ state = AppState()
 # fanen bygges, og kalles fra Selskap-fanen når aksjekapital eller stiftelses-
 # år endres, så indikatoren reflekterer ny verdi når brukeren bytter tilbake.
 _aksjonaer_liste_refresh: callable | None = None
+
+# Registry over inntastingsfelter knyttet til state-attributter. Populeres av
+# num()/txt() når de bygges, og brukes av SAF-T-importen for å oppdatere
+# UI-verdiene etter at state.les_config() har lest nye verdier fra YAML.
+_input_elements: dict[str, object] = {}
+
+# Callback for å oppdatere metric-etikettene på regnskap-fanen (sum
+# driftsinntekter, driftsresultat, sum eiendeler m.fl.). Settes når
+# regnskap-fanen bygges.
+_oppdater_regnskap_metrikker: callable | None = None
 state.les_config()
 
 
@@ -734,6 +744,8 @@ def num(label: str, attr: str, obj=None, step: float = 1000, min_val: float | No
     el = ui.number(**kwargs).classes("w-full")
     if tooltip:
         el.tooltip(tooltip)
+    if obj is None:
+        _input_elements[attr] = el
     return el
 
 
@@ -755,7 +767,21 @@ def txt(label: str, attr: str, obj=None, placeholder: str = "", tooltip: str = "
     ).classes("w-full")
     if tooltip:
         el.tooltip(tooltip)
+    if obj is None:
+        _input_elements[attr] = el
     return el
+
+
+def oppdater_alle_inntastingsfelter() -> None:
+    """Synkroniserer registrerte UI-felt med gjeldende state-verdier.
+
+    Brukes etter handlinger som endrer state programmatisk (f.eks. SAF-T-
+    import), siden num()/txt() ikke har toveis-binding mot state.
+    """
+    for attr, el in _input_elements.items():
+        el.set_value(getattr(state, attr))
+    if _oppdater_regnskap_metrikker is not None:
+        _oppdater_regnskap_metrikker()
 
 
 # ---------------------------------------------------------------------------
@@ -1834,6 +1860,7 @@ def _bygg_selskap_fane() -> None:
                     yaml.dump(data, f, allow_unicode=True, sort_keys=False)
 
                 state.les_config()
+                oppdater_alle_inntastingsfelter()
                 ui.notify(f"SAF-T importert for {state.navn}.", type="positive")
             except Exception as e:
                 ui.notify(f"Feil ved import: {e}", type="negative", timeout=0)
@@ -1940,6 +1967,13 @@ def _bygg_regnskap_fane() -> None:
         else:
             balanse_banner.set_text(f"✗ Differanse: {kr(state.balanseforskjell)}")
             balanse_banner.classes(remove="text-green-600", add="text-red-600")
+
+    def _oppdater_metrikker():
+        oppdater_rr()
+        oppdater_balanse()
+
+    global _oppdater_regnskap_metrikker
+    _oppdater_regnskap_metrikker = _oppdater_metrikker
 
     oppdater_balanse()
 


### PR DESCRIPTION
## Sammendrag

Onboarding-tilbakemeldinger fra en ny bruker avdekket fem relaterte problemer i SAF-T-importen og default-verdiene. Denne PR-en fikser alle:

1. **Placeholder-verdier som lignet ekte tall** i config.example.yaml, AppState og les_config-fallbackene gjorde det vanskelig å se hva som var ekte tall.
2. **SAF-T-import oppdaterte ikke UI-skjemaet** for inneværende år. Verdiene ble skrevet til YAML, men UI-feltene var enveis-bundet via num()/txt() og refresherte ikke.
3. **anvend_fritaksmetoden: true** som default i config.example.yaml ga uriktig skattemelding for brukere uten datterselskap.
4. **kontakt_epost, lån fra aksjonær og fremførbart underskudd** ble ikke hentet ut av SAF-T, selv om dataene var tilgjengelige.
5. **Eierandel datterselskap (100 %)** ble vist selv når fritaksmetoden var av, noe som forvirret brukere uten datterselskap.

## Endringer

### Nullstilte placeholder-defaults

| Felt | Gammel | Ny |
|---|---:|---:|
| `andre_driftskostnader` | 5 500 | 0 |
| `utbytte_fra_datterselskap` | 250 000 | 0 |
| `aksjer_i_datterselskap` | 100 000 | 0 |
| `bankinnskudd` | 1 200 | 0 |
| `annen_egenkapital` | -34 300 / 213 700 | 0 |
| `laan_fra_aksjonaer` | 105 500 | 0 |
| `annen_kortsiktig_gjeld` | 52 000 | 0 |
| `anvend_fritaksmetoden` | true | false |
| `daglig_leder`, `styreleder`, `kontakt_epost` | navn/e-post-placeholders | tomme strenger |

`aksjekapital` beholdes på 30 000 (lovbestemt minimum for AS).

Endringene gjøres i [config.example.yaml](config.example.yaml), `AppState` og `les_config` fallback-verdier i [wenche/ui.py](wenche/ui.py).

### UI-refresh etter SAF-T-import

`num()` og `txt()` registrerer nå elementene sine i `_input_elements`. Den nye `oppdater_alle_inntastingsfelter()` itererer over registeret og kaller `set_value(getattr(state, attr))` på hvert element, pluss refresh av regnskap-metrikker og lån-liste. SAF-T-importen kaller denne etter `state.les_config()`. Selskapsinfo og regnskapstall fra SAF-T blir nå synlige i UI med en gang.

### Utvidet SAF-T-extraction

- **kontakt_epost** hentes fra `Company/Contact/Email` hvis SAF-T-fila inneholder det
- **Lån fra aksjonær (konto 2250)** med positiv saldo gir en stub-oppføring i `noter.laan_til_naerstaaende` med saldo og retning ferdig satt (selskapet som låntaker). Motpart, rentesats og sikkerhet finnes ikke i SAF-T og må fortsatt fylles inn manuelt
- **Fremførbart underskudd til fremføring** estimeres fra åpningssaldoen på konto 2080 (udekket tap). NB: regnskapsmessig estimat; for selskaper med ikke-fradragsberettigede kostnader bør verifiseres mot fjorårets RF-1028

### Granulær preservation under SAF-T-import

Tidligere ble hele `noter`- og `skattemelding`-seksjonene bevart fra eksisterende config, noe som blokkerte SAF-T-stubene og det utledede underskuddet. Nå bevares:

- `noter.antall_ansatte` hvis satt
- `noter.laan_til_naerstaaende` hvis brukeren har fylt ut detaljer (ellers brukes SAF-T-stub)
- `skattemelding.anvend_fritaksmetoden` og `eierandel_datterselskap` (brukerens valg, ikke i SAF-T)
- `skattemelding.underskudd_til_fremfoering` hvis manuelt satt til verdi ulik null (ellers brukes SAF-T-estimatet)

### Skjul eierandel når fritaksmetoden er av

`eierandel_datterselskap`-feltet vises nå kun når «Anvend fritaksmetoden» er avkrysset. Det er konsistent med Wenches øvrige UI-prinsipp om kontekstuell visning, og fjerner et felt uten funksjon for brukere uten datterselskap.

## Testplan

- [x] Alle 232 eksisterende tester passerer
- [x] `wenche.ui` og `wenche.saft` importerer uten feil
- [x] Manuell verifisering med ekte SAF-T-fil fra Uni Micro: selskapsinfo, regnskapstall, kontakt-epost, lån-stub (retning korrekt), og underskudd hentes alle ut og synliggjøres i UI
- [x] Manuell verifisering: genererte dokumenter (årsregnskap, aksjonærregister, noter, skattemelding-utkast) kontrollert mot SAF-T på linje-nivå; alle tall stemmer og balansen går opp
- [x] Verifisert at «Anvend fritaksmetoden» nå er av som default, og at eierandel-feltet skjules/vises riktig