### PR TITLE
fix(fristsjekk): vis fjorårets levering i stedet for rå HTTP 403

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.24.2"
+version = "0.24.3"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_fristsjekk.py
+++ b/tests/test_fristsjekk.py
@@ -121,16 +121,56 @@ class TestSjekkSkattemelding:
 
         assert result.innfridd is False
         assert "klargjort" in result.beskrivelse.lower()
+        # Ingen rå HTTP-kode skal lekke til brukeren.
+        assert "HTTP" not in result.beskrivelse
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_403_gir_vennlig_status_ikke_rå_kode(self, mock_get, prod_env):
+        """403 (året ikke åpnet ennå) → forklarende status, ikke "HTTP 403".
+
+        Når også fjoråret er utilgjengelig, beholder kortet den framoverskuende
+        statusen for det forespurte året.
+        """
+        with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
+            mock_get.return_value = _mock_response(status_code=403)
+            result = sjekk_skattemelding("931808869", 2026)
+
+        assert result.innfridd is False
+        assert "HTTP 403" not in result.beskrivelse
+        assert "klargjort" in result.beskrivelse.lower()
+
+    @patch("wenche.fristsjekk.httpx.get")
+    def test_403_faller_tilbake_til_fjorårets_levering(self, mock_get, prod_env):
+        """Kommende år 403, men fjoråret er fastsatt → vis fjorårets levering.
+
+        Dette er tilstanden rett etter at fristen har passert: brukeren har
+        levert for 2025, men kortet spør om det ennå ikke åpnede 2026.
+        """
+        with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
+            mock_get.side_effect = [
+                _mock_response(status_code=403),  # 2026 – ikke åpnet ennå
+                _mock_response(text=_wrapper_xml("skattemeldingUpersonligFastsatt")),  # 2025 – levert
+            ]
+            result = sjekk_skattemelding("931808869", 2026)
+
+        assert result.innfridd is True
+        # Bekreftelsen gjelder fjoråret som faktisk ble levert.
+        assert "2025" in result.brukertekst
+        assert "sendt inn og godkjent" in result.brukertekst
 
     @patch("wenche.fristsjekk.httpx.get")
     def test_http_feil_gir_beskrivelse(self, mock_get, prod_env):
-        """HTTP 500 fra Skatteetaten → innfridd=False med feilmelding."""
+        """HTTP 500 fra Skatteetaten → innfridd=False med feilmelding.
+
+        Transiente feil skal ikke trigge fallback til fjoråret — kun ett kall.
+        """
         with patch("wenche.auth.get_skd_skattemelding_maskinporten_token", return_value="t"):
             mock_get.return_value = _mock_response(status_code=500)
             result = sjekk_skattemelding("931808869", 2025)
 
         assert result.innfridd is False
         assert "HTTP 500" in result.beskrivelse
+        assert mock_get.call_count == 1
 
     @patch("wenche.fristsjekk.httpx.get")
     def test_ugyldig_xml_gir_beskrivelse(self, mock_get, prod_env):

--- a/wenche/fristsjekk.py
+++ b/wenche/fristsjekk.py
@@ -111,6 +111,31 @@ def sjekk_skattemelding(orgnr: str, aar: int) -> FristStatus:
 
 
 def _utfør_skattemelding_sjekk(token: str, orgnr: str, aar: int) -> FristStatus:
+    status, tilgjengelig = _hent_skattemelding_status(token, orgnr, aar)
+
+    # Så snart årets frist har passert ruller Hjem-fanen fram til neste frist og
+    # spør om det kommende inntektsåret. Det året har Skatteetaten ennå ikke
+    # åpnet (svarer 403/404), så for en bruker som nettopp har levert ville
+    # kortet ellers vist en forvirrende "ikke klargjort"-status rett etter
+    # innsending. Når det forespurte året ikke er tilgjengelig, sjekk derfor om
+    # fjorårets melding er levert og bekreft heller den.
+    if not tilgjengelig:
+        forrige, _ = _hent_skattemelding_status(token, orgnr, aar - 1)
+        if forrige.innfridd:
+            return forrige
+
+    return status
+
+
+def _hent_skattemelding_status(token: str, orgnr: str, aar: int) -> tuple[FristStatus, bool]:
+    """Hent skattemeldingstatus for ett konkret år.
+
+    Returnerer (status, tilgjengelig). `tilgjengelig=False` betyr at Skatteetaten
+    ikke har en skattemelding å vise for orgnr/år (HTTP 403/404) — da kan
+    kalleren trygt falle tilbake til fjoråret. Transiente feil (5xx, nettverk,
+    ugyldig svar) gir `tilgjengelig=True` slik at de ikke trigger fallback som
+    ville skjult den reelle feilen.
+    """
     base = _SKD_BASES["prod"]
 
     try:
@@ -123,26 +148,29 @@ def _utfør_skattemelding_sjekk(token: str, orgnr: str, aar: int) -> FristStatus
             timeout=30,
         )
     except httpx.HTTPError:
-        return FristStatus(beskrivelse="Kunne ikke kontakte Skatteetaten")
+        return FristStatus(beskrivelse="Kunne ikke kontakte Skatteetaten"), True
 
-    # 404 fra Skatteetaten betyr at ingen skattemelding er klargjort for orgnr/år
-    # ennå — det er normal status før forhåndsutfylt utkast publiseres.
-    if resp.status_code == 404:
+    # 404 betyr at ingen skattemelding er klargjort for orgnr/år ennå. 403 får vi
+    # når året ikke er åpnet for oppslag (typisk det kommende inntektsåret som
+    # ikke er avsluttet). Begge betyr i praksis "ingen melding å vise for {aar}":
+    # vis en forklarende status framfor en kryptisk HTTP-kode, og la kalleren
+    # falle tilbake til fjoråret.
+    if resp.status_code in (403, 404):
         return FristStatus(
             beskrivelse="Ikke klargjort ennå",
             brukertekst=(
                 f"Skatteetaten har ikke klargjort skattemelding for {aar} ennå. "
                 "Forhåndsutfylt utkast kommer normalt i mars/april."
             ),
-        )
+        ), False
 
     if not resp.is_success:
-        return FristStatus(beskrivelse=f"Skatteetaten svarte med HTTP {resp.status_code}")
+        return FristStatus(beskrivelse=f"Skatteetaten svarte med HTTP {resp.status_code}"), True
 
     try:
         root = ET.fromstring(resp.text)
     except ET.ParseError:
-        return FristStatus(beskrivelse="Ugyldig svar fra Skatteetaten")
+        return FristStatus(beskrivelse="Ugyldig svar fra Skatteetaten"), True
 
     # <type>-elementet i wrapper-XML-en angir dokumentstatus.
     # Sammenlign eksakt mot kjente "fastsatt"-typer fra XSDen — delstreng-match
@@ -155,12 +183,12 @@ def _utfør_skattemelding_sjekk(token: str, orgnr: str, aar: int) -> FristStatus
                 innfridd=True,
                 brukertekst=f"Skattemeldingen for {aar} er sendt inn og godkjent.",
                 lenke=f"https://af.altinn.no/?party=urn%3Aaltinn%3Aorganization%3Aidentifier-no%3A{orgnr}",
-            )
+            ), True
 
     return FristStatus(
         beskrivelse="Ikke innsendt",
         brukertekst=f"Skattemeldingen for {aar} er ikke innsendt ennå.",
-    )
+    ), True
 
 
 def sjekk_aarsregnskap(orgnr: str, aar: int) -> FristStatus:


### PR DESCRIPTION
## Bakgrunn

Dagen etter at skattemeldingsfristen passerte (31.05) viste statuskortet på Hjem-fanen «Skatteetaten svarte med HTTP 403» til en bruker som nettopp hadde levert. Årsaken: når fristen passerer, ruller `neste_frist` fram til neste års
frist, og statussjekken spør Skatteetaten om det kommende inntektsåret som ennå ikke er åpnet. Skatteetaten svarer 403, og catch-allen viste den rå HTTP-koden.

## Endringer

- Behandle 403 som 404 i `_hent_skattemelding_status` (begge betyr «ingen melding
  å vise for året») og vis forklarende status i stedet for rå HTTP-kode.
- Fall tilbake til å sjekke fjoråret når det forespurte året ikke er tilgjengelig:
  er fjoråret fastsatt, bekreftes den leveringen med grønt «Levert».
- Transiente feil (5xx, nettverk, ugyldig XML) trigger ikke fallback, så reelle
  feil skjules ikke.

## Test plan

- [x] 403 gir forklarende status, ikke «HTTP 403»
- [x] 403 på kommende år + fastsatt fjorår → viser fjorårets levering
- [x] 500 trigger ikke fallback (kun ett API-kall)
- [x] 404-test verifiserer at ingen «HTTP» lekker til bruker
- [x] Hele suiten grønn (302 passed)