### PR TITLE
fix(auth): valider token-cache mot utløp og miljø før gjenbruk

### DIFF
--- a/tests/test_token_cache.py
+++ b/tests/test_token_cache.py
@@ -1,0 +1,122 @@
+"""
+Tester for miljø- og utløpsvalidering av Altinn-token-cachen i wenche.auth.
+
+Regresjonsdekning for issue #103: et cachet token (utløpt eller fra feil
+miljø) ble tidligere returnert ukritisk av get_altinn_token() og ga 401
+ved innsending i produksjon.
+"""
+
+import base64
+import json
+import time
+
+import pytest
+
+from wenche import auth
+
+PROD_ISS = "https://platform.altinn.no/authentication/api/v1/openid/"
+TEST_ISS = "https://platform.tt02.altinn.no/authentication/api/v1/openid/"
+
+
+def _fake_token(exp: int, iss: str) -> str:
+    """Bygger et JWT-lignende token (usignert) med gitt exp og iss."""
+    def seg(d: dict) -> str:
+        return base64.urlsafe_b64encode(json.dumps(d).encode()).decode().rstrip("=")
+
+    return f"{seg({'alg': 'RS256'})}.{seg({'exp': exp, 'iss': iss})}.signatur"
+
+
+class _LoginSpy:
+    """Erstatter auth.login og teller kall; returnerer et ferskt token."""
+
+    def __init__(self):
+        self.kall = 0
+
+    def __call__(self, *args, **kwargs):
+        self.kall += 1
+        return {"altinn_token": "FERSKT", "maskinporten_token": "m"}
+
+
+class TestEnvFraIss:
+    def test_tt02_gir_test(self):
+        assert auth._env_fra_iss(TEST_ISS) == "test"
+
+    def test_prod_gir_prod(self):
+        assert auth._env_fra_iss(PROD_ISS) == "prod"
+
+    def test_tom_gir_prod(self):
+        assert auth._env_fra_iss("") == "prod"
+
+
+class TestTokenFile:
+    def test_prod_bruker_token_json(self):
+        assert auth._token_file("prod").name == "token.json"
+
+    def test_test_bruker_token_dev_json(self):
+        assert auth._token_file("test").name == "token.dev.json"
+
+
+class TestAltinnTokenGyldig:
+    def test_ferskt_og_riktig_miljo_er_gyldig(self):
+        tok = _fake_token(int(time.time()) + 3600, PROD_ISS)
+        assert auth._altinn_token_gyldig(tok, "prod") is True
+
+    def test_utlopt_er_ugyldig(self):
+        tok = _fake_token(int(time.time()) - 10, PROD_ISS)
+        assert auth._altinn_token_gyldig(tok, "prod") is False
+
+    def test_naer_utlop_innenfor_margin_er_ugyldig(self):
+        tok = _fake_token(int(time.time()) + 30, PROD_ISS)
+        assert auth._altinn_token_gyldig(tok, "prod", margin_sek=60) is False
+
+    def test_feil_miljo_er_ugyldig(self):
+        # tt02-token, men vi spør om prod (kjernen i #103)
+        tok = _fake_token(int(time.time()) + 3600, TEST_ISS)
+        assert auth._altinn_token_gyldig(tok, "prod") is False
+
+    def test_uleselig_token_er_ugyldig(self):
+        assert auth._altinn_token_gyldig("ikke-et-jwt", "prod") is False
+        assert auth._altinn_token_gyldig("", "prod") is False
+
+
+class TestGetAltinnToken:
+    @pytest.fixture
+    def spy(self, monkeypatch, tmp_path):
+        """Isolerer cache til tmp og erstatter login med en spion."""
+        spy = _LoginSpy()
+        monkeypatch.setattr(auth, "login", spy)
+        monkeypatch.setattr(
+            auth, "_token_file", lambda env=None: tmp_path / "token.json"
+        )
+        monkeypatch.setenv("WENCHE_ENV", "prod")
+        return spy
+
+    def _skriv_cache(self, tmp_path, tok):
+        (tmp_path / "token.json").write_text(
+            json.dumps({"altinn_token": tok, "maskinporten_token": "m"})
+        )
+
+    def test_gjenbruker_gyldig_cache_uten_login(self, spy, tmp_path):
+        self._skriv_cache(tmp_path, _fake_token(int(time.time()) + 3600, PROD_ISS))
+        assert auth.get_altinn_token() != "FERSKT"
+        assert spy.kall == 0
+
+    def test_re_login_ved_utlopt_token(self, spy, tmp_path):
+        self._skriv_cache(tmp_path, _fake_token(int(time.time()) - 10, PROD_ISS))
+        assert auth.get_altinn_token() == "FERSKT"
+        assert spy.kall == 1
+
+    def test_re_login_ved_feil_miljo(self, spy, tmp_path):
+        # Regresjon #103: tt02-token i prod-cachen skal forkastes, ikke 401.
+        self._skriv_cache(tmp_path, _fake_token(int(time.time()) + 3600, TEST_ISS))
+        assert auth.get_altinn_token() == "FERSKT"
+        assert spy.kall == 1
+
+    def test_re_login_naar_cache_mangler(self, spy):
+        assert auth.get_altinn_token() == "FERSKT"
+        assert spy.kall == 1
+
+    def test_re_login_ved_korrupt_cache(self, spy, tmp_path):
+        (tmp_path / "token.json").write_text("{ ikke gyldig json")
+        assert auth.get_altinn_token() == "FERSKT"
+        assert spy.kall == 1

--- a/wenche/auth.py
+++ b/wenche/auth.py
@@ -10,6 +10,7 @@ Flyt:
   3. Veksle Maskinporten-token mot Altinn-token
 """
 
+import base64
 import json
 import os
 import time
@@ -87,7 +88,48 @@ SKD_SKATTEMELDING_SCOPE = (
 
 # Scope for lesestatus fra SKDs skattemelding-API (ingen Altinn-instanser)
 SKD_SKATTEMELDING_LESE_SCOPE = "skatteetaten:formueinntekt/skattemelding"
-TOKEN_FILE = Path.home() / ".wenche" / "token.json"
+
+
+def _token_file(env: str | None = None) -> Path:
+    """
+    Sti til token-cachen for gitt miljø.
+
+    Prod og test holdes i hver sin fil slik at et test-token (tt02) aldri kan
+    gjenbrukes i produksjon. Speiler config-splittingen (config.yaml /
+    config.dev.yaml) fra PR #96 — token-cachen ble den gang oversett og forble
+    delt, noe som ga 401 ved miljøbytte.
+    """
+    if env is None:
+        env = _gjeldende_env()
+    navn = "token.dev.json" if env == "test" else "token.json"
+    return Path.home() / ".wenche" / navn
+
+
+def _env_fra_iss(iss: str) -> str:
+    """Avleder miljø fra Altinn-tokenets utsteder (iss). tt02 ⇒ test."""
+    return "test" if "tt02" in (iss or "") else "prod"
+
+
+def _altinn_token_gyldig(altinn_token: str, env: str, margin_sek: int = 60) -> bool:
+    """
+    Om et cachet Altinn-token trygt kan gjenbrukes i gitt miljø.
+
+    Returnerer False (⇒ re-autentisering) hvis tokenet er utløpt eller utløper
+    innen margin_sek, tilhører feil miljø (iss), eller ikke lar seg dekode.
+    Defensiv: enhver tvil gir False.
+    """
+    try:
+        deler = altinn_token.split(".")
+        if len(deler) < 2:
+            return False
+        pad = deler[1] + "=" * (-len(deler[1]) % 4)
+        payload = json.loads(base64.urlsafe_b64decode(pad))
+    except Exception:
+        return False
+    exp = payload.get("exp")
+    if not isinstance(exp, (int, float)) or exp <= time.time() + margin_sek:
+        return False
+    return _env_fra_iss(payload.get("iss", "")) == env
 
 
 def _lag_jwt(
@@ -256,9 +298,10 @@ def login(lagre_token: bool = True) -> dict:
         print("Autentisering vellykket (token ikke lagret).\n")
         return tokens
 
-    TOKEN_FILE.parent.mkdir(parents=True, exist_ok=True)
-    TOKEN_FILE.write_text(json.dumps(tokens))
-    TOKEN_FILE.chmod(0o600)
+    fil = _token_file(env)
+    fil.parent.mkdir(parents=True, exist_ok=True)
+    fil.write_text(json.dumps(tokens))
+    fil.chmod(0o600)
 
     print("Autentisering vellykket.\n")
     return tokens
@@ -288,10 +331,22 @@ def login_admin() -> str:
 
 
 def get_altinn_token() -> str:
-    """Returnerer gjeldende Altinn-token, eller henter nytt."""
-    if TOKEN_FILE.exists():
-        tokens = json.loads(TOKEN_FILE.read_text())
-        return tokens["altinn_token"]
+    """
+    Returnerer et gyldig Altinn-token for aktivt miljø.
+
+    Gjenbruker cachet token kun hvis det ikke er utløpt og tilhører riktig
+    miljø; ellers re-autentiseres det. Hindrer 401 ved miljøbytte og utløpt
+    cache (tidligere ble cachet token returnert ukritisk).
+    """
+    env = _gjeldende_env()
+    fil = _token_file(env)
+    if fil.exists():
+        try:
+            tokens = json.loads(fil.read_text())
+        except (json.JSONDecodeError, OSError):
+            tokens = None
+        if tokens and _altinn_token_gyldig(tokens.get("altinn_token", ""), env):
+            return tokens["altinn_token"]
     return login()["altinn_token"]
 
 
@@ -411,9 +466,10 @@ def get_skd_skattemelding_tokens() -> dict:
 
 
 def logout():
-    """Sletter lagret token."""
-    if TOKEN_FILE.exists():
-        TOKEN_FILE.unlink()
+    """Sletter lagret token for aktivt miljø."""
+    fil = _token_file()
+    if fil.exists():
+        fil.unlink()
         print("Token slettet.")
     else:
         print("Ingen aktiv sesjon å logge ut fra.")


### PR DESCRIPTION
Fixes #103

## Problem

`get_altinn_token()` returnerte det cachede Altinn-tokenet fra `~/.wenche/token.json` **uten å sjekke utløp eller miljø**. Det ga `401 Unauthorized` ved innsending av årsregnskap i produksjon når cachen inneholdt et utløpt token, eller et tt02-token fra en tidligere testkjøring. Tilkoblingstesten skjulte feilen fordi den alltid henter et ferskt token (`login(lagre_token=False)`).

Eksponert av #96, som splittet config per miljø (`config.yaml`/`config.dev.yaml`) «slik at testdata ikke kan overskrive ekte selskapsinformasjon» — men token-cachen ble oversett og forble delt mellom prod og test. Full analyse i #103.

## Endringer

- **Validering før gjenbruk:** `get_altinn_token()` dekoder `exp` (re-autentiserer hvis utløpt eller utløper innen 60 s) og `iss` (forkaster ved miljø-mismatch). Defensiv: udekodbart/korrupt token ⇒ re-login.
- **Token-cache splittet per miljø:** `token.json` (prod) / `token.dev.json` (test), konsistent med config-splittingen i #96. `login()` og `logout()` følger aktivt miljø.
- **Selvretting for eksisterende brukere:** `iss`-sjekken forkaster automatisk pre-#96-tokens som ligger igjen i `token.json`, så de re-autentiseres ved neste kall uten manuell `logout`.

## Tester

- Ny `tests/test_token_cache.py` (15 tester): `_env_fra_iss`, `_altinn_token_gyldig` (ferskt/utløpt/nær utløp/feil miljø/uleselig), `_token_file` per miljø, og `get_altinn_token` (gjenbruk av gyldig cache, re-login ved utløp/feil miljø/manglende/korrupt cache).
- Hele suiten grønn: **288 passed**.

## Merknad

Ingen API-endring for kallere (`ui.py`, `cli.py`). `auth.TOKEN_FILE`-konstanten er erstattet av `_token_file(env)`; ingen ekstern kode refererte den.