### PR TITLE
fix(skd): send gjeldende_dokument_id fra send-skattemelding (CLI)

### DIFF
--- a/tests/test_cli_send_skattemelding.py
+++ b/tests/test_cli_send_skattemelding.py
@@ -1,0 +1,50 @@
+"""
+Regresjonstest for `wenche send-skattemelding` (CLI).
+
+CLI-kommandoen må sende `gjeldende_dokument_id` videre til skd.send(), slik at
+konvolutten får `dokumentreferanseTilGjeldendeDokument`. Uten den avviser
+Skatteetaten innsendingen med `innkommendeForespoerselManglerReferanseTilGjeldendeSkattemelding`
+(issue #84). UI-en og valider-kommandoen gjorde dette allerede; CLI-en hang etter.
+"""
+
+from pathlib import Path
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from wenche.cli import main
+
+# Minimal gyldig forhåndsutfylt skattemeldingUpersonlig v5 slik at
+# hent_partsnummer() finner <partsnummer>.
+_FORHANDSUTFYLT = (
+    '<skattemelding xmlns="urn:no:skatteetaten:fastsetting:formueinntekt:'
+    'skattemelding:upersonlig:ekstern:v5">'
+    "<partsnummer>3002792459</partsnummer>"
+    "<inntektsaar>2025</inntektsaar></skattemelding>"
+).encode("utf-8")
+
+_CONFIG = Path(__file__).resolve().parent.parent / "config.example.yaml"
+
+
+def test_send_skattemelding_sender_gjeldende_dokument_id(monkeypatch):
+    monkeypatch.delenv("WENCHE_ENV", raising=False)
+    monkeypatch.delenv("SKD_TEST_PARTSNUMMER", raising=False)
+
+    with patch(
+        "wenche.auth.get_skd_skattemelding_tokens",
+        return_value={"maskinporten_token": "m", "altinn_token": "a"},
+    ), patch("wenche.skd_skattemelding_client.SkdSkattemeldingClient") as Client:
+        skd = Client.return_value.__enter__.return_value
+        skd.hent_forhåndsutfylt_med_id.return_value = (
+            _FORHANDSUTFYLT,
+            "SKI:755:970817908",
+        )
+        skd.send.return_value = "instans-123"
+
+        result = CliRunner().invoke(
+            main, ["send-skattemelding", "--config", str(_CONFIG)]
+        )
+
+    assert result.exit_code == 0, result.output
+    skd.send.assert_called_once()
+    assert skd.send.call_args.kwargs["gjeldende_dokument_id"] == "SKI:755:970817908"

--- a/tests/test_skattemelding_konvolutt.py
+++ b/tests/test_skattemelding_konvolutt.py
@@ -119,6 +119,19 @@ class TestKonvolutt:
         info = root.find(f"{{{_NS}}}innsendingsinformasjon")
         assert info.find(f"{{{_NS}}}innsendingsformaal").text == "klage"
 
+    def test_dokumentreferanse_settes_naar_id_oppgitt(self):
+        root = _parse(
+            generer_konvolutt(_DUMMY_XML, 2024, gjeldende_dokument_id="SKI:755:970817908")
+        )
+        ref = root.find(f"{{{_NS}}}dokumentreferanseTilGjeldendeDokument")
+        assert ref is not None
+        assert ref.find(f"{{{_NS}}}dokumenttype").text == "skattemeldingUpersonlig"
+        assert ref.find(f"{{{_NS}}}dokumentidentifikator").text == "SKI:755:970817908"
+
+    def test_dokumentreferanse_mangler_naar_id_ikke_oppgitt(self):
+        root = _parse(generer_konvolutt(_DUMMY_XML, 2024))
+        assert root.find(f"{{{_NS}}}dokumentreferanseTilGjeldendeDokument") is None
+
     def test_output_er_gyldig_utf8_xml(self):
         result = generer_konvolutt(_DUMMY_XML, 2024, orgnr="922020523")
         assert isinstance(result, bytes)

--- a/wenche/cli.py
+++ b/wenche/cli.py
@@ -345,12 +345,15 @@ def send_skattemelding(config_fil: str, dry_run: bool):
 
     with SkdSkattemeldingClient(tokens["maskinporten_token"], env=env) as skd:
         test_partsnummer = os.getenv("SKD_TEST_PARTSNUMMER") if env == "test" else None
+        gjeldende_dokument_id: str | None = None
         if test_partsnummer:
             click.echo(f"Bruker SKD_TEST_PARTSNUMMER={test_partsnummer} (hopper over forhåndsutfylt)")
             partsnummer = int(test_partsnummer)
         else:
             click.echo("Henter forhåndsutfylt skattemelding...")
-            forhåndsutfylt = skd.hent_forhåndsutfylt(regnskap.regnskapsaar, orgnr)
+            forhåndsutfylt, gjeldende_dokument_id = skd.hent_forhåndsutfylt_med_id(
+                regnskap.regnskapsaar, orgnr
+            )
             partsnummer = hent_partsnummer(forhåndsutfylt)
         click.echo(f"Partsnummer: {partsnummer}")
 
@@ -376,6 +379,7 @@ def send_skattemelding(config_fil: str, dry_run: bool):
                 skattemelding_xml=skattemelding_xml,
                 altinn_token=tokens["altinn_token"],
                 naeringsspesifikasjon_xml=naeringsspesifikasjon_xml,
+                gjeldende_dokument_id=gjeldende_dokument_id,
             )
         except SkattemeldingValideringsfeil as e:
             click.echo(f"\n{e}")


### PR DESCRIPTION
CLI-kommandoen `wenche send-skattemelding` feilet validering med `innkommendeForespoerselManglerReferanseTilGjeldendeSkattemelding`.

## Årsak

`send-skattemelding` brukte den id-løse `hent_forhåndsutfylt()` og kalte `skd.send(...)` uten `gjeldende_dokument_id`, så konvolutten manglet `dokumentreferanseTilGjeldendeDokument`. Både `valider-skattemelding` og UI-en gjorde dette allerede riktig; CLI-en hang etter. Det er derfor den første vellykkede prod-innsendingen (via UI) virket, mens CLI-en ikke gjorde det.

## Endring

Bruker `hent_forhåndsutfylt_med_id()` og sender `gjeldende_dokument_id` videre til `skd.send(...)`, identisk med UI-stien.

## Tester

- `test_cli_send_skattemelding`: regresjonstest som verifiserer at CLI-en sender `gjeldende_dokument_id` gjennom til `send()`.
- To konvolutt-tester: `dokumentreferanseTilGjeldendeDokument` til stede når id oppgis, fraværende ellers.
- Full suite: 244 passed.

Closes #84