### PR TITLE
chore(release): bump versjon til 0.24.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.24.0"
+version = "0.24.1"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
Versjonsbump for en samlet patch-release etter to bugfikser.

## Innhold i 0.24.1
- **#104** (fixes #103) — `fix(auth)`: valider token-cache mot utløp og miljø før gjenbruk. Hindrer 401 ved miljøbytte / utløpt token.
- **#106** (fixes #105) — `fix(naeringsspesifikasjon)`: rund beløp til hele kroner som årsregnskapet. Fjerner 1-krones sprik og balanse som ikke gikk opp.

Begge er `fix:` → PATCH (0.24.0 → 0.24.1).

## Etter merge
Tag og publiser:
```
git checkout main && git pull && git tag v0.24.1 && git push origin v0.24.1
```
`publish.yml` publiserer til PyPI på tag-push.