### PR TITLE
feat(aksjonaer): støtt desimal pålydende for selskaper med fri pålydende

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.19.0"
+version = "0.20.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_aksjonaerregister.py
+++ b/tests/test_aksjonaerregister.py
@@ -132,7 +132,9 @@ def test_hovedskjema_paalydende_desimal():
     Selskaper med fri pålydende (lovlig siden 2013) kan ha brøkdeler av en
     krone som pålydende. For 30 000 kr aksjekapital fordelt på 300 000 aksjer
     er pålydende 0,10. Skjemaet må representere dette eksakt, ikke trunkere
-    til 0 som integer-divisjon ville gjort.
+    til 0 som integer-divisjon ville gjort. RF-1086 tillater opptil 6
+    desimaler (bekreftet i SSV-5278), og vi stripper etterstilte nuller for
+    kompakt representasjon.
     """
     selskap = Selskap(
         navn="Fragmentert Holding AS",
@@ -160,11 +162,11 @@ def test_hovedskjema_paalydende_desimal():
     root = _parse(generer_hovedskjema_xml(oppgave))
     paalydende = root.find(".//{*}AksjeMvPalydende-datadef-23945")
     assert paalydende is not None
-    assert paalydende.text == "0.10"
+    assert paalydende.text == "0.1"
     # Fjorår-pålydende skal også reflektere desimalverdien (ikke stiftelsesår)
     fjor = root.find(".//{*}AksjeMvPalydendeFjoraret-datadef-23944")
     assert fjor is not None
-    assert fjor.text == "0.10"
+    assert fjor.text == "0.1"
 
 
 def test_hovedskjema_kontakt_epost(eksempel_oppgave):

--- a/tests/test_aksjonaerregister.py
+++ b/tests/test_aksjonaerregister.py
@@ -119,11 +119,52 @@ def test_hovedskjema_antall_aksjer(eksempel_oppgave):
 
 
 def test_hovedskjema_paalydende(eksempel_oppgave):
-    """Pålydende per aksje = aksjekapital // antall_aksjer = 30000 // 100 = 300."""
+    """Pålydende per aksje = aksjekapital / antall_aksjer = 30000 / 100 = 300."""
     root = _parse(generer_hovedskjema_xml(eksempel_oppgave))
     paalydende = root.find(".//{*}AksjeMvPalydende-datadef-23945")
     assert paalydende is not None
-    assert int(paalydende.text) == 300
+    # Heltallspålydende skal formateres uten desimalpunktum
+    assert paalydende.text == "300"
+
+
+def test_hovedskjema_paalydende_desimal():
+    """
+    Selskaper med fri pålydende (lovlig siden 2013) kan ha brøkdeler av en
+    krone som pålydende. For 30 000 kr aksjekapital fordelt på 300 000 aksjer
+    er pålydende 0,10. Skjemaet må representere dette eksakt, ikke trunkere
+    til 0 som integer-divisjon ville gjort.
+    """
+    selskap = Selskap(
+        navn="Fragmentert Holding AS",
+        org_nummer="987654321",
+        daglig_leder="Kari Nordmann",
+        styreleder="Kari Nordmann",
+        forretningsadresse="Testveien 2, 0001 Oslo",
+        stiftelsesaar=2020,
+        aksjekapital=30000,
+        kontakt_epost="kari@test.no",
+    )
+    aksjonaer = Aksjonaer(
+        navn="Kari Nordmann",
+        fodselsnummer="20916997389",
+        antall_aksjer=300000,
+        aksjeklasse="A",
+        utbytte_utbetalt=0,
+        innbetalt_kapital_per_aksje=0.10,
+    )
+    oppgave = Aksjonaerregisteroppgave(
+        selskap=selskap,
+        regnskapsaar=2024,
+        aksjonaerer=[aksjonaer],
+    )
+    root = _parse(generer_hovedskjema_xml(oppgave))
+    paalydende = root.find(".//{*}AksjeMvPalydende-datadef-23945")
+    assert paalydende is not None
+    assert paalydende.text == "0.10"
+    # Fjorår-pålydende skal også reflektere desimalverdien (ikke stiftelsesår)
+    fjor = root.find(".//{*}AksjeMvPalydendeFjoraret-datadef-23944")
+    assert fjor is not None
+    assert fjor.text == "0.10"
 
 
 def test_hovedskjema_kontakt_epost(eksempel_oppgave):

--- a/wenche/aksjonaerregister.py
+++ b/wenche/aksjonaerregister.py
@@ -27,16 +27,20 @@ _BRG_ENHET_URL = "https://data.brreg.no/enhetsregisteret/api/enheter"
 
 def _format_paalydende(verdi: float) -> str:
     """
-    Formater pålydende per aksje for RF-1086-XMLen. Rundes til to desimaler
-    for å absorbere flyttalls-støy fra divisjonen, og returneres som
-    heltallstreng når verdien er et helt kronebeløp (f.eks. 300 → "300").
-    Ellers beholdes to desimaler (f.eks. 0,10 → "0.10"), slik at selskaper
-    med fri pålydende (lovlig siden 2013) representeres riktig i skjemaet.
+    Formater pålydende per aksje for RF-1086-XMLen.
+
+    RF-1086 tillater opptil 6 desimaler i pålydende-feltet (bekreftet av
+    Skatteetaten i SSV-5278). Verdien rundes derfor til 6 desimaler for å
+    fjerne flyttalls-støy fra divisjonen og overhold spec-grensen. Resultatet
+    returneres som heltallstreng for hele kroner (f.eks. 300 → "300") og
+    desimalstreng uten unødvendige etterstilte nuller ellers (f.eks. 0,10
+    → "0.1", 0,123456 → "0.123456"), slik at selskaper med fri pålydende
+    (lovlig siden 2013) representeres kompakt i skjemaet.
     """
-    rundet = round(verdi, 2)
+    rundet = round(verdi, 6)
     if rundet.is_integer():
         return str(int(rundet))
-    return f"{rundet:.2f}"
+    return f"{rundet:.6f}".rstrip("0").rstrip(".")
 
 
 def les_config(config_fil: str) -> Aksjonaerregisteroppgave:

--- a/wenche/aksjonaerregister.py
+++ b/wenche/aksjonaerregister.py
@@ -25,6 +25,20 @@ from wenche.skd_client import SkdAksjonaerClient
 _BRG_ENHET_URL = "https://data.brreg.no/enhetsregisteret/api/enheter"
 
 
+def _format_paalydende(verdi: float) -> str:
+    """
+    Formater pålydende per aksje for RF-1086-XMLen. Rundes til to desimaler
+    for å absorbere flyttalls-støy fra divisjonen, og returneres som
+    heltallstreng når verdien er et helt kronebeløp (f.eks. 300 → "300").
+    Ellers beholdes to desimaler (f.eks. 0,10 → "0.10"), slik at selskaper
+    med fri pålydende (lovlig siden 2013) representeres riktig i skjemaet.
+    """
+    rundet = round(verdi, 2)
+    if rundet.is_integer():
+        return str(int(rundet))
+    return f"{rundet:.2f}"
+
+
 def les_config(config_fil: str) -> Aksjonaerregisteroppgave:
     """Leser config.yaml og returnerer en Aksjonaerregisteroppgave."""
     with open(config_fil, encoding="utf-8") as f:
@@ -77,7 +91,11 @@ def generer_hovedskjema_xml(
     org = innsending_org or s.org_nummer
     aar = oppgave.regnskapsaar
     totalt_aksjer = oppgave.totalt_antall_aksjer
-    paalydende = round(s.aksjekapital) // totalt_aksjer if totalt_aksjer > 0 else 0
+    paalydende = (
+        _format_paalydende(s.aksjekapital / totalt_aksjer)
+        if totalt_aksjer > 0
+        else "0"
+    )
     stiftelsesdato = f"{s.stiftelsesaar}-01-01T00:00:00"
 
     # Fjorår-felter og stiftelsestransaksjon skal kun inkluderes i stiftelsesåret.
@@ -86,7 +104,7 @@ def generer_hovedskjema_xml(
     er_stiftelsesaar = s.stiftelsesaar == aar
     fjoraret_aksjekapital = 0 if er_stiftelsesaar else round(s.aksjekapital)
     fjoraret_aksjer = 0 if er_stiftelsesaar else totalt_aksjer
-    fjoraret_paalydende = 0 if er_stiftelsesaar else paalydende
+    fjoraret_paalydende = "0" if er_stiftelsesaar else paalydende
     if er_stiftelsesaar:
         stiftelse_innhold = f"""
             <AksjerNyutstedteStiftelseMvAntall-datadef-17668 orid="17668">{totalt_aksjer}</AksjerNyutstedteStiftelseMvAntall-datadef-17668>

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -940,9 +940,47 @@ def metric_kort(tittel: str, verdi: str, farge: str = "slate") -> ui.label:
 
 
 def num(label: str, attr: str, obj=None, step: float = 1000, min_val: float | None = 0,
-        on_change=None, tooltip: str = "") -> ui.number:
-    """Tallinnfelt som oppdaterer state-attributt ved endring."""
+        on_change=None, tooltip: str = "", desimaler: int | None = 0):
+    """
+    Tallinnfelt som oppdaterer state-attributt ved endring.
+
+    `desimaler` styrer både visningsformat og hvilken type input som brukes:
+      - `int` (standard 0): bruker `ui.number` med fast format `%.Nf`, slik
+        som tidligere. Heltallsfelt og felt med fast desimal-presisjon.
+      - `None`: bruker `ui.input` (tekst-felt) med `inputmode=decimal`. Da
+        kan brukeren skrive både "," og "." som desimalskille (HTML5
+        `type=number` aksepterer kun "."), og visningen padder ikke med
+        etterstilte nuller — 300 vises som "300", 0,10 vises som "0,1".
+        Husk å sette `step` lavt (typisk 0.01) hvis du beholder felt med
+        spinner-knapper andre steder; for tekst-varianten har `step` ingen
+        synlig effekt, men beholdes for API-kompatibilitet.
+    """
     target = obj if obj is not None else state
+
+    if desimaler is None:
+        # Tekst-input som aksepterer både norsk og engelsk desimalskille.
+        def tekst_handler(e):
+            raw = (e.value or "").replace(",", ".").strip()
+            try:
+                verdi = float(raw) if raw else 0.0
+            except ValueError:
+                return
+            setattr(target, attr, verdi)
+            if on_change:
+                on_change()
+
+        startverdi = getattr(target, attr)
+        if isinstance(startverdi, (int, float)) and float(startverdi).is_integer():
+            visning = str(int(startverdi))
+        else:
+            visning = str(startverdi)
+        el = ui.input(label=label, value=visning, on_change=tekst_handler).classes("w-full")
+        el.props("inputmode=decimal")
+        if tooltip:
+            el.tooltip(tooltip)
+        if obj is None:
+            _input_elements[attr] = el
+        return el
 
     def handler(e):
         setattr(target, attr, float(e.value) if e.value is not None else 0.0)
@@ -953,7 +991,7 @@ def num(label: str, attr: str, obj=None, step: float = 1000, min_val: float | No
         "label": label,
         "value": getattr(target, attr),
         "step": step,
-        "format": "%.0f",
+        "format": f"%.{desimaler}f",
         "on_change": handler,
     }
     if min_val is not None:
@@ -2470,9 +2508,14 @@ def _bygg_aksjonaer_fane() -> None:
                         "Innbetalt kapital per aksje (NOK)",
                         "innbetalt_kapital_per_aksje",
                         obj=a,
-                        step=1,
+                        step=0.01,
                         min_val=0,
-                        tooltip="Aksjekapital delt på antall aksjer. Eks: 30 000 kr / 100 aksjer = 300 kr per aksje.",
+                        desimaler=None,
+                        tooltip=(
+                            "Aksjekapital delt på antall aksjer. "
+                            "Eks: 30 000 kr / 100 aksjer = 300 kr per aksje, "
+                            "eller 30 000 kr / 300 000 aksjer = 0,10 kr per aksje."
+                        ),
                     )
                     innbetalt_inp.on("blur", lambda _: aksjonaer_liste.refresh())
 


### PR DESCRIPTION
## Sammendrag
- Pålydende per aksje beregnes som float-divisjon i stedet for integer-divisjon i [wenche/aksjonaerregister.py](wenche/aksjonaerregister.py). Hjelpefunksjonen `_format_paalydende()` rounder til 6 desimaler (per SKD-spec) og returnerer heltallstreng for hele kroner («300») eller desimalstreng uten unødvendige etterstilte nuller («0.1», «0.123456»).
- «Innbetalt kapital per aksje»-feltet i UIet bruker tekst-input med `inputmode=decimal`, slik at både «0,10» og «0.10» fungerer. HTML5 `type=number` aksepterer kun «.» uavhengig av locale.
- `num()`-helperen er utvidet med en `desimaler`-parameter: `int` for fast format (uendret oppførsel), `None` for fri tekst-input med locale-tolerant parsing.
- Versjonsbump til **0.20.0** (MINOR for `feat`). Releasen bundler også fixen fra PR #91 (`fix(oppsett): kjør registrer_system automatisk fra «Opprett systembruker»`) som ble merget før denne PR-en.

## Bakgrunn
Konkret bruker: et passivt holdingselskap med 30 000 kr aksjekapital fordelt på 300 000 aksjer á 0,10 kr (i tråd med aksjeloven §3-1 om fri pålydende, lovlig siden 2013). Den gamle koden brukte integer-divisjon (`s.aksjekapital // totalt_aksjer`), som ga pålydende = 0 og ville feilet SKDs validering.

## Bekreftet fra SKD (SSV-5278)
> «de aktuelle feltet kan fylles ut med desimaler inntil 6 tegn. dvs 10,000000 ev. 7 tegn må avrundes opp til næreste tall i 6 desimal.»

Implementasjonen følger denne spec-en: `round(verdi, 6)`, og etterstilte nuller strippes for kompakt XML. Skjemaene som valideres mot ligger her: https://skatteetaten.github.io/api-dokumentasjon/api/innrapportering-aksjonaerregisteroppgave?tab=Om+tjenesten

## Risikoanalyse for eksisterende brukere
Brukere med «vanlig» aksjekapital (heltallspålydende):
- Funksjonelt: ingen endring. XML-output identisk («300» → «300»).
- Visuelt: UI-feltet «Innbetalt kapital per aksje» har ikke lenger spinner-knapper, men beholder visningen av det brukeren skrev (300 forblir «300», ikke «300,00»).
- Eksisterende test `test_hovedskjema_paalydende` strammet til å sjekke eksakt streng-output («300»), bekrefter regresjonsfri oppførsel.

Edge case forbedret: hvis aksjekapital ikke deler jevnt på antall aksjer (f.eks. 30 000 / 7), avkortet gammel kode til «4285». Ny kode representerer 4 285.714286 korrekt (6 desimaler).

## Test plan
- [x] Lokal testsuite (249/249 grønne, inkludert ny `test_hovedskjema_paalydende_desimal`)
- [x] Skriftlig bekreftelse fra SKD (SSV-5278)
- [ ] Visuell verifikasjon i `wenche ui`: skriv «0,10» og «0.10», sjekk at begge fungerer
- [ ] Faktisk innsending mot prod for brukerens selskap når oppsettet er klart