### PR TITLE
fix(oppsett): kjør registrer_system automatisk fra «Opprett systembruker»

### DIFF
--- a/docs/oppsett.md
+++ b/docs/oppsett.md
@@ -254,12 +254,11 @@ Start `wenche ui` og gå til **1. Oppsett**-fanen. Under «Per miljø-oppsett» 
 **For å opprette en ny systembruker:**
 
 1. Sørg for at Maskinporten-credentials og organisasjonsnummer er fylt inn i kortet (og lagret).
-2. Åpne **Avansert**-ekspansjonen i kortet og klikk **Registrer system**. Dette registrerer Wenche i Altinns systemregister med de nødvendige tilgangsrettighetene. Idempotent — kan kjøres flere ganger uten skade.
-3. Klikk **Opprett systembruker** i samme kort. Wenche oppretter en forespørsel og viser en «Godkjenn i Altinn →»-lenke.
-4. Åpne lenken og godkjenn:
+2. Klikk **Opprett systembruker**. Wenche registrerer seg i Altinns systemregister automatisk hvis det ikke er gjort, oppretter en forespørsel, og viser en «Godkjenn i Altinn →»-lenke.
+3. Åpne lenken og godkjenn:
     - **Produksjon:** Logg inn med BankID som daglig leder eller styreleder.
     - **Testmiljø:** Logg inn med TestID. Bruk fødselsnummeret til daglig leder for Tenor-orgen din (finnes under **Kildedata → rollegrupper → DAGL** i [Tenor testdatasøk](https://www.skatteetaten.no/testdata/)).
-5. Tilbake i Wenche: klikk **Jeg har godkjent — sjekk status** ved siden av lenken. Status oppdateres til **Systembruker godkjent**.
+4. Tilbake i Wenche: klikk **Jeg har godkjent — sjekk status** ved siden av lenken. Status oppdateres til **Systembruker godkjent**.
 
 **Hvis status fortsatt sier «venter»:** Vent 10-20 sekunder og klikk knappen igjen — Altinn trenger noen sekunder på å registrere godkjenningen.
 

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -1544,17 +1544,8 @@ def _bygg_oppsett_fane() -> None:
                         # streng på POST i stedet for et dict. Håndter begge.
                         oppdatert = isinstance(svar, dict) and svar.get("oppdatert", False)
                         hva = "System oppdatert." if oppdatert else "System registrert."
-                        # Hvis systembruker ikke er satt opp ennå, dyttene
-                        # brukeren videre til neste logiske handling.
-                        if _siste_status.get(env) in ("ikke_opprettet", None):
-                            n.message = (
-                                f"{hva} Neste steg: klikk «Opprett systembruker» "
-                                "for å lage forespørselen som skal godkjennes."
-                            )
-                            n.timeout = 10
-                        else:
-                            n.message = hva
-                            n.timeout = 5
+                        n.message = hva
+                        n.timeout = 5
                         n.spinner = False
                         n.type = "positive"
                     except Exception as e:
@@ -1566,13 +1557,25 @@ def _bygg_oppsett_fane() -> None:
 
                 async def opprett_handler(env=env_var):
                     n = ui.notification(
-                        f"Oppretter systembruker-forespørsel i "
+                        f"Oppretter systembruker i "
                         f"{('testmiljø' if env == 'test' else 'produksjon')}...",
                         spinner=True, timeout=None,
                     )
                     try:
                         token = await run.io_bound(lambda: _med_env(env, auth.login_admin))
                         vendor_orgnr = os.getenv("ORG_NUMMER")
+                        client_id = _les_konfig_for_milj("MASKINPORTEN_CLIENT_ID", env)
+                        # Sørg for at Wenche er registrert i Altinns systemregister
+                        # før vi oppretter forespørselen — opprett_forespørsel
+                        # forutsetter at systemId finnes. registrer_system er
+                        # idempotent (POST → PUT-fallback hvis allerede registrert),
+                        # så det er trygt å kjøre hver gang.
+                        await run.io_bound(
+                            lambda: _med_env(
+                                env, systembruker.registrer_system,
+                                token, vendor_orgnr, client_id,
+                            )
+                        )
                         party_orgnr = (
                             os.getenv("SKD_TEST_ORG_NUMMER", vendor_orgnr)
                             if env == "test" else vendor_orgnr


### PR DESCRIPTION
## Sammendrag
- «Opprett systembruker»-hovedknappen kjører nå `registrer_system` transparent som første steg, før `opprett_forespørsel`. Førstegangsbrukere slipper å åpne Avansert og klikke to knapper i riktig rekkefølge for å komme videre.
- Dokumentasjonen i [docs/oppsett.md](docs/oppsett.md) er forenklet tilsvarende: steg 5 har nå fire steg i stedet for fem, og det er konsistens mellom dokumentasjon og UI.
- «Registrer system»-knappen i Avansert er beholdt for re-registrering ved scope-endringer (slik forklarende tekst der allerede sier).

## Bakgrunn
`opprett_forespørsel` POSTer mot Altinns systemuser-request-endpoint med en `systemId` som må være registrert i Altinns systemregister først. `opprett_handler` i UIet kalte ikke `registrer_system`, så en ny bruker som klikket primærknappen «Opprett systembruker» (uten å først gå inn i Avansert og kjøre «Registrer system») fikk en kryptisk feilmelding fra Altinn.

Den eldre UX-modellen forutsatte at brukeren leste dokumentasjonen og forsto at de to handlingene måtte gjøres i rekkefølge. Det er en dårlig opplevelse, og dokumentasjonen og UI sa to forskjellige ting: docen sa «åpne Avansert og kjør Registrer system», mens UI-teksten under Avansert sa «Disse trengs sjelden».

## Endring
`opprett_handler` ([wenche/ui.py](wenche/ui.py)) kjører nå:
1. `registrer_system` (idempotent — POST med PUT-fallback hvis systemet allerede finnes)
2. `opprett_forespørsel` (uendret)

Brukere som allerede har systemet registrert merker ingen forskjell utover én ekstra HTTP-roundtrip (sub-sekund). Brukere som ikke har det får full første-gangs-flyt fra én enkel knapp.

## Test plan
- [x] Lokal testsuite (248/248 grønne)