### PR TITLE
docs(readme): omdøp søsterprosjekt Wenche-regnskap til Bodil

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,11 @@ Autentisering skjer via Maskinporten med et selvgenerert RSA-nøkkelpar, ingen v
 
 Wenche sender inn, men forutsetter at du allerede har tallene. For
 **passive holdingselskaper** finnes søsterprosjektet
-[Wenche-regnskap](https://github.com/olefredrik/Wenche-regnskap): et
-template-repo drevet av Claude Code som gjør en bankeksport om til et
-lesbart regnskap, en generalforsamlingsprotokoll og en ferdig
-`config.yaml` som Wenche leser direkte. Trykk «Use this template» på
-repoet for å opprette ditt eget repo med verktøyet i, og velg
-**Private** så regnskapstallene blir hos deg.
+[Bodil](https://github.com/olefredrik/Bodil): et template-repo drevet av
+Claude Code som gjør en bankeksport om til et lesbart regnskap, en
+generalforsamlingsprotokoll og en ferdig `config.yaml` som Wenche leser
+direkte. Trykk «Use this template» på repoet for å opprette ditt eget repo
+med verktøyet i, og velg **Private** så regnskapstallene blir hos deg.
 
 ## Kom i gang
 


### PR DESCRIPTION
## Bakgrunn

Søsterprosjektet som tidligere het Wenche-regnskap er omdøpt til Bodil og flyttet til <https://github.com/olefredrik/Bodil>. Gammel URL redirigerer, men det nye navnet er kanonisk og bør brukes overalt.

## Endringer

- Avsnittet «Trenger du å føre regnskapet først?» i README oppdatert til å bruke navnet Bodil og ny URL `/Bodil`
- Verifisert at det ikke finnes flere referanser til Wenche-regnskap i repoet

## Test plan

- [x] Sjekk at lenken til <https://github.com/olefredrik/Bodil> fungerer
- [x] Verifiser at avsnittet vises riktig på GitHub