### PR TITLE
fix(fristsjekk): rydd opp tre nits fra PR #55 review

### DIFF
--- a/tests/test_fristsjekk.py
+++ b/tests/test_fristsjekk.py
@@ -75,22 +75,30 @@ def prod_env():
 class TestSjekkSkattemelding:
 
     @patch("wenche.fristsjekk.httpx.get")
-    @patch("wenche.fristsjekk.get_skd_skattemelding_maskinporten_token", create=True)
-    def test_fastsatt_gir_innfridd(self, mock_token, mock_get, prod_env):
+    def test_fastsatt_gir_innfridd(self, mock_get, prod_env):
         """Respons med skattemeldingUpersonligFastsatt → innfridd=True."""
-        # Importer igjen etter patching
-        import wenche.fristsjekk as mod
-        mock_token_fn = MagicMock(return_value="test-token")
-        with patch.object(mod, "sjekk_skattemelding", wraps=mod.sjekk_skattemelding):
-            with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", mock_token_fn):
-                mock_get.return_value = _mock_response(
-                    text=_wrapper_xml("skattemeldingUpersonligFastsatt"),
-                )
-                result = mod.sjekk_skattemelding("931808869", 2025)
+        with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
+            mock_get.return_value = _mock_response(
+                text=_wrapper_xml("skattemeldingUpersonligFastsatt"),
+            )
+            result = sjekk_skattemelding("931808869", 2025)
 
         assert result.innfridd is True
         assert "sendt inn og godkjent" in result.brukertekst
         assert "931808869" in result.lenke
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_ukjent_fastsatt_variant_gir_ikke_innfridd(self, mock_get, prod_env):
+        """Hypotetisk fremtidig type som inneholder 'Fastsatt' men ikke er i
+        kjent-settet skal ikke falskt markeres som innfridd."""
+        with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
+            mock_get.return_value = _mock_response(
+                text=_wrapper_xml("skattemeldingUpersonligFastsattForVurdering"),
+            )
+            result = sjekk_skattemelding("931808869", 2025)
+
+        assert result.innfridd is False
+        assert "ikke innsendt" in result.brukertekst
 
     @patch("wenche.fristsjekk.httpx.get")
     def test_utkast_gir_ikke_innfridd(self, mock_get, prod_env):

--- a/wenche/fristsjekk.py
+++ b/wenche/fristsjekk.py
@@ -58,6 +58,10 @@ _SKD_BASES = {
 # Dokumentasjon: https://data.brreg.no/regnskapsregisteret/openapi/index.html
 _BRG_REGNSKAP_URL = "https://data.brreg.no/regnskapsregisteret/regnskap"
 
+# Eksakte verdier fra Dokumenttype-enum i Skatteetatens XSD (se modul-docstring).
+# Utvid settet hvis XSDen får nye verdier som indikerer "innsendt og fastsatt".
+_FASTSATT_DOKUMENTTYPER = {"skattemeldingUpersonligFastsatt"}
+
 
 @dataclass
 class FristStatus:
@@ -130,11 +134,12 @@ def _utfør_skattemelding_sjekk(token: str, orgnr: str, aar: int) -> FristStatus
         return FristStatus(beskrivelse="Ugyldig svar fra Skatteetaten")
 
     # <type>-elementet i wrapper-XML-en angir dokumentstatus.
-    # "Fastsatt" i verdien betyr at skattemeldingen er innsendt og godkjent.
-    # Ref: Dokumenttype-enum i XSD (se modul-docstring).
+    # Sammenlign eksakt mot kjente "fastsatt"-typer fra XSDen — delstreng-match
+    # ville falskt slå inn hvis Skatteetaten innfører nye typer som inneholder
+    # "Fastsatt" uten å bety "innsendt og godkjent".
     for elem in root.iter():
         tag = elem.tag.split("}")[-1] if "}" in elem.tag else elem.tag
-        if tag == "type" and elem.text and "Fastsatt" in elem.text:
+        if tag == "type" and elem.text and elem.text.strip() in _FASTSATT_DOKUMENTTYPER:
             return FristStatus(
                 innfridd=True,
                 brukertekst=f"Skattemeldingen for {aar} er sendt inn og godkjent.",

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -834,17 +834,20 @@ def _frist_info(maaned: int, dag: int) -> tuple[str, str, str]:
         return dato_tekst, f"{dager} dager igjen", "green-600"
 
 
-def _fristkort(tittel: str, undertittel: str) -> tuple:
-    """Oppretter fristkort med loading-tilstand. Returnerer (card, content)."""
+def _fristkort(tittel: str, undertittel: str, vis_loading: bool = True) -> tuple:
+    """Oppretter fristkort. Med `vis_loading=False` hoppes spinner-tilstanden over
+    når sluttilstanden allerede er kjent (f.eks. aksjonærregister uten API-sjekk).
+    Returnerer (card, content)."""
     card = ui.card().classes("w-full p-5 border border-slate-200 shadow-none rounded-xl")
     with card:
         content = ui.column().classes("w-full gap-0")
         with content:
             ui.label(tittel).classes("font-semibold text-slate-800 text-base")
             ui.label(undertittel).classes("text-xs text-slate-500 mb-3")
-            with ui.row().classes("items-center gap-2"):
-                ui.spinner(size="sm").classes("text-slate-400")
-                ui.label("Sjekker status...").classes("text-xs text-slate-400 italic")
+            if vis_loading:
+                with ui.row().classes("items-center gap-2"):
+                    ui.spinner(size="sm").classes("text-slate-400")
+                    ui.label("Sjekker status...").classes("text-xs text-slate-400 italic")
     return card, content
 
 
@@ -955,7 +958,7 @@ def _bygg_hjem_fane(tabs=None, t_oppsett=None) -> None:
         for f in frister:
             if f["key"] == "aksjonaerregister":
                 # Ingen automatisk sjekk — vis sluttilstand direkte uten spinner.
-                card, content = _fristkort(f["tittel"], f["undertittel"])
+                card, content = _fristkort(f["tittel"], f["undertittel"], vis_loading=False)
                 _fristkort_ventende(
                     card, content, f["tittel"], f["undertittel"],
                     f["maaned"], f["dag"], f["beskrivelse"],
@@ -963,7 +966,7 @@ def _bygg_hjem_fane(tabs=None, t_oppsett=None) -> None:
                 )
             elif not orgnr_konfigurert:
                 # Ingen API-sjekk uten orgnr — hopp over spinner og vis ventende direkte.
-                card, content = _fristkort(f["tittel"], f["undertittel"])
+                card, content = _fristkort(f["tittel"], f["undertittel"], vis_loading=False)
                 _fristkort_ventende(
                     card, content, f["tittel"], f["undertittel"],
                     f["maaned"], f["dag"], f["beskrivelse"],


### PR DESCRIPTION
## Sammendrag

Adresserer de tre små nittene du flagget i [merge-kommentaren på #55](https://github.com/olefredrik/Wenche/pull/55#issuecomment-3000000) — alle innenfor samme `fristsjekk`-modulen, slik at det henger sammen som én oppfølger.

## Hva endres

**1. `test_fastsatt_gir_innfridd` — forenklet mocking-stil**
Fjerner `create=True` + `patch.object(..., wraps=...)` + re-import. Bruker samme enkle mønster som `test_utkast_gir_ikke_innfridd` og de øvrige skattemelding-testene: `@patch("wenche.fristsjekk.httpx.get")` + `with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t")`.

**2. `_fristkort()` — ny `vis_loading`-parameter**
Aksjonærregister-kortet og placeholder-orgnr-kortet vet på forhånd at det ikke kommer noe API-svar. Tidligere ble spinner + "Sjekker status..." opprettet og umiddelbart fjernet av `_fristkort_ventende`. Nå hopper de over loading-tilstanden direkte.

**3. `sjekk_skattemelding` — eksakt match mot Dokumenttype-settet**
Bytter `"Fastsatt" in elem.text` til `elem.text.strip() in _FASTSATT_DOKUMENTTYPER`, der settet inneholder de eksakte verdiene fra Skatteetatens XSD. Robusthet mot fremtidige XSD-utvidelser med andre `*Fastsatt*`-varianter som ikke betyr "innsendt og godkjent".

Ny test `test_ukjent_fastsatt_variant_gir_ikke_innfridd` dokumenterer at en hypotetisk `skattemeldingUpersonligFastsattForVurdering` *ikke* slår inn — som var hele poenget med å bytte fra delstreng til set.

## Test plan

- [x] `pytest` — 241 passed (var 240 før, ny test lagt til)
- [x] `pytest tests/test_fristsjekk.py -v` — alle 26 fristsjekk-tester grønne
- [x] Verifisert at `_fristkort(..., vis_loading=False)` ikke bryter eksisterende kall til `_fristkort_ventende`
- [x] Manuell sjekk av diff — kun nittene fra reviewen, ingen scope creep