### PR TITLE
chore: bump versjon til 0.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.18.0"
+version = "0.19.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Sammendrag
- Bumper versjon fra 0.18.0 til 0.19.0 etter feature-PR #88 (versjon i header + oppdateringssjekk + auto-oppdaterings-dialog).

## Oppfølging
Etter merge, kjør `/release` for å tagge `v0.19.0` og publisere til PyPI.