### PR TITLE
feat: valider dokumenter før innsending og varsle om udekket utbytte

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.22.0"
+version = "0.23.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_aarsregnskap_advarsler.py
+++ b/tests/test_aarsregnskap_advarsler.py
@@ -1,0 +1,47 @@
+"""
+Ikke-blokkerende advarsler i aarsregnskap.advarsler().
+
+Advarslene skal fange forhold som ikke gjør innsendingen ugyldig, men som
+ofte tyder på feil i tallene, særlig utbytte uten dekning i fri egenkapital.
+De skal IKKE blokkere innsending (det er valider() sin jobb).
+"""
+
+from dataclasses import replace
+
+from wenche.aarsregnskap import advarsler
+from wenche.models import Egenkapital
+
+
+def _med_ek(regnskap, egenkapital):
+    """Returnerer en kopi av regnskapet med ny egenkapital i balansen."""
+    ny_ekg = replace(regnskap.balanse.egenkapital_og_gjeld, egenkapital=egenkapital)
+    ny_balanse = replace(regnskap.balanse, egenkapital_og_gjeld=ny_ekg)
+    return replace(regnskap, balanse=ny_balanse)
+
+
+def test_ingen_advarsel_uten_utbytte(eksempel_regnskap):
+    # Negativ fri egenkapital, men intet utbytte → ingen advarsel.
+    assert eksempel_regnskap.utbytte_utbetalt == 0
+    assert advarsler(eksempel_regnskap) == []
+
+
+def test_advarsel_utbytte_uten_fri_egenkapital(eksempel_regnskap):
+    # Akkumulert underskudd (negativ fri EK) + utbetalt utbytte → advarsel.
+    regnskap = replace(eksempel_regnskap, utbytte_utbetalt=10000)
+    adv = advarsler(regnskap)
+    assert len(adv) == 1
+    assert "fri egenkapital" in adv[0]
+    assert "§ 8-1" in adv[0]
+
+
+def test_ingen_advarsel_utbytte_med_dekning(regnskap_med_utbytte):
+    # Positiv annen egenkapital (60 200) gir dekning for utbytte.
+    regnskap = replace(regnskap_med_utbytte, utbytte_utbetalt=50000)
+    assert advarsler(regnskap) == []
+
+
+def test_overkursfond_teller_som_fri_egenkapital(eksempel_regnskap):
+    # Overkursfond er fri egenkapital og dekker utbyttet selv om annen EK er negativ.
+    ek = Egenkapital(aksjekapital=30000, overkursfond=50000, annen_egenkapital=-34300)
+    regnskap = replace(_med_ek(eksempel_regnskap, ek), utbytte_utbetalt=10000)
+    assert advarsler(regnskap) == []

--- a/tests/test_cli_valider_aarsregnskap.py
+++ b/tests/test_cli_valider_aarsregnskap.py
@@ -1,0 +1,110 @@
+"""
+Tester for `wenche valider-aarsregnskap` (CLI).
+
+Kommandoen kjører de lokale sjekkene (valider + advarsler) uten å sende inn,
+slik at den kan brukes som en gate: exit-kode 1 ved blokkerende feil, 0 ellers
+(advarsler alene gir ikke feilkode). Ingenting genereres eller sendes.
+"""
+
+import yaml
+from click.testing import CliRunner
+
+from wenche.cli import main
+
+_BASE = {
+    "selskap": {
+        "navn": "Test Holding AS",
+        "org_nummer": "123456789",
+        "daglig_leder": "Ola Nordmann",
+        "styreleder": "Ola Nordmann",
+        "forretningsadresse": "Testveien 1, 0001 Oslo",
+        "stiftelsesaar": 2020,
+        "aksjekapital": 30000,
+    },
+    "regnskapsaar": 2025,
+    "resultatregnskap": {
+        "driftsinntekter": {"salgsinntekter": 0, "andre_driftsinntekter": 0},
+        "driftskostnader": {"loennskostnader": 0, "avskrivninger": 0, "andre_driftskostnader": 0},
+        "finansposter": {
+            "utbytte_fra_datterselskap": 0,
+            "andre_finansinntekter": 0,
+            "rentekostnader": 0,
+            "andre_finanskostnader": 0,
+        },
+    },
+    "balanse": {
+        "eiendeler": {
+            "anleggsmidler": {"aksjer_i_datterselskap": 0, "andre_aksjer": 0, "langsiktige_fordringer": 0},
+            "omloepmidler": {"kortsiktige_fordringer": 0, "bankinnskudd": 30000},
+        },
+        "egenkapital_og_gjeld": {
+            "egenkapital": {"aksjekapital": 30000, "overkursfond": 0, "annen_egenkapital": 0},
+            "langsiktig_gjeld": {"laan_fra_aksjonaer": 0, "andre_langsiktige_laan": 0},
+            "kortsiktig_gjeld": {
+                "leverandoergjeld": 0,
+                "skyldige_offentlige_avgifter": 0,
+                "annen_kortsiktig_gjeld": 0,
+            },
+        },
+    },
+    "aksjonaerer": [
+        {
+            "navn": "Kari Nordmann",
+            "fodselsnummer": "01010112345",
+            "antall_aksjer": 1000,
+            "aksjeklasse": "ordinære",
+            "utbytte_utbetalt": 0,
+            "innbetalt_kapital_per_aksje": 30,
+        }
+    ],
+}
+
+
+def _skriv(tmp_path, muter=None):
+    import copy
+
+    cfg = copy.deepcopy(_BASE)
+    if muter:
+        muter(cfg)
+    fil = tmp_path / "config.yaml"
+    fil.write_text(yaml.safe_dump(cfg, allow_unicode=True), encoding="utf-8")
+    return str(fil)
+
+
+def test_gyldig_regnskap_gir_exit_0(tmp_path):
+    fil = _skriv(tmp_path)
+    res = CliRunner().invoke(main, ["valider-aarsregnskap", "--config", fil])
+    assert res.exit_code == 0
+    assert "Validering OK." in res.output
+
+
+def test_ubalanse_gir_exit_1(tmp_path):
+    def muter(cfg):
+        cfg["balanse"]["eiendeler"]["omloepmidler"]["bankinnskudd"] = 0  # eiendeler 0, EK 30000
+
+    fil = _skriv(tmp_path, muter)
+    res = CliRunner().invoke(main, ["valider-aarsregnskap", "--config", fil])
+    assert res.exit_code == 1
+    assert "Balansen går ikke opp" in res.output
+
+
+def test_utbytte_uten_dekning_advarer_men_exit_0(tmp_path):
+    def muter(cfg):
+        # Balansen holdes gyldig: bank 5000, fri EK negativ (-25000), aksjekapital 30000.
+        cfg["balanse"]["eiendeler"]["omloepmidler"]["bankinnskudd"] = 5000
+        cfg["balanse"]["egenkapital_og_gjeld"]["egenkapital"]["annen_egenkapital"] = -25000
+        cfg["aksjonaerer"][0]["utbytte_utbetalt"] = 10000
+
+    fil = _skriv(tmp_path, muter)
+    res = CliRunner().invoke(main, ["valider-aarsregnskap", "--config", fil])
+    assert res.exit_code == 0
+    assert "ADVARSEL" in res.output
+    assert "fri egenkapital" in res.output
+
+
+def test_finner_ikke_config_gir_exit_1(tmp_path):
+    res = CliRunner().invoke(
+        main, ["valider-aarsregnskap", "--config", str(tmp_path / "mangler.yaml")]
+    )
+    assert res.exit_code == 1
+    assert "finner ikke" in res.output

--- a/wenche/aarsregnskap.py
+++ b/wenche/aarsregnskap.py
@@ -134,6 +134,35 @@ def valider(regnskap: Aarsregnskap) -> list[str]:
     return feil
 
 
+def advarsler(regnskap: Aarsregnskap) -> list[str]:
+    """
+    Ikke-blokkerende advarsler om forhold som ikke gjør innsendingen ugyldig,
+    men som ofte tyder på en feil i tallene. Tom liste betyr ingen advarsler.
+
+    I motsetning til valider() stopper ikke disse innsendingen. De er ment som
+    et varsku som brukeren (eller et verktøy som genererer config.yaml) kan lene
+    seg på.
+    """
+    adv = []
+
+    # Utbytte kan bare deles ut av fri egenkapital (aksjeloven § 8-1). Fri
+    # egenkapital = overkursfond + annen egenkapital (aksjekapital er bundet).
+    # I modellen reduserer utbytte annen_egenkapital, så hvis utdelingen
+    # overstiger det utdelbare, blir fri egenkapital negativ etter utdelingen.
+    ek = regnskap.balanse.egenkapital_og_gjeld.egenkapital
+    fri_egenkapital = ek.overkursfond + ek.annen_egenkapital
+    if regnskap.utbytte_utbetalt > 0 and fri_egenkapital < -0.01:
+        adv.append(
+            f"Det er utbetalt utbytte ({regnskap.utbytte_utbetalt:,.0f} NOK), men "
+            f"fri egenkapital etter utdelingen er negativ ({fri_egenkapital:,.0f} "
+            "NOK). Utbytte kan bare deles ut av fri egenkapital (aksjeloven § 8-1). "
+            "Kontroller at utbetalingen faktisk er utbytte og ikke f.eks. lån til "
+            "aksjonær eller tilbakebetaling av innbetalt kapital."
+        )
+
+    return adv
+
+
 def send_inn(regnskap: Aarsregnskap, klient: AltinnClient, dry_run: bool = False) -> str | None:
     """
     Sender inn årsregnskapet til Brønnøysundregistrene via Altinn.
@@ -157,6 +186,9 @@ def send_inn(regnskap: Aarsregnskap, klient: AltinnClient, dry_run: bool = False
         raise SystemExit(1)
 
     print("Validering OK.")
+
+    for a in advarsler(regnskap):
+        print(f"  ADVARSEL: {a}")
 
     hovedskjema = generer_hovedskjema(regnskap)
     underskjema = generer_underskjema(regnskap)

--- a/wenche/cli.py
+++ b/wenche/cli.py
@@ -6,6 +6,7 @@ Bruk:
   wenche dev                Starter UI mot testmiljø (tt02)
   wenche login
   wenche logout
+  wenche valider-aarsregnskap [--config config.yaml]
   wenche send-aarsregnskap [--config config.yaml] [--dry-run]
   wenche send-aksjonaerregister [--config config.yaml] [--dry-run]
   wenche generer-skattemelding [--config config.yaml] [--ut skattemelding.txt]
@@ -156,6 +157,56 @@ def send_aarsregnskap(config_fil: str, dry_run: bool):
     token = auth.get_altinn_token()
     with AltinnClient(token) as klient:
         aarsregnskap.send_inn(regnskap, klient)
+
+
+@main.command("valider-aarsregnskap")
+@click.option(
+    "--config",
+    "config_fil",
+    default="config.yaml",
+    show_default=True,
+    help="Sti til konfigurasjonsfilen.",
+)
+def valider_aarsregnskap(config_fil: str):
+    """Valider årsregnskapet lokalt uten å sende inn.
+
+    Kjører de samme sjekkene som innsendingen (balanse, org.nr.) pluss
+    ikke-blokkerende advarsler (f.eks. utbytte uten dekning i fri egenkapital).
+    Ingenting genereres eller sendes. Avslutter med exit-kode 1 hvis det finnes
+    blokkerende feil, ellers 0 (advarsler alene gir ikke feilkode).
+    """
+    click.echo(f"Leser konfigurasjon fra {config_fil}...")
+    try:
+        regnskap = aarsregnskap.les_config(config_fil)
+    except FileNotFoundError:
+        click.echo(
+            f"Feil: finner ikke {config_fil}.\n"
+            "Kopier config.example.yaml til config.yaml og fyll inn dine verdier.",
+            err=True,
+        )
+        raise SystemExit(1)
+
+    click.echo(
+        f"Aarsregnskap {regnskap.regnskapsaar} for {regnskap.selskap.navn} "
+        f"({regnskap.selskap.org_nummer})\n"
+    )
+
+    feil = aarsregnskap.valider(regnskap)
+    advarsler = aarsregnskap.advarsler(regnskap)
+
+    for a in advarsler:
+        click.echo(f"ADVARSEL: {a}")
+
+    if feil:
+        click.echo("\nValidering mislyktes:", err=True)
+        for f in feil:
+            click.echo(f"  - {f}", err=True)
+        raise SystemExit(1)
+
+    if advarsler:
+        click.echo("\nValidering OK, men sjekk advarslene over.")
+    else:
+        click.echo("Validering OK.")
 
 
 # ---------------------------------------------------------------------------

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -53,9 +53,11 @@ from wenche.skd_client import SkdAksjonaerClient
 from wenche.skd_skattemelding_client import (
     SkattemeldingValideringsfeil,
     SkdSkattemeldingClient,
+    formater_valideringsresultat,
 )
 from wenche.skattemelding_xml import generer_skattemelding_fra_konfig, hent_partsnummer
 from wenche.naeringsspesifikasjon_xml import generer_naeringsspesifikasjon
+from wenche.skattemelding_konvolutt import generer_konvolutt
 
 _WENCHE_DIR = Path.home() / ".wenche"
 _BRUKER_ENV_FIL = _WENCHE_DIR / ".env"
@@ -2862,6 +2864,101 @@ def _bygg_send_fane() -> None:
                 ui.notify(f"Autentisering feilet: {feilmelding}", type="negative", timeout=0)
             return None
 
+    def _vis_lokalt_resultat(container, feil: list[str], advarsler_liste: list[str]):
+        """Render et lokalt valideringsresultat (feil + advarsler) inline."""
+        container.clear()
+        with container:
+            if feil:
+                ui.label("Validering mislyktes:").classes("text-sm font-semibold text-red-600")
+                for f in feil:
+                    ui.label(f"• {f}").classes("text-sm text-red-600")
+            for a in advarsler_liste:
+                ui.label(f"⚠ {a}").classes("text-sm text-amber-600")
+            if not feil and not advarsler_liste:
+                ui.label("✓ Validering OK. Klar for innsending.").classes(
+                    "text-sm font-medium text-green-600"
+                )
+            elif not feil:
+                ui.label("Validering OK, men sjekk advarslene over.").classes(
+                    "text-sm text-slate-600"
+                )
+
+    def valider_aarsregnskap():
+        """Kjør de lokale årsregnskap-sjekkene uten å sende inn."""
+        regnskap = state.bygg_regnskap()
+        _vis_lokalt_resultat(
+            aarsregnskap_resultat,
+            ar_modul.valider(regnskap),
+            ar_modul.advarsler(regnskap),
+        )
+
+    async def valider_aksjonaerregister():
+        """Valider aksjonærregisteroppgaven lokalt (+ mot BRG i prod) uten å sende."""
+        oppgave = state.bygg_oppgave()
+        feil = akr_modul.valider(oppgave)
+        # BRG-funn blokkerer innsending, så de vises som feil (rødt), ikke advarsler.
+        if env == "prod" and not feil:
+            feil = await run.io_bound(akr_modul.valider_mot_brg, oppgave)
+        _vis_lokalt_resultat(aksjonaer_resultat, feil, [])
+
+    async def valider_skattemelding():
+        """Valider skattemeldingen mot Skatteetatens valider-tjeneste (lagrer ikke data)."""
+        regnskap = state.bygg_regnskap()
+        orgnr = os.getenv("SKD_TEST_ORG_NUMMER", state.org_nummer) if env == "test" else state.org_nummer
+        n = ui.notification("Henter tokens for skattemelding...", spinner=True, timeout=None)
+        try:
+            tokens = await run.io_bound(lambda: _med_env(env, auth.get_skd_skattemelding_tokens))
+            n.message = "Validerer mot Skatteetaten (lagrer ikke data)..."
+
+            def _bygg_og_valider():
+                with SkdSkattemeldingClient(tokens["maskinporten_token"], env=env) as skd:
+                    test_partsnummer = os.getenv("SKD_TEST_PARTSNUMMER") if env == "test" else None
+                    gjeldende_dokument_id: str | None = None
+                    if test_partsnummer:
+                        partsnummer = int(test_partsnummer)
+                    else:
+                        forhåndsutfylt, gjeldende_dokument_id = skd.hent_forhåndsutfylt_med_id(
+                            int(state.regnskapsaar), orgnr
+                        )
+                        partsnummer = hent_partsnummer(forhåndsutfylt)
+                    skattemelding_xml = generer_skattemelding_fra_konfig(
+                        regnskap, state.bygg_skattemelding_konfig(), partsnummer
+                    )
+                    naeringsspesifikasjon_xml = generer_naeringsspesifikasjon(regnskap, partsnummer)
+                    konvolutt = generer_konvolutt(
+                        skattemelding_xml=skattemelding_xml,
+                        inntektsaar=int(state.regnskapsaar),
+                        orgnr=orgnr,
+                        naeringsspesifikasjon_xml=naeringsspesifikasjon_xml,
+                        gjeldende_dokument_id=gjeldende_dokument_id,
+                    )
+                    return skd.valider(int(state.regnskapsaar), orgnr, konvolutt)
+
+            resultat = await run.io_bound(_bygg_og_valider)
+            n.dismiss()
+            skattemelding_resultat.clear()
+            with skattemelding_resultat:
+                if resultat.get("resultat") == "validertOK":
+                    ui.label("✓ Skatteetaten: validertOK").classes(
+                        "text-sm font-medium text-green-600"
+                    )
+                else:
+                    ui.label(f"Skatteetaten: {resultat.get('resultat')}").classes(
+                        "text-sm font-semibold text-red-600"
+                    )
+                ui.label(formater_valideringsresultat(resultat)).classes(
+                    "text-xs whitespace-pre-wrap font-mono text-slate-600 mt-1"
+                )
+                ui.label("Validering lagrer ikke data hos Skatteetaten.").classes(
+                    "text-xs text-slate-400 mt-1"
+                )
+        except Exception as e:
+            n.message = f"Validering feilet: {e}"
+            n.spinner = False
+            n.type = "negative"
+            n.timeout = 0
+            n.close_button = "Lukk"
+
     async def send_aarsregnskap():
         regnskap = state.bygg_regnskap()
         feil = ar_modul.valider(regnskap)
@@ -2869,6 +2966,8 @@ def _bygg_send_fane() -> None:
             for f in feil:
                 ui.notify(f, type="negative")
             return
+        for advarsel in ar_modul.advarsler(regnskap):
+            ui.notify(advarsel, type="warning", timeout=0, close_button="Lukk")
         n = ui.notification("Henter Altinn-token...", spinner=True, timeout=None)
         token = await hent_altinn_token()
         if not token:
@@ -3033,14 +3132,28 @@ def _bygg_send_fane() -> None:
             n.close_button = "Lukk"
 
     ui.separator().classes("my-4")
-    with ui.grid(columns=3).classes("w-full gap-4"):
-        ui.button("Send årsregnskap til Altinn", on_click=send_aarsregnskap).props("color=primary").classes("w-full")
-        ui.button(
-            "Send aksjonærregister til Skatteetaten", on_click=send_aksjonaerregister
-        ).props("color=primary").classes("w-full")
-        ui.button(
-            "Send skattemelding til Skatteetaten", on_click=send_skattemelding
-        ).props("color=primary").classes("w-full")
+    ui.label("Valider dokumentene før innsending (ingenting sendes):").classes(
+        "text-sm text-slate-500 mb-2"
+    )
+    with ui.column().classes("w-full gap-3"):
+        with ui.grid(columns=3).classes("w-full gap-4"):
+            ui.button("Valider årsregnskap", on_click=valider_aarsregnskap).props(
+                "color=primary outline"
+            ).classes("w-full")
+            ui.button("Valider aksjonærregister", on_click=valider_aksjonaerregister).props(
+                "color=primary outline"
+            ).classes("w-full")
+            ui.button("Valider skattemelding", on_click=valider_skattemelding).props(
+                "color=primary outline"
+            ).classes("w-full")
+        with ui.grid(columns=3).classes("w-full gap-4"):
+            ui.button("Send årsregnskap til Altinn", on_click=send_aarsregnskap).props("color=primary").classes("w-full")
+            ui.button(
+                "Send aksjonærregister til Skatteetaten", on_click=send_aksjonaerregister
+            ).props("color=primary").classes("w-full")
+            ui.button(
+                "Send skattemelding til Skatteetaten", on_click=send_skattemelding
+            ).props("color=primary").classes("w-full")
 
     aarsregnskap_resultat = ui.column().classes("mt-3")
     aksjonaer_resultat = ui.column().classes("mt-3")


### PR DESCRIPTION
## Sammendrag
Varsler om utbytte uten dekning i fri egenkapital, og gjør valideringen kjørbar frittstående fra innsending (CLI + UI) så man kan bekrefte at alt er OK før man sender. Begge deler retter seg mot passive holdingselskaper som bare har utgifter, der en utbetaling til eier ikke uten videre er lovlig utbytte.

## Endringer
- `advarsler()` i årsregnskapsmodellen: ikke-blokkerende varsel når det er utbetalt utbytte uten dekning i fri egenkapital (aksjeloven § 8-1). Vises i både CLI- og UI-innsendingen.
- Ny CLI-kommando `wenche valider-aarsregnskap` (offline, ingen token). Exit-kode 1 ved blokkerende feil, 0 ellers, slik at den kan brukes som gate av eksterne verktøy.
- Valider-knapper i UI for alle tre dokumenter, i en symmetrisk rad over send-knappene: årsregnskap og aksjonærregister lokalt, skattemelding mot Skatteetatens valider-tjeneste (lagrer ikke data).
- 8 nye tester (advarsler-logikk + CLI-gate). Versjonsbump 0.22.0 → 0.23.0.

## Vurdert og avslått
- Hard blokk på utbytte uten dekning. Avslått fordi lovlig tilleggsutbytte kan besluttes på forrige godkjente balanse, så en blokk ville gitt falske avvisninger. Derfor advarsel, ikke feil.

## Test plan
- [x] `wenche valider-aarsregnskap --config config.yaml` gir exit 1 ved ubalanse, exit 0 ved gyldig regnskap
- [x] Årsregnskap med utbytte og negativ fri egenkapital gir ADVARSEL, men exit 0
- [x] UI: «Valider årsregnskap» viser feil/advarsel/OK inline uten å sende
- [x] UI: «Valider aksjonærregister» kjører lokal validering (+ BRG-sjekk i prod)
- [x] UI: «Valider skattemelding» returnerer validertOK/avvik fra Skatteetaten uten å sende
- [x] Send-flyten viser fortsatt utbytte-advarselen som gul varsling
- [x] `pytest` grønn (273 passed)