### PR TITLE
feat(skattemelding): emit avledede summer for å unngå etterBeregning-avvik

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.20.0"
+version = "0.21.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_naeringsspesifikasjon_xml.py
+++ b/tests/test_naeringsspesifikasjon_xml.py
@@ -453,3 +453,168 @@ class TestBeloepsformat:
             if el.text:
                 assert "." in el.text
                 break
+
+
+# ---------------------------------------------------------------------------
+# Avledede summer
+#
+# SKD krever at vi echo-er våre egne beregnede summer for kryssvalidering.
+# Manglende felt flagges som «manglerNaeringsopplysninger» i etterBeregning
+# (SSV/tilbakemelding 2026-05) selv om resultatAvValidering er «validertOK».
+# ---------------------------------------------------------------------------
+
+class TestAvledetSummer:
+    def _beloep(self, root, path: str) -> float:
+        """
+        Hent ut det innerste beloep-elementets verdi (struktur
+        <{tag}><beloep><beloep>...</beloep></beloep></{tag}>) for en gitt sti.
+        """
+        ns_path = ".//".join(f"{{{_NS}}}{p}" for p in path.split("/"))
+        el = root.find(f".//{ns_path}")
+        assert el is not None, f"Fant ikke {path}"
+        verdi = el.find(f"{{{_NS}}}beloep/{{{_NS}}}beloep")
+        assert verdi is not None and verdi.text, f"Fant ikke beloep-tekst i {path}"
+        return float(verdi.text)
+
+    def test_sumDriftsinntekt(self):
+        regnskap = _lag_regnskap(
+            resultatregnskap=Resultatregnskap(
+                driftsinntekter=Driftsinntekter(
+                    salgsinntekter=100000, andre_driftsinntekter=5000
+                ),
+                driftskostnader=Driftskostnader(),
+                finansposter=Finansposter(),
+            )
+        )
+        assert self._beloep(_parse(regnskap), "sumDriftsinntekt") == 105000.0
+
+    def test_sumDriftskostnad(self):
+        regnskap = _lag_regnskap(
+            resultatregnskap=Resultatregnskap(
+                driftsinntekter=Driftsinntekter(),
+                driftskostnader=Driftskostnader(
+                    loennskostnader=20000,
+                    avskrivninger=3000,
+                    andre_driftskostnader=5000,
+                ),
+                finansposter=Finansposter(),
+            )
+        )
+        assert self._beloep(_parse(regnskap), "sumDriftskostnad") == 28000.0
+
+    def test_sum_finansinntekt_og_finanskostnad(self):
+        regnskap = _lag_regnskap(
+            resultatregnskap=Resultatregnskap(
+                driftsinntekter=Driftsinntekter(),
+                driftskostnader=Driftskostnader(),
+                finansposter=Finansposter(
+                    utbytte_fra_datterselskap=10000,
+                    andre_finansinntekter=2000,
+                    rentekostnader=1500,
+                    andre_finanskostnader=500,
+                ),
+            )
+        )
+        root = _parse(regnskap)
+        assert self._beloep(root, "sumFinansinntekt") == 12000.0
+        assert self._beloep(root, "sumFinanskostnad") == 2000.0
+
+    def test_aarsresultat_er_resultat_foer_skatt(self):
+        # Holdingselskap uten skattekostnad: aarsresultat = resultat_foer_skatt
+        regnskap = _lag_regnskap(
+            resultatregnskap=Resultatregnskap(
+                driftsinntekter=Driftsinntekter(salgsinntekter=100000),
+                driftskostnader=Driftskostnader(andre_driftskostnader=80000),
+                finansposter=Finansposter(rentekostnader=5000),
+            )
+        )
+        # 100000 - 80000 - 5000 = 15000
+        assert self._beloep(_parse(regnskap), "aarsresultat") == 15000.0
+
+    def test_sumBalanseverdiForAnleggsmiddel_og_omloepsmiddel(self):
+        regnskap = _lag_regnskap(
+            balanse=Balanse(
+                eiendeler=Eiendeler(
+                    anleggsmidler=Anleggsmidler(
+                        aksjer_i_datterselskap=50000, andre_aksjer=20000
+                    ),
+                    omloepmidler=Omloepmidler(
+                        kortsiktige_fordringer=3000, bankinnskudd=10000
+                    ),
+                ),
+                egenkapital_og_gjeld=EgenkapitalOgGjeld(
+                    egenkapital=Egenkapital(aksjekapital=30000),
+                ),
+            )
+        )
+        root = _parse(regnskap)
+        assert self._beloep(root, "sumBalanseverdiForAnleggsmiddel") == 70000.0
+        assert self._beloep(root, "sumBalanseverdiForOmloepsmiddel") == 13000.0
+        assert self._beloep(root, "sumBalanseverdiForEiendel") == 83000.0
+
+    def test_gjeldOgEgenkapital_summer(self):
+        regnskap = _lag_regnskap(
+            balanse=Balanse(
+                eiendeler=Eiendeler(
+                    anleggsmidler=Anleggsmidler(aksjer_i_datterselskap=100000),
+                ),
+                egenkapital_og_gjeld=EgenkapitalOgGjeld(
+                    egenkapital=Egenkapital(aksjekapital=30000, annen_egenkapital=10000),
+                    langsiktig_gjeld=LangsiktigGjeld(laan_fra_aksjonaer=50000),
+                    kortsiktig_gjeld=KortsiktigGjeld(annen_kortsiktig_gjeld=10000),
+                ),
+            )
+        )
+        root = _parse(regnskap)
+        assert self._beloep(root, "sumLangsiktigGjeld") == 50000.0
+        assert self._beloep(root, "sumKortsiktigGjeld") == 10000.0
+        assert self._beloep(root, "sumEgenkapital") == 40000.0
+        assert self._beloep(root, "sumGjeldOgEgenkapital") == 100000.0
+
+    def test_beregnetNaeringsinntekt_med_underskudd(self):
+        regnskap = _lag_regnskap(
+            resultatregnskap=Resultatregnskap(
+                driftsinntekter=Driftsinntekter(salgsinntekter=10000),
+                driftskostnader=Driftskostnader(andre_driftskostnader=15000),
+                finansposter=Finansposter(),
+            )
+        )
+        root = _parse(regnskap)
+        assert root.find(f".//{{{_NS}}}beregnetNaeringsinntekt") is not None
+        # skattemessigResultat = aarsresultat = -5000
+        assert self._beloep(root, "skattemessigResultat") == -5000.0
+        # Fordeling på forekomst id=1
+        fordelt = root.find(
+            f".//{{{_NS}}}fordeltBeregnetNaeringsinntektForUpersonligSkattepliktig"
+        )
+        assert fordelt is not None
+        assert fordelt.find(f"{{{_NS}}}id").text == "1"
+
+    def test_egenkapitalavstemming_har_sumFradragOgUtgaaendeEK_ved_underskudd(self):
+        # Inngående EK 30000, årets underskudd 5000 → utgående 25000,
+        # sumFradragIEgenkapital = 5000.
+        regnskap = _lag_regnskap(
+            resultatregnskap=Resultatregnskap(
+                driftsinntekter=Driftsinntekter(),
+                driftskostnader=Driftskostnader(andre_driftskostnader=5000),
+                finansposter=Finansposter(),
+            ),
+            balanse=Balanse(
+                eiendeler=Eiendeler(
+                    anleggsmidler=Anleggsmidler(aksjer_i_datterselskap=25000),
+                ),
+                egenkapital_og_gjeld=EgenkapitalOgGjeld(
+                    egenkapital=Egenkapital(aksjekapital=30000, annen_egenkapital=-5000),
+                ),
+            ),
+            foregaaende_aar_balanse=Balanse(
+                egenkapital_og_gjeld=EgenkapitalOgGjeld(
+                    egenkapital=Egenkapital(aksjekapital=30000),
+                ),
+            ),
+        )
+        root = _parse(regnskap)
+        assert self._beloep(root, "sumFradragIEgenkapital") == 5000.0
+        assert self._beloep(root, "utgaaendeEgenkapital") == 25000.0
+        # Ingen sumTilleggIEgenkapital ved underskudd
+        assert root.find(f".//{{{_NS}}}sumTilleggIEgenkapital") is None

--- a/tests/test_skattemelding_xml.py
+++ b/tests/test_skattemelding_xml.py
@@ -83,3 +83,78 @@ class TestSkattemeldingXml:
         result = generer_skattemelding_upersonlig(99887766, 2023)
         assert isinstance(result, bytes)
         fromstring(result.decode("utf-8"))
+
+
+class TestAaretsUnderskudd:
+    """
+    Tester for de avledede underskuddssumene som SKD krever for å unngå
+    «manglerSkattemelding»-avvik i etterBeregning (jf. tilbakemelding 2026-05).
+    """
+
+    def test_aarets_underskudd_inkluderer_alle_avledede_summer(self):
+        root = _parse(generer_skattemelding_upersonlig(
+            12345678, 2024, aarets_underskudd=5000,
+        ))
+        iou = root.find(f"{{{_NS}}}inntektOgUnderskudd")
+        assert iou is not None
+
+        # inntektsfradrag/underskudd = årets underskudd
+        ifr = iou.find(f"{{{_NS}}}inntektsfradrag/{{{_NS}}}underskudd/{{{_NS}}}beloepSomHeltall")
+        assert ifr is not None and ifr.text == "5000"
+
+        # inntektFoerFradragForEventueltAvgittKonsernbidrag = -underskudd
+        ifu = iou.find(
+            f"{{{_NS}}}inntektFoerFradragForEventueltAvgittKonsernbidrag/{{{_NS}}}beloepSomHeltall"
+        )
+        assert ifu is not None and ifu.text == "-5000"
+
+        # samletUnderskudd (overstyrt) = årets underskudd
+        sum_u = iou.find(
+            f"{{{_NS}}}samletUnderskudd/{{{_NS}}}beloep/{{{_NS}}}beloepSomHeltall"
+        )
+        assert sum_u is not None and sum_u.text == "5000"
+
+    def test_fremfoerbart_er_summen_av_aarets_og_fremfoert(self):
+        # Fremført fra tidligere år 1500 + årets underskudd 5000 = 6500
+        root = _parse(generer_skattemelding_upersonlig(
+            12345678, 2024,
+            fremfoert_underskudd=1500,
+            aarets_underskudd=5000,
+        ))
+        utf = root.find(f"{{{_NS}}}inntektOgUnderskudd/{{{_NS}}}underskuddTilFremfoering")
+        assert utf is not None
+
+        fra_tidligere = utf.find(
+            f"{{{_NS}}}fremfoertUnderskuddFraTidligereAar/{{{_NS}}}beloepSomHeltall"
+        )
+        assert fra_tidligere is not None and fra_tidligere.text == "1500"
+
+        fremfoerbart = utf.find(
+            f"{{{_NS}}}fremfoerbartUnderskuddIInntekt/{{{_NS}}}beloep/{{{_NS}}}beloepSomHeltall"
+        )
+        assert fremfoerbart is not None and fremfoerbart.text == "6500"
+
+    def test_aarets_underskudd_uten_fremfoert_genererer_underskuddTilFremfoering(self):
+        root = _parse(generer_skattemelding_upersonlig(
+            12345678, 2024, aarets_underskudd=4000,
+        ))
+        utf = root.find(f"{{{_NS}}}inntektOgUnderskudd/{{{_NS}}}underskuddTilFremfoering")
+        assert utf is not None
+        # Uten fremført fra tidligere år, men med årets underskudd:
+        # fremfoerbartUnderskuddIInntekt = 0 + 4000 = 4000
+        fremfoerbart = utf.find(
+            f"{{{_NS}}}fremfoerbartUnderskuddIInntekt/{{{_NS}}}beloep/{{{_NS}}}beloepSomHeltall"
+        )
+        assert fremfoerbart is not None and fremfoerbart.text == "4000"
+        # fremfoertUnderskuddFraTidligereAar utelates når 0
+        assert utf.find(f"{{{_NS}}}fremfoertUnderskuddFraTidligereAar") is None
+
+    def test_uten_underskudd_ingen_avledede_summer(self):
+        root = _parse(generer_skattemelding_upersonlig(12345678, 2024))
+        assert root.find(f"{{{_NS}}}inntektOgUnderskudd") is None
+
+    def test_output_med_underskudd_er_gyldig_xml(self):
+        result = generer_skattemelding_upersonlig(
+            12345678, 2024, fremfoert_underskudd=1500, aarets_underskudd=5000,
+        )
+        fromstring(result.decode("utf-8"))

--- a/wenche/naeringsspesifikasjon_xml.py
+++ b/wenche/naeringsspesifikasjon_xml.py
@@ -8,8 +8,12 @@ Namespace: urn:no:skatteetaten:fastsetting:formueinntekt:naeringsspesifikasjon:e
 XSD: naeringsspesifikasjon_v6_ekstern.xsd
 
 Kodeliste: 2025_resultatregnskapOgBalanse.xml
-  Feltene erAvledet="true" i XSD-en beregnes av Skatteetaten — disse
-  settes ikke av Wenche.
+  Feltene erAvledet="true" i XSD-en beregnes også av Skatteetaten, men
+  tilbakemeldingen fra en innsending 2026-05 (OFL Holding) viste at SKD
+  forventer at vi echo-er våre egne beregnede summer for kryssvalidering.
+  Manglende summer flagges som «manglerSkattemelding»/«manglerNaerings-
+  opplysninger» i avvikEtterBeregning selv om resultatAvValidering blir
+  «validertOK». Wenche emitterer derfor de avledede sumemene eksplisitt.
 
 Implementasjonen dekker en typisk norsk holding AS med:
   - Salgsinntekter (3200) og andre driftsinntekter (3900)
@@ -109,8 +113,9 @@ def generer_naeringsspesifikasjon(
     Genererer naeringsspesifikasjon XML for innsending til Skatteetaten.
 
     Næringsoppgaven er obligatorisk for AS — uten den avviser Skatteetaten
-    konvolutten. Avledede felt (sumDriftsinntekt osv.) beregnes av
-    Skatteetaten og settes ikke her.
+    konvolutten. Avledede summer (sumDriftsinntekt, aarsresultat,
+    sumBalanseverdiFor*, sumGjeldOgEgenkapital, skattemessigResultat osv.)
+    emitteres eksplisitt for å unngå avvik i SKDs etterBeregning.
 
     Args:
         regnskap:     Årsregnskap med resultatregnskap og balanse.
@@ -134,8 +139,10 @@ def generer_naeringsspesifikasjon(
 
     resultatregnskap = SubElement(root, "resultatregnskap")
 
-    # Driftsinntekter
+    # Driftsinntekter. sumDriftsinntekt må stå først i Driftsinntekt per XSD.
     driftsinntekt_el = SubElement(resultatregnskap, "driftsinntekt")
+    if di.sum:
+        _beloep_element(driftsinntekt_el, "sumDriftsinntekt", di.sum)
 
     if di.salgsinntekter:
         salgsinntekt_el = SubElement(driftsinntekt_el, "salgsinntekt")
@@ -145,8 +152,10 @@ def generer_naeringsspesifikasjon(
         annen_di_el = SubElement(driftsinntekt_el, "annenDriftsinntekt")
         _resultatforekomst(annen_di_el, "inntekt", di.andre_driftsinntekter, "3900")
 
-    # Driftskostnader
+    # Driftskostnader. sumDriftskostnad må stå først i Driftskostnad per XSD.
     driftskostnad_el = SubElement(resultatregnskap, "driftskostnad")
+    if dk.sum:
+        _beloep_element(driftskostnad_el, "sumDriftskostnad", dk.sum)
 
     if dk.loennskostnader:
         loenn_el = SubElement(driftskostnad_el, "loennskostnad")
@@ -161,6 +170,13 @@ def generer_naeringsspesifikasjon(
         annen_dk_el = SubElement(driftskostnad_el, "annenDriftskostnad")
         for beloep, kode in annen_dk_poster:
             _resultatforekomst(annen_dk_el, "kostnad", beloep, kode)
+
+    # Sum-finansposter må stå på resultatregnskap-nivå før finansinntekt/-kostnad
+    # per XSD-sekvensen.
+    if fp.sum_inntekter:
+        _beloep_element(resultatregnskap, "sumFinansinntekt", fp.sum_inntekter)
+    if fp.sum_kostnader:
+        _beloep_element(resultatregnskap, "sumFinanskostnad", fp.sum_kostnader)
 
     # Finansinntekter
     fi_poster = [
@@ -184,6 +200,10 @@ def generer_naeringsspesifikasjon(
         for beloep, kode in fk_poster:
             _resultatforekomst(finanskostnad_el, "kostnad", beloep, kode)
 
+    # aarsresultat står sist i Resultatregnskap-sekvensen.
+    if res.aarsresultat:
+        _beloep_element(resultatregnskap, "aarsresultat", res.aarsresultat)
+
     # -----------------------------------------------------------------------
     # Balanseregnskap
     # -----------------------------------------------------------------------
@@ -194,40 +214,57 @@ def generer_naeringsspesifikasjon(
 
     balanseregnskap = SubElement(root, "balanseregnskap")
 
-    # Anleggsmidler
+    # Anleggsmidler. sumBalanseverdiForAnleggsmiddel må stå først per XSD.
     am_poster = [
         (am.aksjer_i_datterselskap, "1313"),
         (am.andre_aksjer, "1350"),
         (am.langsiktige_fordringer, "1390"),
     ]
     am_poster = [(b, k) for b, k in am_poster if b]
-    if am_poster:
+    if am_poster or am.sum:
         anleggsmiddel_el = SubElement(balanseregnskap, "anleggsmiddel")
-        bv_am_el = SubElement(anleggsmiddel_el, "balanseverdiForAnleggsmiddel")
-        for beloep, kode in am_poster:
-            _balanseforekomst(bv_am_el, "balanseverdi", beloep, kode)
+        if am.sum:
+            _beloep_element(anleggsmiddel_el, "sumBalanseverdiForAnleggsmiddel", am.sum)
+        if am_poster:
+            bv_am_el = SubElement(anleggsmiddel_el, "balanseverdiForAnleggsmiddel")
+            for beloep, kode in am_poster:
+                _balanseforekomst(bv_am_el, "balanseverdi", beloep, kode)
 
-    # Omløpsmidler
+    # Omløpsmidler. sumBalanseverdiForOmloepsmiddel må stå først per XSD.
     om_poster = [
         (om.kortsiktige_fordringer, "1500"),
         (om.bankinnskudd, "1920"),
     ]
     om_poster = [(b, k) for b, k in om_poster if b]
-    if om_poster:
+    if om_poster or om.sum:
         omloepsmiddel_el = SubElement(balanseregnskap, "omloepsmiddel")
-        bv_om_el = SubElement(omloepsmiddel_el, "balanseverdiForOmloepsmiddel")
-        for beloep, kode in om_poster:
-            _balanseforekomst(bv_om_el, "balanseverdi", beloep, kode)
+        if om.sum:
+            _beloep_element(omloepsmiddel_el, "sumBalanseverdiForOmloepsmiddel", om.sum)
+        if om_poster:
+            bv_om_el = SubElement(omloepsmiddel_el, "balanseverdiForOmloepsmiddel")
+            for beloep, kode in om_poster:
+                _balanseforekomst(bv_om_el, "balanseverdi", beloep, kode)
 
     # Gjeld og egenkapital
-    # Rekkefølgen på barneelementene er bundet av XSD-sekvensen i
-    # GjeldOgEgenkapital: langsiktigGjeld -> kortsiktigGjeld -> egenkapital.
+    # XSD-sekvensen i GjeldOgEgenkapital:
+    #   sumLangsiktigGjeld -> sumKortsiktigGjeld -> sumEgenkapital
+    #   -> langsiktigGjeld -> kortsiktigGjeld -> egenkapital.
     # Feil rekkefølge gjør XML-en ugyldig mot naeringsspesifikasjon_v6 og er
     # årsaken til SMEVB-005 fra Skatteetatens visning-API (SSV-5187).
     gek_el = SubElement(balanseregnskap, "gjeldOgEgenkapital")
 
-    # Langsiktig gjeld
     lg = eg.langsiktig_gjeld
+    kg = eg.kortsiktig_gjeld
+    ek = eg.egenkapital
+
+    if lg.sum:
+        _beloep_element(gek_el, "sumLangsiktigGjeld", lg.sum)
+    if kg.sum:
+        _beloep_element(gek_el, "sumKortsiktigGjeld", kg.sum)
+    if ek.sum:
+        _beloep_element(gek_el, "sumEgenkapital", ek.sum)
+
+    # Langsiktig gjeld
     lg_poster = [
         (lg.laan_fra_aksjonaer, "2250"),
         (lg.andre_langsiktige_laan, "2290"),
@@ -239,7 +276,6 @@ def generer_naeringsspesifikasjon(
             _balanseforekomst(langsiktig_gjeld_el, "gjeld", beloep, kode)
 
     # Kortsiktig gjeld
-    kg = eg.kortsiktig_gjeld
     kg_poster = [
         (kg.leverandoergjeld, "2400"),
         (kg.skyldige_offentlige_avgifter, "2600"),
@@ -252,7 +288,6 @@ def generer_naeringsspesifikasjon(
             _balanseforekomst(kortsiktig_gjeld_el, "gjeld", beloep, kode)
 
     # Egenkapital
-    ek = eg.egenkapital
     ek_poster = [
         (ek.aksjekapital, "2000"),
         (ek.overkursfond, "2020"),
@@ -268,6 +303,32 @@ def generer_naeringsspesifikasjon(
         egenkapital_el = SubElement(gek_el, "egenkapital")
         for beloep, kode in ek_poster:
             _balanseforekomst(egenkapital_el, "kapital", beloep, kode)
+
+    # Balanse-totaler står sist i Balanseregnskap-sekvensen.
+    if bal.eiendeler.sum:
+        _beloep_element(balanseregnskap, "sumBalanseverdiForEiendel", bal.eiendeler.sum)
+    gek_total = lg.sum + kg.sum + ek.sum
+    if gek_total:
+        _beloep_element(balanseregnskap, "sumGjeldOgEgenkapital", gek_total)
+
+    # -----------------------------------------------------------------------
+    # BeregnetNaeringsinntekt (XSD-pos: etter balanseregnskap, før virksomhet)
+    # For et upersonlig skattesubjekt (AS) fordeles skattemessig resultat på
+    # «forekomst 1» (én virksomhet). skattemessigResultat = aarsresultat for
+    # holdingselskap uten skattekostnad. SKD krysstillegger feltet mot
+    # skattemeldingens inntektOgUnderskudd-poster.
+    # -----------------------------------------------------------------------
+    if res.aarsresultat:
+        bni_el = SubElement(root, "beregnetNaeringsinntekt")
+        fordelt_el = SubElement(
+            bni_el, "fordeltBeregnetNaeringsinntektForUpersonligSkattepliktig"
+        )
+        SubElement(fordelt_el, "id").text = "1"
+        _beloep_element(fordelt_el, "fordeltSkattemessigResultat", res.aarsresultat)
+        _beloep_element(
+            fordelt_el, "fordeltSkattemessigResultatEtterKorreksjon", res.aarsresultat
+        )
+        _beloep_element(bni_el, "skattemessigResultat", res.aarsresultat)
 
     # -----------------------------------------------------------------------
     # Virksomhet (obligatorisk)
@@ -299,6 +360,12 @@ def generer_naeringsspesifikasjon(
         ekavst = SubElement(root, "egenkapitalavstemming")
         _beloep_element(ekavst, "inngaaendeEgenkapital", inngaaende_ek)
         endring = round(utgaaende_ek - inngaaende_ek, 2)
+        # sumTilleggIEgenkapital / sumFradragIEgenkapital må stå før
+        # egenkapitalendring-listen per XSD-sekvensen.
+        if endring > 0:
+            _beloep_element(ekavst, "sumTilleggIEgenkapital", endring)
+        elif endring < 0:
+            _beloep_element(ekavst, "sumFradragIEgenkapital", abs(endring))
         if endring:
             # aaretsUnderskudd er kategori "fradrag", aaretsOverskudd "tillegg":
             # utgaaende = inngaaende + tillegg - fradrag. Beløpet føres derfor
@@ -310,6 +377,8 @@ def generer_naeringsspesifikasjon(
             ekt = SubElement(endring_el, "egenkapitalendringstype")
             SubElement(ekt, "egenkapitalendringstype").text = kode
             _beloep_element(endring_el, "beloep", abs(endring))
+        # utgaaendeEgenkapital står sist i Egenkapitalavstemming.
+        _beloep_element(ekavst, "utgaaendeEgenkapital", utgaaende_ek)
 
     # -----------------------------------------------------------------------
     # andreForhold: spesifiser ytelse mellom aksjonær og selskap (lån fra

--- a/wenche/skattemelding_xml.py
+++ b/wenche/skattemelding_xml.py
@@ -7,8 +7,13 @@ via Altinn3. Krever partsnummer fra Skatteetatens forhåndsutfylt-API.
 Namespace: urn:no:skatteetaten:fastsetting:formueinntekt:skattemelding:upersonlig:ekstern:v5
 XSD: skattemeldingUpersonlig_v5_ekstern.xsd
 
-Felter merket erAvledet="true" i XSD-en beregnes av Skatteetaten fra
-næringsoppgaven — disse settes ikke av Wenche.
+Felter merket erAvledet="true" i XSD-en beregnes også av Skatteetaten, men
+en tilbakemelding fra prod-innsending 2026-05 viste at SKD forventer at vi
+echo-er våre egne beregnede summer (samletUnderskudd, inntektsfradrag/
+underskudd, inntektFoerFradragForEventueltAvgittKonsernbidrag,
+fremfoerbartUnderskuddIInntekt) for kryssvalidering. Manglende summer
+flagges som «manglerSkattemelding» i avvikEtterBeregning selv om
+resultatAvValidering blir «validertOK».
 """
 
 from __future__ import annotations
@@ -32,10 +37,17 @@ def _overstyrt_heltall(parent: Element, tag: str, verdi: int) -> None:
     SubElement(erov, "boolsk").text = "true"
 
 
+def _heltall_med_innkapsling(parent: Element, tag: str, verdi: int) -> None:
+    """Bygger et BeloepSomHeltallMedInnkapsling-element (uten erOverstyrt)."""
+    el = SubElement(parent, tag)
+    SubElement(el, "beloepSomHeltall").text = str(int(round(verdi)))
+
+
 def generer_skattemelding_upersonlig(
     partsnummer: int,
     inntektsaar: int,
     fremfoert_underskudd: int = 0,
+    aarets_underskudd: int = 0,
     boersnotert: bool | None = None,
     harytelse: bool | None = None,
     formue_verdi_foer_rabatt: int | None = None,
@@ -52,6 +64,14 @@ def generer_skattemelding_upersonlig(
         fremfoert_underskudd: Fremført underskudd fra tidligere år (kroner, heltall).
                               Korresponderer med konfig.underskudd_til_fremfoering.
                               0 = elementet inkluderes ikke i XML.
+        aarets_underskudd:    Årets underskudd (positiv kroner-heltall, magnitude).
+                              Fra |min(0, aarsresultat)| når aarsresultat < 0.
+                              0 = underskuddsbaserte felter utelates. Når > 0
+                              emitteres samletUnderskudd, inntektsfradrag/underskudd,
+                              inntektFoerFradragForEventueltAvgittKonsernbidrag,
+                              og fremfoerbartUnderskuddIInntekt = aarets +
+                              fremfoert. Med disse blir SKDs etterBeregning ren
+                              (ingen «manglerSkattemelding»-avvik).
         boersnotert:          Om selskapet er børsnotert. None = utelat opplysningen.
         harytelse:            Om det er ytelser mellom aksjonær/nærstående og selskapet
                               (f.eks. lån fra aksjonær). None = utelat opplysningen.
@@ -70,11 +90,35 @@ def generer_skattemelding_upersonlig(
     SubElement(root, "partsnummer").text = str(partsnummer)
     SubElement(root, "inntektsaar").text = str(inntektsaar)
 
-    if fremfoert_underskudd > 0:
+    if fremfoert_underskudd > 0 or aarets_underskudd > 0:
         iou = SubElement(root, "inntektOgUnderskudd")
         utf = SubElement(iou, "underskuddTilFremfoering")
-        fremfoert = SubElement(utf, "fremfoertUnderskuddFraTidligereAar")
-        SubElement(fremfoert, "beloepSomHeltall").text = str(round(fremfoert_underskudd))
+        if fremfoert_underskudd > 0:
+            fremfoert = SubElement(utf, "fremfoertUnderskuddFraTidligereAar")
+            SubElement(fremfoert, "beloepSomHeltall").text = str(
+                int(round(fremfoert_underskudd))
+            )
+        if aarets_underskudd > 0:
+            # fremfoerbartUnderskuddIInntekt = årets + fremført fra tidligere år.
+            # Står sist i UnderskuddTilFremfoering-sekvensen.
+            _overstyrt_heltall(
+                utf,
+                "fremfoerbartUnderskuddIInntekt",
+                aarets_underskudd + fremfoert_underskudd,
+            )
+        if aarets_underskudd > 0:
+            # XSD-sekvens i InntektOgUnderskudd:
+            #   underskuddTilFremfoering -> inntekt -> inntektsfradrag
+            #   -> inntektFoerFradragForEventueltAvgittKonsernbidrag
+            #   -> samletInntekt -> samletUnderskudd
+            ifr = SubElement(iou, "inntektsfradrag")
+            _heltall_med_innkapsling(ifr, "underskudd", aarets_underskudd)
+            _heltall_med_innkapsling(
+                iou,
+                "inntektFoerFradragForEventueltAvgittKonsernbidrag",
+                -aarets_underskudd,
+            )
+            _overstyrt_heltall(iou, "samletUnderskudd", aarets_underskudd)
 
     # formueOgGjeld: formuesgrunnlaget bak aksjene. Skatteetaten utleder
     # samletVerdiBakAksjeneISelskapet = samletVerdiFoerVerdsettingsrabatt -
@@ -162,10 +206,14 @@ def generer_skattemelding_fra_konfig(
     laan_fra_aksjonaer = regnskap.balanse.egenkapital_og_gjeld.langsiktig_gjeld.laan_fra_aksjonaer
     harytelse = bool(laan_fra_aksjonaer and laan_fra_aksjonaer > 0)
     verdi_foer_rabatt, samlet_gjeld = beregn_formue_inputs(regnskap, konfig)
+    # Årets underskudd som positiv kroner-magnitude. For et overskuddsår
+    # (eller nullresultat) blir det 0 og underskuddsbaserte felter utelates.
+    aarets_underskudd = max(0, int(round(-regnskap.resultatregnskap.aarsresultat)))
     return generer_skattemelding_upersonlig(
         partsnummer=partsnummer,
         inntektsaar=regnskap.regnskapsaar,
         fremfoert_underskudd=int(konfig.underskudd_til_fremfoering),
+        aarets_underskudd=aarets_underskudd,
         boersnotert=konfig.boersnotert,
         harytelse=harytelse,
         formue_verdi_foer_rabatt=verdi_foer_rabatt,


### PR DESCRIPTION
## Sammendrag
- Emitterer avledede summer eksplisitt i både næringsspesifikasjon og skattemelding, slik at SKDs etterBeregning-tilbakemelding blir ren (ingen «manglerSkattemelding» / «manglerNaeringsopplysninger»-avvik).
- Versjonsbump til **0.21.0** (MINOR per Conventional Commits).
- 262/262 tester grønne (249 eksisterende + 8 nye for næringsspes-summer + 5 nye for skattemelding-underskudd).

## Bakgrunn
Tilbakemeldingsfilen fra en prod-innsending (OFL Holding, inntektsår 2025) viste 21 avvikspunkter i `<avvikEtterBeregning>` med typene `manglerSkattemelding` og `manglerNaeringsopplysninger`. Selv om `<resultatAvValidering>` ble `validertOK`, forventer SKD at vi echo-er våre egne beregnede summer for kryssvalidering. Den tidligere antagelsen («avledede felt beregnes av Skatteetaten — settes ikke her») var feil. En kontakt som bygger et tilsvarende verktøy i Elixir traff samme problem og bekreftet at SKD ønsker disse feltene populert.

## Konkrete felter som nå emitteres

**Næringsspesifikasjon** ([wenche/naeringsspesifikasjon_xml.py](wenche/naeringsspesifikasjon_xml.py)):
- Resultatregnskap: `sumDriftsinntekt`, `sumDriftskostnad`, `sumFinansinntekt`, `sumFinanskostnad`, `aarsresultat`
- Balanseregnskap: `sumBalanseverdiForAnleggsmiddel`, `sumBalanseverdiForOmloepsmiddel`, `sumLangsiktigGjeld`, `sumKortsiktigGjeld`, `sumEgenkapital`, `sumBalanseverdiForEiendel`, `sumGjeldOgEgenkapital`
- BeregnetNaeringsinntekt-blokken: `fordeltSkattemessigResultat`, `fordeltSkattemessigResultatEtterKorreksjon`, `skattemessigResultat`
- Egenkapitalavstemming: `sumTilleggIEgenkapital` (overskudd) eller `sumFradragIEgenkapital` (underskudd), pluss `utgaaendeEgenkapital`

**Skattemelding** ([wenche/skattemelding_xml.py](wenche/skattemelding_xml.py)):
- Ny parameter `aarets_underskudd` (positiv kr-magnitude). Når > 0 emitteres:
  - `inntektsfradrag/underskudd`
  - `inntektFoerFradragForEventueltAvgittKonsernbidrag` (= -underskudd)
  - `samletUnderskudd` (overstyrt)
  - `fremfoerbartUnderskuddIInntekt` = årets + fremført fra tidligere år
- `generer_skattemelding_fra_konfig` beregner `aarets_underskudd` fra `regnskap.resultatregnskap.aarsresultat` (gulv 0 ved overskudd)

## Risikoanalyse for eksisterende brukere
- Alle nye felter respekterer XSD-sekvensen. Regresjonstest for XSD-validering passerer.
- Eksisterende oppførsel (overskuddsår, regnskap uten poster, etc.) er funksjonelt identisk; vi legger bare til summene SKD allerede har beregnet og forventer.
- Brukere som tidligere fikk `validertOK` med avvik vil nå få `validertOK` uten avvik.
- Brukere med spesielle datakonstellasjoner (f.eks. aarsresultat = 0) får uendret oppførsel (ingen sum-felter når magnituden er 0).

## Test plan
- [x] Lokal testsuite (262/262 grønne, inkludert nye `TestAvledetSummer` og `TestAaretsUnderskudd`)
- [x] XSD-validering består uendret