### PR TITLE
docs(readme): legg til bonus-seksjon med folkevise om Wenche

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,3 +48,23 @@ Bidrag er velkomne. Åpne gjerne en issue eller pull request.
 ## Lisens
 
 MIT, se [LICENSE](LICENSE).
+
+## 🎵 Bonus: En helt unødvendig folkevise
+
+> "Alle gode åpen-kildekode-prosjekter trenger dokumentasjon. Men bare de store trenger en oppriktig folkevise om skatteinnsending."
+
+Med dyp respekt for sjangeren presenterer jeg ...
+
+En stillferdig, bittersøt og oppriktig kjærlighetsvise om skattemelding, aksjonærregister og maskinell innsending til Altinn.
+
+Inkluderer:
+
+- akustisk gitar med fingerspill
+- lett piano og myke strykere
+- en varm, intim mannlig vokal med et streif av ironi
+- en holdingeier som forteller sin historie med ettertanke
+
+🎧 Hør "Wenche" her:
+👉 https://suno.com/s/QSz9P1EylWOF7vnz
+
+Og ja, refrenget vil sette seg fast i hodet ditt.


### PR DESCRIPTION
## Sammendrag

Legger til en bonus-seksjon nederst i README med en lenke til en Suno-generert folkevise om Wenche. Stillferdig norsk visestil, à la Halvdan Sivertsen-tradisjonen, med subtilt ironisk tekst om skattemelding og maskinell innsending til Altinn.

Plassert under Lisens-seksjonen for å holde seriøs dokumentasjon i toppen og det lekne i bunnen.

🎧 Hør "Wenche": https://suno.com/s/QSz9P1EylWOF7vnz

## Test plan

- [x] mkdocs build (README påvirker ikke docs-build, men ingen lenker brutt)
- [x] Verifiser at lenken til Suno fungerer