### PR TITLE
refactor(skattemelding)!: omdøp eierandel-feltet og skjul defaulten

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -111,7 +111,9 @@ skattemelding:
                                     # Finnes i fjorårets skattemelding (RF-1028).
   anvend_fritaksmetoden: false      # true for holdingselskaper som eier aksjer i
                                     # datterselskaper (skatteloven § 2-38).
-  eierandel_datterselskap: 100      # Eierandel i datterselskapet (prosent, 0–100).
+  # eierandel_for_fritaksmetoden: 100  # Eierandel i selskapet som deler ut utbytte
+                                    # (prosent, 0–100). Brukes bare når
+                                    # anvend_fritaksmetoden er true.
                                     # ≥ 90 %: hele utbyttet er skattefritt.
                                     # < 90 %: 3 % er skattepliktig (sjablonregelen).
   boersnotert: false                # true hvis selskapet er børsnotert.

--- a/docs/bruk.md
+++ b/docs/bruk.md
@@ -65,7 +65,7 @@ Sammendraget inneholder:
 - **Egenkapitalnote** (rskl. § 7-2b) med bevegelse per egenkapitalpost (inngående balanse, årsresultat, utbytte og utgående balanse)
 
 !!! info "Fritaksmetoden og sjablonregelen"
-    Wenche håndterer **to tilfeller** avhengig av eierandel i datterselskapet (`eierandel_datterselskap` i config.yaml):
+    Wenche håndterer **to tilfeller** avhengig av eierandelen i selskapet som deler ut utbytte (`eierandel_for_fritaksmetoden` i config.yaml):
 
     - **Eierandel ≥ 90 %:** Hele utbyttet er skattefritt (fritaksmetoden, sktl. § 2-38).
     - **Eierandel < 90 %:** 3 % av utbyttet er skattepliktig (sjablonregelen, sktl. § 2-38 sjette ledd). Skatteberegningen justeres automatisk.

--- a/docs/referanse.md
+++ b/docs/referanse.md
@@ -112,7 +112,7 @@ foregaaende_aar:
 |---|---|---|---|
 | `underskudd_til_fremfoering` | heltall | nei | Fremførbart underskudd fra tidligere år (NOK). Finnes i fjorårets skattemelding. Standard: `0` |
 | `anvend_fritaksmetoden` | boolsk | nei | `true` for holdingselskaper som eier aksjer i datterselskaper (sktl. § 2-38). Standard: `false` |
-| `eierandel_datterselskap` | heltall | nei | Eierandel i datterselskapet i prosent (0–100). ≥ 90 %: hele utbyttet fritatt. < 90 %: 3 % skattepliktig (sjablonregelen, sktl. § 2-38 sjette ledd). Standard: `100` |
+| `eierandel_for_fritaksmetoden` | heltall | nei | Eierandel i selskapet som deler ut utbytte, i prosent (0–100). Brukes bare når `anvend_fritaksmetoden` er `true`. ≥ 90 %: hele utbyttet fritatt. < 90 %: 3 % skattepliktig (sjablonregelen, sktl. § 2-38 sjette ledd). Standard: `100` |
 | `boersnotert` | boolsk | nei | `true` hvis selskapet er børsnotert. Standard: `false` |
 | `formuesverdi_aksjer` | heltall | nei | Formuesverdi av aksjer selskapet eier i andre selskap, fra aksjeoppgaven (RF-1088S, post 209). Brukes til å beregne netto formuesverdi bak selskapets egne aksjer. Standard: `0` |
 | `samlet_verdi_bak_aksjene` | heltall | nei | Overstyrer den beregnede netto formuesverdien bak aksjene direkte. Utelat for å la Wenche beregne den fra `formuesverdi_aksjer` og balansen |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.23.0"
+version = "0.24.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_skattemelding.py
+++ b/tests/test_skattemelding.py
@@ -42,7 +42,7 @@ def test_ingen_skatt_ved_underskudd(eksempel_regnskap):
 
 def test_fritaksmetoden_under_90_prosent_eierandel(regnskap_med_utbytte):
     """Ved eierandel < 90 % gjelder sjablonregelen: 3 % er skattepliktig."""
-    konfig = SkattemeldingKonfig(anvend_fritaksmetoden=True, eierandel_datterselskap=50)
+    konfig = SkattemeldingKonfig(anvend_fritaksmetoden=True, eierandel_for_fritaksmetoden=50)
     tekst = generer(regnskap_med_utbytte, konfig)
     assert "fritatt, 97 %" in tekst
     assert "sjablonregel, 3 %" in tekst
@@ -50,7 +50,7 @@ def test_fritaksmetoden_under_90_prosent_eierandel(regnskap_med_utbytte):
 
 def test_fritaksmetoden_over_90_prosent_eierandel(regnskap_med_utbytte):
     """Ved eierandel ≥ 90 % er hele utbyttet fritatt — ingen sjablonregel."""
-    konfig = SkattemeldingKonfig(anvend_fritaksmetoden=True, eierandel_datterselskap=100)
+    konfig = SkattemeldingKonfig(anvend_fritaksmetoden=True, eierandel_for_fritaksmetoden=100)
     tekst = generer(regnskap_med_utbytte, konfig)
     assert "100 % fritatt" in tekst
     assert "sjablonregel" not in tekst
@@ -60,7 +60,7 @@ def test_fritaksmetoden_under_90_skattepliktig_beloep(regnskap_med_utbytte):
     """3 % av 100 000 kr utbytte = 3 000 kr skattepliktig; skatt = 0 (inntekt = -2 500)."""
     # Driftsresultat = -5500, skattepliktig utbytte = ceil(100000 * 0.03) = 3000
     # Skattepliktig inntekt = -5500 + 3000 = -2500 → ingen skatt
-    konfig = SkattemeldingKonfig(anvend_fritaksmetoden=True, eierandel_datterselskap=50)
+    konfig = SkattemeldingKonfig(anvend_fritaksmetoden=True, eierandel_for_fritaksmetoden=50)
     tekst = generer(regnskap_med_utbytte, konfig)
     assert _skatt_linje(tekst).endswith("0 kr")
 
@@ -68,7 +68,7 @@ def test_fritaksmetoden_under_90_skattepliktig_beloep(regnskap_med_utbytte):
 def test_fritaksmetoden_over_90_ingen_skatt(regnskap_med_utbytte):
     """Ved eierandel ≥ 90 % og negativt driftsresultat skal det ikke beregnes skatt."""
     # Driftsresultat = -5500, skattepliktig utbytte = 0 → ingen skatt
-    konfig = SkattemeldingKonfig(anvend_fritaksmetoden=True, eierandel_datterselskap=100)
+    konfig = SkattemeldingKonfig(anvend_fritaksmetoden=True, eierandel_for_fritaksmetoden=100)
     tekst = generer(regnskap_med_utbytte, konfig)
     assert _skatt_linje(tekst).endswith("0 kr")
 

--- a/wenche/models.py
+++ b/wenche/models.py
@@ -263,7 +263,8 @@ class Noter:
 class SkattemeldingKonfig:
     underskudd_til_fremfoering: float = 0.0   # Ubenyttet underskudd fra tidligere år
     anvend_fritaksmetoden: bool = True         # True for holdingselskaper som eier aksjer
-    eierandel_datterselskap: int = 100         # Eierandel i datterselskap (prosent, 0–100)
+    eierandel_for_fritaksmetoden: int = 100    # Eierandel i utbyttegivende selskap (prosent, 0–100).
+                                               # Brukes bare når anvend_fritaksmetoden er True.
     boersnotert: bool = False                  # True hvis selskapet er børsnotert
     formuesverdi_aksjer: float = 0.0           # Formuesverdi av aksjer selskapet eier
                                                # (fra aksjeoppgaven RF-1088S, post 209)

--- a/wenche/saft.py
+++ b/wenche/saft.py
@@ -336,7 +336,6 @@ def importer(saft_fil: str | Path) -> dict:
         "skattemelding": {
             "underskudd_til_fremfoering": underskudd_aapning,
             "anvend_fritaksmetoden": False,
-            "eierandel_datterselskap": 100,
         },
         "aksjonaerer": [],
         "noter": {

--- a/wenche/skattemelding.py
+++ b/wenche/skattemelding.py
@@ -76,7 +76,7 @@ def les_config(config_fil: str) -> tuple[Aarsregnskap, SkattemeldingKonfig]:
     konfig = SkattemeldingKonfig(
         underskudd_til_fremfoering=float(sm_raw.get("underskudd_til_fremfoering", 0)),
         anvend_fritaksmetoden=bool(sm_raw.get("anvend_fritaksmetoden", True)),
-        eierandel_datterselskap=int(sm_raw.get("eierandel_datterselskap", 100)),
+        eierandel_for_fritaksmetoden=int(sm_raw.get("eierandel_for_fritaksmetoden", 100)),
         boersnotert=bool(sm_raw.get("boersnotert", False)),
         formuesverdi_aksjer=float(sm_raw.get("formuesverdi_aksjer", 0)),
         samlet_verdi_bak_aksjene=(
@@ -128,7 +128,7 @@ def generer(regnskap: Aarsregnskap, konfig: SkattemeldingKonfig) -> str:
     # Merk: dette er basert på faglig vurdering — sjekk alltid mot gjeldende regelverk.
     utbytte = r.finansposter.utbytte_fra_datterselskap
     if konfig.anvend_fritaksmetoden and utbytte > 0:
-        if konfig.eierandel_datterselskap >= 90:
+        if konfig.eierandel_for_fritaksmetoden >= 90:
             skattepliktig_utbytte = 0
             fritatt_utbytte = utbytte
         else:
@@ -221,7 +221,7 @@ def generer(regnskap: Aarsregnskap, konfig: SkattemeldingKonfig) -> str:
     ]
 
     if konfig.anvend_fritaksmetoden and utbytte > 0:
-        if konfig.eierandel_datterselskap >= 90:
+        if konfig.eierandel_for_fritaksmetoden >= 90:
             linjer += [
                 f"    Utbytte (100 % fritatt)      {_nok(fritatt_utbytte)}",
             ]

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -207,7 +207,7 @@ class AppState:
     # Skattemelding
     underskudd: float = 0.0
     fritaksmetoden: bool = False
-    eierandel_datterselskap: int = 100
+    eierandel_for_fritaksmetoden: int = 100
     boersnotert: bool = False
     formuesverdi_aksjer: float = 0.0   # Fra aksjeoppgaven RF-1088S, post 209
 
@@ -364,7 +364,7 @@ class AppState:
         return SkattemeldingKonfig(
             underskudd_til_fremfoering=self.underskudd,
             anvend_fritaksmetoden=self.fritaksmetoden,
-            eierandel_datterselskap=int(self.eierandel_datterselskap),
+            eierandel_for_fritaksmetoden=int(self.eierandel_for_fritaksmetoden),
             boersnotert=self.boersnotert,
             formuesverdi_aksjer=self.formuesverdi_aksjer,
         )
@@ -456,7 +456,7 @@ class AppState:
             sm_cfg = cfg.get("skattemelding", {})
             self.underskudd = float(sm_cfg.get("underskudd_til_fremfoering", 0))
             self.fritaksmetoden = bool(sm_cfg.get("anvend_fritaksmetoden", False))
-            self.eierandel_datterselskap = int(sm_cfg.get("eierandel_datterselskap", 100))
+            self.eierandel_for_fritaksmetoden = int(sm_cfg.get("eierandel_for_fritaksmetoden", 100))
             self.boersnotert = bool(sm_cfg.get("boersnotert", False))
             self.formuesverdi_aksjer = float(sm_cfg.get("formuesverdi_aksjer", 0))
 
@@ -586,7 +586,11 @@ class AppState:
             "skattemelding": {
                 "underskudd_til_fremfoering": self.underskudd,
                 "anvend_fritaksmetoden": self.fritaksmetoden,
-                "eierandel_datterselskap": int(self.eierandel_datterselskap),
+                **(
+                    {"eierandel_for_fritaksmetoden": int(self.eierandel_for_fritaksmetoden)}
+                    if self.fritaksmetoden
+                    else {}
+                ),
                 "boersnotert": self.boersnotert,
                 "formuesverdi_aksjer": self.formuesverdi_aksjer,
             },
@@ -2177,8 +2181,8 @@ def _bygg_selskap_fane() -> None:
                     eks_sm = eks.get("skattemelding") or {}
                     if "anvend_fritaksmetoden" in eks_sm:
                         data["skattemelding"]["anvend_fritaksmetoden"] = eks_sm["anvend_fritaksmetoden"]
-                    if "eierandel_datterselskap" in eks_sm:
-                        data["skattemelding"]["eierandel_datterselskap"] = eks_sm["eierandel_datterselskap"]
+                    if "eierandel_for_fritaksmetoden" in eks_sm:
+                        data["skattemelding"]["eierandel_for_fritaksmetoden"] = eks_sm["eierandel_for_fritaksmetoden"]
                     if eks_sm.get("underskudd_til_fremfoering"):
                         data["skattemelding"]["underskudd_til_fremfoering"] = eks_sm["underskudd_til_fremfoering"]
                     # Noter: bevar antall_ansatte hvis satt, og bevar
@@ -2637,8 +2641,8 @@ def _bygg_dokumenter_fane() -> None:
                 "Ved eierandel ≥ 90 % er hele utbyttet skattefritt."
             )
             eierandel_el = num(
-                "Eierandel i datterselskap (%)",
-                "eierandel_datterselskap",
+                "Eierandel i utbyttegivende selskap (%)",
+                "eierandel_for_fritaksmetoden",
                 step=1,
                 min_val=0,
             )


### PR DESCRIPTION
## Bakgrunn

`eierandel_datterselskap` var villedende på to nivåer:

1. **Navnet implisitt «datterselskap»**, men feltet er i praksis bare en parameter til fritaksmetoden (terskelen for 3 %-sjablonen, sktl. § 2-38 sjette ledd). Det gjelder enhver eierpost i et utbyttegivende selskap, ikke bare datterselskaper i konsernforstand.
2. **Defaulten 100 ble alltid persistert** til `config.yaml`, også når `anvend_fritaksmetoden: false`. Det lekket ut som et feilaktig «datterselskap-signal» som forvirret companion-verktøy (f.eks. wenche-regnskap-bokføringsfilen) som leser config.

UI-et skjulte allerede feltet når fritaksmetoden var av (`ui.py:2645`), men persisteringen i `lagre`-funksjonen gjorde det uansett. Nå matcher de hverandre.

## Endringer

- Omdøper `eierandel_datterselskap` -> `eierandel_for_fritaksmetoden` i:
  - `wenche/models.py` (dataklasse)
  - `wenche/skattemelding.py` (logikk og config-lesing)
  - `wenche/ui.py` (state, form, persistering, gjenbruk av tidligere config)
  - `wenche/saft.py` (fjernet helt fra SAF-T-generert config siden den har `anvend_fritaksmetoden: false`)
  - `tests/test_skattemelding.py`
  - `config.example.yaml` (nå kommentert ut som default-eksempel)
  - `docs/referanse.md`, `docs/bruk.md`
- Lagrer feltet i `config.yaml` kun når `anvend_fritaksmetoden: true` (`ui.py:589`)
- UI-label endret: «Eierandel i datterselskap (%)» -> «Eierandel i utbyttegivende selskap (%)»
- Versjon bumpet 0.23.0 -> 0.24.0

## Breaking change

Eksisterende `config.yaml`-filer som setter `skattemelding.eierandel_datterselskap` må oppdateres manuelt til `eierandel_for_fritaksmetoden`. Feltet leses ikke lenger under det gamle navnet. Effekten er kun synlig når `anvend_fritaksmetoden: true` og selskapet mottar utbytte; ellers spiller verdien ingen rolle.

## Test plan

- [x] `pytest tests/` (262 passed, 1 skipped)
- [x] Manuell sjekk i UI: toggle fritaksmetoden av/på og lagre, verifiser at `eierandel_for_fritaksmetoden` kun skrives når den er på
- [x] Last inn en config med fritaksmetoden=true og se at eierandel-feltet vises og leses riktig