### PR TITLE
fix(fristsjekk): tydeligere årsregnskap-status, journalnr og opprydding på hjem-fanen

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.24.1"
+version = "0.24.2"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_fristsjekk.py
+++ b/tests/test_fristsjekk.py
@@ -193,6 +193,7 @@ class TestSjekkAarsregnskap:
             {
                 "regnskapsperiode": {"fraDato": "2025-01-01", "tilDato": "2025-12-31"},
                 "mottaksdag": "2026-04-15",
+                "journalnr": "2026505123",
             },
         ])
         result = sjekk_aarsregnskap("931808869", 2025)
@@ -201,6 +202,19 @@ class TestSjekkAarsregnskap:
         assert "mottatt" in result.brukertekst.lower()
         assert "2025" in result.brukertekst
         assert result.tidspunkt == "2026-04-15"
+        assert result.referanse == "2026505123"
+        assert result.referanse_etikett == "Journalnr"
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_manglende_journalnr_gir_none_referanse(self, mock_get):
+        """BRG-svar uten journalnr → innfridd, men referanse=None (vises ikke)."""
+        mock_get.return_value = _mock_response(json_data=[
+            {"regnskapsperiode": {"fraDato": "2025-01-01", "tilDato": "2025-12-31"}},
+        ])
+        result = sjekk_aarsregnskap("931808869", 2025)
+
+        assert result.innfridd is True
+        assert result.referanse is None
 
     @patch("wenche.fristsjekk.httpx.get")
     def test_annet_aar_gir_ikke_innfridd(self, mock_get):
@@ -213,7 +227,9 @@ class TestSjekkAarsregnskap:
         result = sjekk_aarsregnskap("931808869", 2025)
 
         assert result.innfridd is False
-        assert "ikke mottatt" in result.brukertekst.lower()
+        assert result.beskrivelse == "Ikke synlig i registeret ennå"
+        assert "ennå" in result.brukertekst.lower()
+        assert "2025" in result.brukertekst
 
     @patch("wenche.fristsjekk.httpx.get")
     def test_tom_liste_gir_ikke_innfridd(self, mock_get):
@@ -224,14 +240,18 @@ class TestSjekkAarsregnskap:
         assert result.innfridd is False
 
     @patch("wenche.fristsjekk.httpx.get")
-    def test_404_gir_ikke_levert(self, mock_get):
-        """404 fra BRG → orgnr har ingen innleverte regnskap → 'Ikke levert'."""
+    def test_404_gir_ikke_synlig(self, mock_get):
+        """404 fra BRG → orgnr har ingen publiserte regnskap → 'Ikke synlig ennå'.
+
+        Formuleres som publiseringsetterslep, ikke bekreftet 'ikke levert', siden
+        et nettopp innsendt regnskap ikke er publisert i registeret umiddelbart.
+        """
         mock_get.return_value = _mock_response(status_code=404)
         result = sjekk_aarsregnskap("931808869", 2025)
 
         assert result.innfridd is False
-        assert result.beskrivelse == "Ikke levert"
-        assert "ikke mottatt" in result.brukertekst.lower()
+        assert result.beskrivelse == "Ikke synlig i registeret ennå"
+        assert "publiseres" in result.brukertekst.lower()
 
     @patch("wenche.fristsjekk.httpx.get")
     def test_http_feil_gir_beskrivelse(self, mock_get):

--- a/wenche/fristsjekk.py
+++ b/wenche/fristsjekk.py
@@ -76,6 +76,11 @@ class FristStatus:
     beskrivelse: str = ""
     brukertekst: str = ""
     lenke: str | None = None
+    # Saksreferanse fra myndighetenes register (f.eks. Brønnøysunds journalnr),
+    # vist på det innfridde kortet. referanse_etikett gir riktig ledetekst siden
+    # ulike etater bruker ulike begreper.
+    referanse: str | None = None
+    referanse_etikett: str = "Referanse"
 
 
 def sjekk_skattemelding(orgnr: str, aar: int) -> FristStatus:
@@ -170,12 +175,9 @@ def sjekk_aarsregnskap(orgnr: str, aar: int) -> FristStatus:
         return FristStatus(beskrivelse="Kunne ikke kontakte Regnskapsregisteret")
 
     # 404 betyr at orgnr ikke har innleverte regnskap i registeret — det er
-    # samme tilstand som "ikke levert ennå" for inneværende regnskapsår.
+    # samme tilstand som "ikke synlig ennå" for inneværende regnskapsår.
     if resp.status_code == 404:
-        return FristStatus(
-            beskrivelse="Ikke levert",
-            brukertekst=f"Brønnøysundregistrene har ikke mottatt årsregnskapet for {aar} ennå.",
-        )
+        return _aarsregnskap_ikke_synlig(aar)
 
     if not resp.is_success:
         return FristStatus(
@@ -195,15 +197,33 @@ def sjekk_aarsregnskap(orgnr: str, aar: int) -> FristStatus:
         fra = periode.get("fraDato", "")
         if fra.startswith(str(aar)):
             mottatt = regnskap.get("mottaksdag")
+            journalnr = regnskap.get("journalnr")
             return FristStatus(
                 innfridd=True,
                 tidspunkt=mottatt,
                 brukertekst=f"Brønnøysundregistrene har mottatt årsregnskapet for {aar}.",
+                referanse=journalnr,
+                referanse_etikett="Journalnr",
             )
 
+    return _aarsregnskap_ikke_synlig(aar)
+
+
+def _aarsregnskap_ikke_synlig(aar: int) -> FristStatus:
+    """
+    Status når årsregnskapet ikke (ennå) finnes i Regnskapsregisteret.
+
+    Det åpne API-et viser kun ferdig behandlede, publiserte regnskap. Et
+    årsregnskap som nettopp er sendt inn og signert i Altinn er ikke publisert
+    umiddelbart, så vi formulerer dette som et publiseringsetterslep, ikke som
+    en bekreftet "ikke levert" — sistnevnte er villedende rett etter innsending.
+    """
     return FristStatus(
-        beskrivelse="Ikke levert",
-        brukertekst=f"Brønnøysundregistrene har ikke mottatt årsregnskapet for {aar} ennå.",
+        beskrivelse="Ikke synlig i registeret ennå",
+        brukertekst=(
+            f"Regnskapsregisteret viser ikke årsregnskapet for {aar} ennå. "
+            "Et nylig innsendt regnskap kan ta noen dager før det publiseres."
+        ),
     )
 
 

--- a/wenche/ui.py
+++ b/wenche/ui.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 import httpx
 import yaml
+from fastapi import Response
 from nicegui import app, run, ui
 
 from wenche import (
@@ -1106,6 +1107,10 @@ def _fristkort_innfridd(card, content, tittel: str, undertittel: str, result) ->
         ui.label(result.brukertekst).classes("text-sm text-slate-600 mt-2")
         if result.tidspunkt:
             ui.label(f"Mottatt {result.tidspunkt}").classes("text-xs text-slate-400 mt-1")
+        if result.referanse:
+            ui.label(f"{result.referanse_etikett}: {result.referanse}").classes(
+                "text-xs text-slate-400 mt-1"
+            )
         if result.lenke:
             ui.separator().classes("my-3")
             ui.link(
@@ -1127,6 +1132,10 @@ def _fristkort_ventende(card, content, tittel: str, undertittel: str, maaned: in
                 ui.label(result.beskrivelse).classes("text-sm text-slate-500")
         ui.label(dato_tekst).classes(f"text-sm font-medium text-{farge}")
         ui.label(countdown).classes(f"text-xs text-{farge}")
+        # Statusdetalj fra API-sjekken (f.eks. forklaring på publiseringsetterslep
+        # i Regnskapsregisteret) — gir kontekst utover den korte status-chippen.
+        if result and result.brukertekst:
+            ui.label(result.brukertekst).classes("text-xs text-slate-500 mt-2")
         ui.separator().classes("my-3")
         ui.label(beskrivelse).classes("text-sm text-slate-600")
 
@@ -1203,8 +1212,8 @@ def _bygg_hjem_fane(tabs=None, t_oppsett=None) -> None:
          "beskrivelse": "Wenche beregner skatten og sender skattemeldingen digitalt via Altinn i steg 6."},
         {"key": "aarsregnskap", "tittel": "Årsregnskap", "undertittel": "Brønnøysundregistrene",
          "maaned": 7, "dag": 31,
-         "beskrivelse": "Sendes digitalt via Altinn i steg 6. "
-                        "Krever signering med BankID av daglig leder eller styreleder."},
+         "beskrivelse": "Sendes digitalt via Altinn i steg 6 og signeres der av en "
+                        "person med signeringsrett."},
         {"key": "aksjonaerregister", "tittel": "Aksjonærregisteroppgave",
          "undertittel": "RF-1086, Skatteetaten", "maaned": 1, "dag": 31,
          "beskrivelse": "Sendes maskinelt til Skatteetatens API via steg 6. "
@@ -3259,6 +3268,16 @@ def main() -> None:
 # ---------------------------------------------------------------------------
 # Inngangspunkt
 # ---------------------------------------------------------------------------
+
+# Safari/iOS ber automatisk om apple-touch-icon-*.png uavhengig av om vi bruker
+# dem. Uten en matchende rute logger NiceGUI en 404 for hver forespørsel ved
+# oppstart. Vi har kun emoji-favicon og ingen touch-ikon, så vi svarer 204 No
+# Content for å holde terminalloggen ren.
+@app.get("/apple-touch-icon-precomposed.png")
+@app.get("/apple-touch-icon.png")
+def _apple_touch_icon() -> Response:
+    return Response(status_code=204)
+
 
 def run_app(env: str = "prod") -> None:
     """Start NiceGUI-serveren med valgt miljø låst for hele sesjonen.


### PR DESCRIPTION
## Bakgrunn

Under prod-innsending av årsregnskap for et passivt holdingselskap viste hjem-fanens årsregnskap-kort «Ikke levert» rett etter en bekreftet innsending i Altinn. Innsendingen var i orden. Brønnøysunds åpne Regnskapsregister-API viser kun ferdigbehandlede, publiserte regnskap, så det er et naturlig etterslep mellom innsending og publisering. Den gamle ordlyden fremsto som en feilet innsending.

## Endringer

- **Status som etterslep, ikke feil:** Ikke-synlig-tilstanden viser nå «Ikke synlig i registeret ennå» med en kort forklaring på at nylig innsendte regnskap kan ta noen dager før de publiseres.
- **Statusdetalj i ventende-kort:** `FristStatus.brukertekst` rendres nå også i ventende-kortet, ikke bare i det innfridde, så forklaringen faktisk vises.
- **Journalnr på innfridd kort:** Plukker Brønnøysunds `journalnr` fra registersvaret og viser det på det grønne «Levert»-kortet (nye felt `referanse`/`referanse_etikett` på `FristStatus`).
- **Presisert signeringstekst:** Årsregnskap-kortet sa «Krever signering med BankID av daglig leder eller styreleder». BankID er innloggingsmetode (ikke selve signaturen), og signeringsretten er rollebasert. Teksten er rettet og forkortet.
- **Stilnet oppstartstøy:** `apple-touch-icon-*.png` svarer nå 204 i stedet for å logge 404 ved hver Safari/iOS-forespørsel.

## Vurdert og avslått

- **Vise Altinn-kvitteringsreferansen** (f.eks. b273fb…): avslått. Den blir endelig først ved signering, som skjer i Altinn etter at Wenche er ferdig, og kortet leser uansett fra de offentlige status-API-ene. Brønnøysunds journalnr ligger gratis i svaret vi allerede parser.
- **Lokal innsendingskvittering for «under behandling»**: avslått. Wenche laster bare opp og får ikke vite om brukeren fullfører signeringen, så en slik kvittering kunne vist falsk «sendt».

## Test plan

- [x] `pytest` grønn (293 tester), inkl. nye/oppdaterte tester i `test_fristsjekk.py` for journalnr og ny ordlyd
- [x] Verifisert mot live Regnskapsregister-API at orgnr kun har fjorårsregnskap publisert (matcher ny status)
- [x] Manuell: start `wenche`, bekreft at årsregnskap-kortet viser ny tekst og at terminalen er fri for apple-touch-icon-404
