### PR TITLE
fix(skattemelding): drop erOverstyrt på samletVerdiBakAksjeneISelskapet

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.21.2"
+version = "0.21.3"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_skattemelding_xml.py
+++ b/tests/test_skattemelding_xml.py
@@ -165,6 +165,9 @@ class TestVerdsettingAvAksje:
     SKD beregner samletVerdiBakAksjeneISelskapet = verdiFoerRabatt - gjeld,
     men forventer at vi echo-er verdien i `verdsettingAvAksje`-blokken for
     å unngå «manglerSkattemelding»-avvik (jf. OFL Holdings 2025-tilbakemelding).
+
+    Feltet emitteres UTEN erOverstyrt-flagget — Skatteetatens PDF-visning
+    skjuler verdien fra Formue-seksjonen hvis flagget er satt.
     """
 
     def test_emit_med_positiv_netto(self):
@@ -173,11 +176,13 @@ class TestVerdsettingAvAksje:
             formue_verdi_foer_rabatt=72622,
             samlet_gjeld=12682,
         ))
-        verdi = root.find(
+        sva = root.find(
             f"{{{_NS}}}verdsettingAvAksje/{{{_NS}}}samletVerdiBakAksjeneISelskapet"
-            f"/{{{_NS}}}beloep/{{{_NS}}}beloepSomHeltall"
         )
-        assert verdi is not None and verdi.text == "59940"
+        assert sva is not None
+        assert sva.findtext(f"{{{_NS}}}beloep/{{{_NS}}}beloepSomHeltall") == "59940"
+        # Eksplisitt: erOverstyrt skal IKKE være satt
+        assert sva.find(f"{{{_NS}}}erOverstyrt") is None
 
     def test_gulv_paa_null_naar_gjeld_overstiger_formue(self):
         root = _parse(generer_skattemelding_upersonlig(

--- a/tests/test_xsd_validering.py
+++ b/tests/test_xsd_validering.py
@@ -165,12 +165,14 @@ class TestOpplysningOgVerdsettingXsd:
         # verdsettingAvAksje/samletVerdiBakAksjeneISelskapet skal emittes
         # eksplisitt (72622 - 12682 = 59940) for å unngå «manglerSkattemelding»-
         # avvik i SKDs etterBeregning. Plassering: etter opplysningOmSkattesubjekt.
+        # UTEN erOverstyrt-flagget — Skatteetatens PDF-visning skjuler verdien
+        # fra Formue-seksjonen hvis flagget er satt.
         vav = root.find(f"{_SM_NS}verdsettingAvAksje")
         assert vav is not None
         verdi_bak = vav.find(f"{_SM_NS}samletVerdiBakAksjeneISelskapet")
         assert verdi_bak is not None
         assert verdi_bak.findtext(f"{_SM_NS}beloep/{_SM_NS}beloepSomHeltall") == "59940"
-        assert verdi_bak.find(f"{_SM_NS}erOverstyrt/{_SM_NS}boolsk").text == "true"
+        assert verdi_bak.find(f"{_SM_NS}erOverstyrt") is None
         assert barn.index("opplysningOmSkattesubjekt") < barn.index("verdsettingAvAksje")
 
     def test_beregn_verdi_bak_aksjene(self, eksempel_regnskap):

--- a/wenche/skattemelding_xml.py
+++ b/wenche/skattemelding_xml.py
@@ -43,6 +43,19 @@ def _heltall_med_innkapsling(parent: Element, tag: str, verdi: int) -> None:
     SubElement(el, "beloepSomHeltall").text = str(int(round(verdi)))
 
 
+def _heltall_med_beloep(parent: Element, tag: str, verdi: int) -> None:
+    """
+    Bygger et StortBeloepSomHeltallMedOverstyring-element UTEN erOverstyrt.
+    Matcher formatet SKD selv bruker når de beregner et erAvledet-felt — vi
+    setter verdien, men signaliserer ikke overstyring. Brukes for felt der
+    Skatteetatens visning-API skjuler verdien hvis erOverstyrt=true er satt
+    (jf. samletVerdiBakAksjeneISelskapet).
+    """
+    el = SubElement(parent, tag)
+    beloep = SubElement(el, "beloep")
+    SubElement(beloep, "beloepSomHeltall").text = str(int(round(verdi)))
+
+
 def generer_skattemelding_upersonlig(
     partsnummer: int,
     inntektsaar: int,
@@ -149,10 +162,16 @@ def generer_skattemelding_upersonlig(
     # tilbakemeldingen ikke flagger «manglerSkattemelding» for feltet (jf.
     # OFL Holdings 2025-innsending hvor dette var siste gjenstående avvik).
     # XSD-pos: etter opplysningOmSkattesubjekt.
+    #
+    # Emitteres UTEN erOverstyrt fordi Skatteetatens visning-API skjuler
+    # verdien fra «Samlet formue og gjeld»-seksjonen på PDF-en hvis
+    # erOverstyrt=true er satt — selv om feltet er teknisk korrekt for
+    # avviks-detektoren. Uten flagget vises verdien som forventet (matcher
+    # formatet SKD returnerte i tidligere etterBeregning).
     if formue_verdi_foer_rabatt is not None:
         verdi_bak = max(0, formue_verdi_foer_rabatt - (samlet_gjeld or 0))
         vav = SubElement(root, "verdsettingAvAksje")
-        _overstyrt_heltall(vav, "samletVerdiBakAksjeneISelskapet", verdi_bak)
+        _heltall_med_beloep(vav, "samletVerdiBakAksjeneISelskapet", verdi_bak)
 
     return tostring(root, encoding="unicode").encode("utf-8")
 


### PR DESCRIPTION
## Sammendrag
- `samletVerdiBakAksjeneISelskapet` emitteres nå UTEN `erOverstyrt`-flagget, slik at Skatteetatens PDF-visning igjen viser «Samlet verdi av aksjene bak selskapet»-linjen i Formue-seksjonen.
- Avviks-detektoren tilfredsstilles fortsatt (feltet er til stede med riktig verdi).
- Versjonsbump til **0.21.3** (PATCH per Conventional Commits).
- 265/265 tester grønne (test oppdatert til å bekrefte at `erOverstyrt` IKKE settes).

## Bakgrunn
PR #94 (0.21.2) emitterte `samletVerdiBakAksjeneISelskapet` med `erOverstyrt=true`. Det fjernet det siste «manglerSkattemelding»-avviket i etterBeregning, men introduserte en regresjon: Skatteetatens PDF-visning skjuler verdien fra «Samlet formue og gjeld»-seksjonen når flagget er satt, sannsynligvis fordi visningen tolker overstyrt-flagget som «brukerens egen korrigering» og ikke noe som skal vises som derivert verdi.

Sammenligning av PDF-visningen:
- **Før 0.21.2** (med 0.21.1 og tidligere): «Samlet verdi av aksjene bak selskapet 59 940» vises som forventet. SKD beregnet verdien selv.
- **Etter 0.21.2**: Linjen forsvinner. Beløpet er fortsatt i XMLen og brukes i beregningen, men ikke synlig på PDF-en.

## Endring
[wenche/skattemelding_xml.py](wenche/skattemelding_xml.py): Ny `_heltall_med_beloep`-helper emitterer `StortBeloepSomHeltallMedOverstyring` UTEN `erOverstyrt`-elementet (XSD tillater det som `minOccurs=0`). Formatet matcher det SKD selv brukte i etterBeregning fra forrige innsending. `samletVerdiBakAksjeneISelskapet` bruker den nå.

```xml
<verdsettingAvAksje>
  <samletVerdiBakAksjeneISelskapet>
    <beloep>
      <beloepSomHeltall>59940</beloepSomHeltall>
    </beloep>
  </samletVerdiBakAksjeneISelskapet>
</verdsettingAvAksje>
```

## Test plan
- [x] Lokal testsuite (265/265 grønne)
- [x] Eksplisitt assert at `erOverstyrt` ikke er satt på `samletVerdiBakAksjeneISelskapet`
- [x] XSD-validering passerer
- [x] (Etter merge + release:) Re-send innsending og verifiser at både avvik-listen er tom OG «Samlet verdi av aksjene bak selskapet 59 940»-linjen er tilbake i PDF-visningen