### PR TITLE
feat(skd): forklar kjente valideringskoder i klartekst

### DIFF
--- a/tests/test_valideringskode_forklaringer.py
+++ b/tests/test_valideringskode_forklaringer.py
@@ -1,0 +1,61 @@
+"""
+Klartekst-forklaringer i formater_valideringsresultat().
+
+Kjente, kryptiske Skatteetaten-koder skal oversettes til hva brukeren kan
+gjøre. Forklaringene er rent informative og endrer ikke hva som sendes.
+"""
+
+from wenche.skd_skattemelding_client import formater_valideringsresultat
+
+
+def _res(**kwargs) -> dict:
+    base = {
+        "resultat": "validertMedFeil",
+        "aarsak": None,
+        "avvik_ved_validering": [],
+        "avvik_etter_beregning": [],
+        "veiledning": [],
+    }
+    base.update(kwargs)
+    return base
+
+
+def test_forklarer_kjent_veiledningskode():
+    res = _res(
+        veiledning=[
+            {
+                "veiledningstype": "UP_HAR_NÆRINGSSPESIFIKASJON_MANGLER_SKATTEMELDING",
+                "hjelpetekst": "Selskapet mangler skattemelding.",
+            }
+        ]
+    )
+    ut = formater_valideringsresultat(res)
+    assert "Hva betyr dette?" in ut
+    assert "passive holdingselskaper" in ut
+    assert "utenfor" in ut
+    assert "skatteetaten.no" in ut
+
+
+def test_forklarer_kjent_aarsakskode():
+    res = _res(aarsak="innkommendeForespoerselManglerReferanseTilGjeldendeSkattemelding")
+    ut = formater_valideringsresultat(res)
+    assert "Hva betyr dette?" in ut
+    assert "Oppgrader Wenche" in ut
+
+
+def test_ingen_forklaringsseksjon_ved_ukjente_koder():
+    res = _res(
+        avvik_ved_validering=[{"avvikstype": "heltUkjentKode", "oevrigInformasjon": "x"}]
+    )
+    ut = formater_valideringsresultat(res)
+    assert "Hva betyr dette?" not in ut
+
+
+def test_duplikate_koder_forklares_kun_en_gang():
+    kode = "UP_HAR_NÆRINGSSPESIFIKASJON_MANGLER_SKATTEMELDING"
+    res = _res(
+        aarsak=kode,
+        veiledning=[{"veiledningstype": kode, "hjelpetekst": "x"}],
+    )
+    ut = formater_valideringsresultat(res)
+    assert ut.count("passive holdingselskaper") == 1

--- a/wenche/skd_skattemelding_client.py
+++ b/wenche/skd_skattemelding_client.py
@@ -310,6 +310,45 @@ def _parse_valideringsrespons(raw: bytes) -> dict:
     }
 
 
+# Klartekst-forklaringer for valideringskoder vi har sett i praksis.
+# Skatteetatens koder er kryptiske; her oversetter vi de kjente til hva
+# brukeren faktisk kan gjøre. Rent informativt; påvirker ikke hva som sendes.
+_KODE_FORKLARINGER = {
+    "UP_HAR_NÆRINGSSPESIFIKASJON_MANGLER_SKATTEMELDING": (
+        "Skattemeldingen inneholder ingen skattepliktige poster, mens "
+        "næringsspesifikasjonen har innhold. Wenche støtter kun passive "
+        "holdingselskaper (aksjeinntekt under fritaksmetoden). Selskaper med "
+        "ordinær drift og skattepliktig over- eller underskudd er utenfor "
+        "Wenches støtteområde og må levere via skatteetaten.no eller et "
+        "regnskapsprogram."
+    ),
+    "innkommendeForespoerselManglerReferanseTilGjeldendeSkattemelding": (
+        "Innsendingen mangler referanse til den forhåndsutfylte skattemeldingen. "
+        "Oppgrader Wenche til nyeste versjon og prøv igjen."
+    ),
+    "innkommendeForespoerselManglerSporTilUtfoerende": (
+        "Innsendingen ble forsøkt bekreftet maskinelt. Det siste steget må gjøres "
+        "manuelt: logg inn i Altinn med BankID og klikk «Send inn». Oppgrader "
+        "Wenche til 0.17.0 eller nyere."
+    ),
+}
+
+
+def _koder_i_resultat(res: dict):
+    """Samler alle koder (aarsak, avvikstype, veiledningstype) i rekkefølge, uten duplikater."""
+    koder = []
+    if res.get("aarsak"):
+        koder.append(res["aarsak"])
+    for a in (res.get("avvik_ved_validering") or []) + (res.get("avvik_etter_beregning") or []):
+        if a.get("avvikstype"):
+            koder.append(a["avvikstype"])
+    for v in res.get("veiledning") or []:
+        if v.get("veiledningstype"):
+            koder.append(v["veiledningstype"])
+    # bevar rekkefølge, fjern duplikater
+    return list(dict.fromkeys(koder))
+
+
 def formater_valideringsresultat(res: dict) -> str:
     """Formaterer et valideringsresultat fra valider() til lesbar tekst."""
     linjer = [f"resultatAvValidering: {res.get('resultat')}"]
@@ -337,6 +376,16 @@ def formater_valideringsresultat(res: dict) -> str:
         linjer.append(f"\nVeiledning/merknader ({len(veil)}):")
         for v in veil:
             linjer.append(f"  - {v.get('veiledningstype')}: {v.get('hjelpetekst')}")
+
+    forklaringer = [
+        (kode, _KODE_FORKLARINGER[kode])
+        for kode in _koder_i_resultat(res)
+        if kode in _KODE_FORKLARINGER
+    ]
+    if forklaringer:
+        linjer.append("\nHva betyr dette?")
+        for kode, tekst in forklaringer:
+            linjer.append(f"  - {kode}:\n    {tekst}")
 
     return "\n".join(linjer)
 


### PR DESCRIPTION
Skatteetatens valideringskoder er kryptiske. `formater_valideringsresultat` oversetter nå de kjente kodene til hva brukeren faktisk kan gjøre, i en «Hva betyr dette?»-seksjon.

## Endring

Rent additiv: en oppslagstabell over kjente koder og en hjelpefunksjon som samler kodene fra resultatet. Endrer ikke hva som sendes, kun den lesbare utskriften ved validering/avvisning.

Dekker kodene observert i praksis:
- `UP_HAR_NÆRINGSSPESIFIKASJON_MANGLER_SKATTEMELDING` (selskapet er utenfor Wenches støtteområde; Wenche støtter kun passive holdingselskaper)
- `innkommendeForespoerselManglerReferanseTilGjeldendeSkattemelding` (oppgrader Wenche)
- `innkommendeForespoerselManglerSporTilUtfoerende` (bekreft manuelt i Altinn med BankID)

## Tester

4 nye tester (kjent veiledningskode, kjent årsakskode, ukjente koder gir ingen seksjon, duplikater forklares én gang). Full suite: 245 passed.

Bakgrunn: kodene ble avdekket under diagnostisering i #82.