### PR TITLE
chore: bump versjon til 0.18.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.17.0"
+version = "0.18.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Versjonsbump før release.

Endringer siden v0.17.0:
- fix(skd): send gjeldende_dokument_id fra send-skattemelding (CLI) (#85, lukket #84)
- feat(skd): forklar kjente valideringskoder i klartekst (#86)
- fix(fristsjekk): rydd opp tre nits fra PR #55-review (#83)
- refactor/docs: bytt utdaterte RF-numre til moderne navn (#81)

MINOR-bump (0.17.0 → 0.18.0) siden endringene inkluderer en `feat`.

Etter merge: kjør `/release` for å tagge v0.18.0 og publisere til PyPI.