### PR TITLE
docs(readme): lenke til Wenche-regnskap som søsterprosjekt

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ Autentisering skjer via Maskinporten med et selvgenerert RSA-nøkkelpar, ingen v
 | **Skattemelding for AS** (skattemelding + næringsspesifikasjon) | Skatteetaten | 31. mai | Automatisk innsending |
 | **Årsregnskap** | Brønnøysundregistrene | 31. juli | Automatisk innsending |
 
+## Trenger du å føre regnskapet først?
+
+Wenche sender inn, men forutsetter at du allerede har tallene. For
+**passive holdingselskaper** finnes søsterprosjektet
+[Wenche-regnskap](https://github.com/olefredrik/Wenche-regnskap): et
+template-repo drevet av Claude Code som gjør en bankeksport om til et
+lesbart regnskap, en generalforsamlingsprotokoll og en ferdig
+`config.yaml` som Wenche leser direkte. Du fører bøkene i git, Wenche
+sender inn, og sammen blir det en komplett flyt. Lag din egen private
+kopi via «Use this template».
+
 ## Kom i gang
 
 Wenche krever Python 3.11 eller nyere. Installer i et virtuelt miljø (macOS/Linux):

--- a/README.md
+++ b/README.md
@@ -28,12 +28,9 @@ Wenche sender inn, men forutsetter at du allerede har tallene. For
 [Wenche-regnskap](https://github.com/olefredrik/Wenche-regnskap): et
 template-repo drevet av Claude Code som gjør en bankeksport om til et
 lesbart regnskap, en generalforsamlingsprotokoll og en ferdig
-`config.yaml` som Wenche leser direkte. Du fører bøkene i git, Wenche
-sender inn, og sammen blir det en komplett flyt.
-
-Trykk «Use this template» på repoet for å opprette ditt eget repo med
-verktøyet i. Velg **Private** når du oppretter det, så holder du
-regnskapstallene dine for deg selv.
+`config.yaml` som Wenche leser direkte. Trykk «Use this template» på
+repoet for å opprette ditt eget repo med verktøyet i, og velg
+**Private** så regnskapstallene blir hos deg.
 
 ## Kom i gang
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,11 @@ Wenche sender inn, men forutsetter at du allerede har tallene. For
 template-repo drevet av Claude Code som gjør en bankeksport om til et
 lesbart regnskap, en generalforsamlingsprotokoll og en ferdig
 `config.yaml` som Wenche leser direkte. Du fører bøkene i git, Wenche
-sender inn, og sammen blir det en komplett flyt. Lag din egen private
-kopi via «Use this template».
+sender inn, og sammen blir det en komplett flyt.
+
+Trykk «Use this template» på repoet for å opprette ditt eget repo med
+verktøyet i. Velg **Private** når du oppretter det, så holder du
+regnskapstallene dine for deg selv.
 
 ## Kom i gang
 


### PR DESCRIPTION
## Bakgrunn

[Wenche-regnskap](https://github.com/olefredrik/Wenche-regnskap) er nå publisert som offentlig template-repo for å føre regnskap for passive holdingselskaper og produsere en `config.yaml` som Wenche leser direkte. Denne PR-en lenker det inn fra Wenches README, slik at brukere som har Wenche, men mangler en bokføringsløsning, finner companion-flyten.

## Endringer

- Nytt avsnitt «Trenger du å føre regnskapet først?» rett etter «Hva er støttet?»-tabellen, før «Kom i gang»
- Forklarer kort hva Wenche-regnskap gjør, og hvordan «Use this template» med Private-valg gir leseren sitt eget repo uten å eksponere regnskapstall

## Test plan

- [x] Sjekk at lenken til Wenche-regnskap fungerer
- [x] Verifiser at avsnittet vises riktig på GitHub og i mkdocs-siten (hvis README brukes der)