### PR TITLE
docs: dokumenter utvidet SAF-T-extraction i referanse og tutorial

### DIFF
--- a/docs/referanse.md
+++ b/docs/referanse.md
@@ -287,6 +287,12 @@ Etter import må følgende felt fylles inn manuelt i `config.yaml`:
 - `aksjonaerer` (navn, fødselsnummer, antall aksjer, utbytte)
 - `foregaaende_aar.resultatregnskap` (er ikke tilgjengelig i SAF-T)
 
+Følgende felt fylles inn automatisk så langt det lar seg gjøre fra SAF-T, men bør verifiseres:
+
+- `selskap.kontakt_epost` hentes fra `Company/Contact/Email` hvis SAF-T-fila inneholder det
+- `noter.laan_til_naerstaaende` får en stub-oppføring med saldo og retning satt hvis konto 2250 (gjeld til eier) har saldo. Motpart, rentesats og sikkerhet må fortsatt fylles inn manuelt
+- `skattemelding.underskudd_til_fremfoering` estimeres fra åpningssaldoen på konto 2080 (udekket tap). Verdien er regnskapsmessig og kan avvike fra det skattemessige fremførbare underskuddet; verifiser mot fjorårets RF-1028 hvis selskapet har ikke-fradragsberettigede kostnader
+
 !!! tip "Tilgjengelig i webgrensesnittet"
     SAF-T-import er også tilgjengelig under fanen **Selskap** i `wenche ui`.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -57,7 +57,7 @@ Denne veiledningen tar deg gjennom en komplett innsending fra start til slutt. V
     Klikk **Lagre konfigurasjon**.
 
     !!! tip "Har du SAF-T fra regnskapssystemet ditt?"
-        Klikk **Importer fra SAF-T Financial** øverst i fanen. Last opp XML-filen og Wenche fyller inn alle regnskapstall automatisk. Du må fortsatt fylle inn daglig leder, styreleder og aksjonærdata manuelt.
+        Klikk **Importer fra SAF-T Financial** øverst i fanen. Last opp XML-filen og Wenche fyller inn alle regnskapstall, kontakt-epost (hvis tilgjengelig), lån fra aksjonær (saldo og retning) og fremførbart underskudd (estimat fra konto 2080) automatisk. Du må fortsatt fylle inn daglig leder, styreleder, aksjonærdata, samt motpart, rente og sikkerhet for lån.
 
 === "Kommandolinje"
 


### PR DESCRIPTION
## Sammendrag

Følger opp #79 (0.16.0) som utvidet SAF-T-importen. Dokumentasjonen sa fortsatt at kontakt-epost, lån fra aksjonær og fremførbart underskudd måtte fylles inn manuelt, selv om disse nå hentes ut automatisk.

## Endringer

- **`docs/referanse.md`**: Ny seksjon under SAF-T-importen som lister felt som fylles inn automatisk så langt det lar seg gjøre (kontakt_epost, laan_til_naerstaaende-stub, underskudd_til_fremfoering), med caveat om at brukeren bør verifisere de mer usikre verdiene.
- **`docs/tutorial.md`**: Presiserer tip-boksen om SAF-T-import med hva som faktisk hentes ut, og hva som fortsatt må fylles inn manuelt (motpart, rente og sikkerhet for lån).

Refs #79