### PR TITLE
feat(hosted): dokument-nedlasting + stegvis skall med tilkoblingsport

### DIFF
--- a/docs/avansert/utvikling.md
+++ b/docs/avansert/utvikling.md
@@ -21,7 +21,7 @@ hosted/
 
 Domenelaget i `wenche/` vet ingenting om grensesnittet. Det leser en config (fra fil eller dict), bygger XML og snakker med Altinn og Skatteetaten. Begge SPA-ene sender den samme config-strukturen som `config.yaml` til hvert sitt API.
 
-Frontend-koden er en npm-workspace (`package.json` i repo-roten). Det delte designsystemet i `packages/ui` (skjema, send-flyt, knapper, farger) konsumeres som kildekode av begge appene via et Vite-alias, så det finnes ingen separat byggesteg for pakken.
+Frontend-koden er en npm-workspace (`package.json` i repo-roten). Det delte designsystemet i `packages/ui` (skjema, send-flyt, dokument-nedlasting, noter, stegvis navigasjon, knapper, farger) konsumeres som kildekode av begge appene via et Vite-alias, så det finnes ingen separat byggesteg for pakken.
 
 ## Kjøre lokalt
 

--- a/docs/hostet.md
+++ b/docs/hostet.md
@@ -17,6 +17,11 @@ Den hostede tjenesten er for deg som heller vil slippe det tekniske oppsettet. D
 nøyaktig samme åpne kildekode under panseret, så du kan når som helst velge å kjøre
 self-hosted i stedet.
 
+Du følger en enkel stegvis flyt: koble selskapet til Altinn (én gang, med BankID), fylle inn
+tallene, eventuelt laste ned dokumentene (skattemelding, årsregnskap, aksjonæroppgave og noter)
+for gjennomgang, og så sende inn. Noter sendes ikke inn digitalt, men kan lastes ned for
+signering og arkivering hos selskapet.
+
 !!! note "For operatører"
     Drifts- og deploy-dokumentasjon (Docker, Fly.io, secrets) ligger i `hosted/README.md`
     i kodebasen, ikke her. Denne siden er kun ment for sluttbrukere.

--- a/hosted/api/dokumenter.py
+++ b/hosted/api/dokumenter.py
@@ -1,0 +1,99 @@
+"""
+Dokumentgenerering for forhåndsvisning/nedlasting i hostet Wenche.
+
+Genererer lokalt fra config-en i request-body (akkurat som innsending dry-run): ingen nettverk,
+ingenting lagres mellom kall. Krever kun gyldig invite (`krev_invitert`), ikke vendor/kunde-org,
+siden ingenting sendes inn. Notene sendes heller ikke inn, men kan lastes ned for signering og
+arkivering hos selskapet. Gjenbruker domene-genereringen, samme kode som self-hosted bruker.
+"""
+import base64
+from typing import Any
+
+from fastapi import APIRouter, Body, HTTPException, Request
+
+from wenche import aarsregnskap as ar
+from wenche import aksjonaerregister as akr
+from wenche import noter as noter_modul
+from wenche import skattemelding as sm
+from wenche.aksjonaerregister import generer_hovedskjema_xml, generer_underskjema_xml
+from wenche.brg_xml import generer_hovedskjema, generer_underskjema
+from wenche.models import LaanTilNaerstaaende, Noter
+
+from .deps import krev_invitert
+
+router = APIRouter(prefix="/api/dokumenter", tags=["dokumenter"])
+
+
+def _fil(filnavn: str, innhold: bytes, mime: str) -> dict:
+    return {"filnavn": filnavn, "mime": mime, "base64": base64.b64encode(innhold).decode("ascii")}
+
+
+def _bygg_noter(config: dict) -> Noter:
+    noter_cfg = config.get("noter") or {}
+    return Noter(
+        antall_ansatte=int(noter_cfg.get("antall_ansatte", 0)),
+        laan_til_naerstaaende=[
+            LaanTilNaerstaaende(
+                motpart=l.get("motpart", l.get("mottaker", "")),
+                saldo=float(l.get("saldo", l.get("beloep", 0))),
+                retning=l.get("retning", "långiver"),
+                rente_prosent=float(l.get("rente_prosent", 0.0)),
+                sikkerhet=l.get("sikkerhet", ""),
+            )
+            for l in noter_cfg.get("laan_til_naerstaaende", [])
+        ],
+    )
+
+
+@router.post("/skattemelding")
+def dok_skattemelding(request: Request, config: dict[str, Any] = Body(...)) -> dict:
+    krev_invitert(request)
+    regnskap, konfig = sm.les_config(config)
+    tekst = sm.generer(regnskap, konfig)
+    navn = f"skattemelding_{regnskap.regnskapsaar}_{regnskap.selskap.org_nummer}.txt"
+    return {"filer": [_fil(navn, tekst.encode("utf-8"), "text/plain; charset=utf-8")]}
+
+
+@router.post("/aarsregnskap")
+def dok_aarsregnskap(request: Request, config: dict[str, Any] = Body(...)) -> dict:
+    krev_invitert(request)
+    regnskap = ar.les_config(config)
+    feil = ar.valider(regnskap)
+    if feil:
+        raise HTTPException(status_code=422, detail={"feil": feil})
+    base = f"aarsregnskap_{regnskap.regnskapsaar}_{regnskap.selskap.org_nummer}"
+    return {
+        "filer": [
+            _fil(f"{base}_hovedskjema.xml", generer_hovedskjema(regnskap), "application/xml"),
+            _fil(f"{base}_underskjema.xml", generer_underskjema(regnskap), "application/xml"),
+        ]
+    }
+
+
+@router.post("/aksjonaer")
+def dok_aksjonaer(request: Request, config: dict[str, Any] = Body(...)) -> dict:
+    krev_invitert(request)
+    oppgave = akr.les_config(config)
+    feil = akr.valider(oppgave)
+    if feil:
+        raise HTTPException(status_code=422, detail={"feil": feil})
+    base = f"aksjonaerregister_{oppgave.regnskapsaar}_{oppgave.selskap.org_nummer}"
+    filer = [_fil(f"{base}_hovedskjema.xml", generer_hovedskjema_xml(oppgave), "application/xml")]
+    for i, aksjonaer in enumerate(oppgave.aksjonaerer, 1):
+        filer.append(
+            _fil(
+                f"{base}_underskjema_{i}.xml",
+                generer_underskjema_xml(aksjonaer, oppgave),
+                "application/xml",
+            )
+        )
+    return {"filer": filer}
+
+
+@router.post("/noter")
+def dok_noter(request: Request, config: dict[str, Any] = Body(...)) -> dict:
+    krev_invitert(request)
+    regnskap = ar.les_config(config)
+    tekst = noter_modul.generer(regnskap, _bygg_noter(config))
+    navn = f"noter_{regnskap.regnskapsaar}_{regnskap.selskap.org_nummer}.txt"
+    return {"filer": [_fil(navn, tekst.encode("utf-8"), "text/plain; charset=utf-8")]}

--- a/hosted/api/innsending.py
+++ b/hosted/api/innsending.py
@@ -17,6 +17,7 @@ data-org == godkjent systembruker-org (kunde_org), så vi aldri sender på vegne
 import logging
 from typing import Any
 
+import httpx
 from fastapi import APIRouter, Body, HTTPException, Request
 
 from wenche import auth as wauth
@@ -47,6 +48,46 @@ def _sjekk_org(cfg: dict, kunde_org: str) -> None:
         )
 
 
+def _tolk_http_feil(e: httpx.HTTPStatusError) -> HTTPException:
+    """Gjør en rå HTTP-feil fra Altinn/Skatteetaten om til en lesbar 502 (unngår 500 + stacktrace)."""
+    kode = e.response.status_code
+    if kode == 403:
+        melding = (
+            "Altinn avslo tilgangen (HTTP 403). Vanligste årsak: systembrukeren er ikke lenger "
+            "godkjent for selskapet, eller tjenesten mangler nødvendig rettighet."
+        )
+    elif kode == 401:
+        melding = "Altinn avviste tokenet (HTTP 401). Prøv igjen, eller koble systembrukeren på nytt."
+    elif kode >= 500:
+        melding = (
+            f"Altinn/Skatteetaten svarte med en serverfeil (HTTP {kode}). Dette er som regel "
+            "midlertidig hos myndighetene. Ingenting er sendt inn. Prøv igjen om litt."
+        )
+    else:
+        detalj = (e.response.text or "").strip()[:200]
+        melding = f"Altinn/Skatteetaten svarte med HTTP {kode}." + (f" {detalj}" if detalj else "")
+    return HTTPException(status_code=502, detail=melding)
+
+
+def _utfor(fn):
+    """
+    Kjør en innsending og gjør alle feil om til lesbare HTTP-svar, aldri en rå 500.
+
+    Domeneklientene melder feil på to måter: rå `httpx.HTTPStatusError` (Altinn) og
+    `RuntimeError` med ferdig melding (SKD-klienten). Valideringsfeil gir 422; alt annet 502.
+    """
+    try:
+        return fn()
+    except InnsendingValideringsfeil as e:
+        raise HTTPException(status_code=422, detail={"feil": e.feil})
+    except SkattemeldingValideringsfeil as e:  # subklasse av RuntimeError — fanges først
+        raise HTTPException(status_code=422, detail={"validering": str(e)})
+    except httpx.HTTPStatusError as e:
+        raise _tolk_http_feil(e)
+    except RuntimeError as e:
+        raise HTTPException(status_code=502, detail=str(e))
+
+
 @router.post("/innsending/aarsregnskap")
 def innsending_aarsregnskap(
     request: Request, config: dict[str, Any] = Body(...), dry_run: bool = False
@@ -59,11 +100,12 @@ def innsending_aarsregnskap(
     _sjekk_org(config, org)
     s = settings()
     altinn_token = wauth.hent_tokens_for(creds, org, SCOPES, veksle_altinn=True)["altinn_token"]
-    try:
+
+    def _send():
         with AltinnClient(altinn_token, env=s.env) as klient:
             return tjeneste.send_aarsregnskap(config, klient)
-    except InnsendingValideringsfeil as e:
-        raise HTTPException(status_code=422, detail={"feil": e.feil})
+
+    return _utfor(_send)
 
 
 @router.post("/innsending/aksjonaer")
@@ -78,8 +120,12 @@ def innsending_aksjonaer(
     _sjekk_org(config, org)
     s = settings()
     token = wauth.hent_tokens_for(creds, org, SKD_AKSJONAER_SCOPE)["maskinporten_token"]
-    with SkdAksjonaerClient(token, env=s.env) as klient:
-        return tjeneste.send_aksjonaer(config, klient)
+
+    def _send():
+        with SkdAksjonaerClient(token, env=s.env) as klient:
+            return tjeneste.send_aksjonaer(config, klient)
+
+    return _utfor(_send)
 
 
 @router.post("/innsending/skattemelding")
@@ -94,10 +140,9 @@ def innsending_skattemelding(
     _sjekk_org(config, org)
     s = settings()
     tokens = wauth.hent_tokens_for(creds, org, SKD_SKATTEMELDING_SCOPE, veksle_altinn=True)
-    try:
+
+    def _send():
         with SkdSkattemeldingClient(tokens["maskinporten_token"], env=s.env) as skd:
-            return tjeneste.send_skattemelding(
-                config, skd, tokens["altinn_token"], orgnr=org
-            )
-    except SkattemeldingValideringsfeil as e:
-        raise HTTPException(status_code=422, detail={"validering": str(e)})
+            return tjeneste.send_skattemelding(config, skd, tokens["altinn_token"], orgnr=org)
+
+    return _utfor(_send)

--- a/hosted/api/main.py
+++ b/hosted/api/main.py
@@ -19,6 +19,7 @@ from wenche import __version__ as WENCHE_VERSJON
 
 from .auth import router as auth_router
 from .config import settings
+from .dokumenter import router as dokumenter_router
 from .innsending import router as innsending_router
 from .systembruker import router as systembruker_router
 
@@ -46,6 +47,7 @@ app.add_middleware(
 app.include_router(auth_router)
 app.include_router(systembruker_router)
 app.include_router(innsending_router)
+app.include_router(dokumenter_router)
 
 
 @app.get("/api/health")

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -3,13 +3,21 @@ import { api } from "./api";
 import {
   DataSkjema,
   SendSeksjon,
-  SeksjonsNav,
+  Dokumenter,
+  NoterSeksjon,
+  noterFraConfig,
+  StegNav,
+  GaaVidere,
   Kort,
+  Panel,
   oppsummer,
+  harMinimumsdata,
   btnPrimar,
   btnOutline,
   monoLabel,
+  type Fane,
   type InnsendingFn,
+  type NoterData,
 } from "@wenche/ui";
 
 interface Me {
@@ -18,6 +26,17 @@ interface Me {
   kunde_org?: string | null;
   env?: string;
 }
+
+type FaneId = "hjem" | "tall" | "dokumenter" | "send";
+
+// Færre steg enn self-hosted: Maskinporten-oppsettet er gjort av operatøren, så brukeren har
+// bare Hjem (tilkoblingsstatus) + tre arbeidssteg.
+const FANER: Fane[] = [
+  { id: "hjem", navn: "Hjem" },
+  { id: "tall", navn: "Tall", steg: 1 },
+  { id: "dokumenter", navn: "Dokumenter", steg: 2 },
+  { id: "send", navn: "Send", steg: 3 },
+];
 
 // Lenke til vilkårene (publisert på markedssiden wenche-web).
 const VILKAAR_URL = "https://www.wenche.cloud/vilkaar";
@@ -40,25 +59,6 @@ const HOSTET_SAMTYKKE = (
   </span>
 );
 
-function Skall({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="min-h-screen">
-      <header className="sticky top-0 z-50 border-b border-border bg-background/85 backdrop-blur-sm">
-        <div className="mx-auto flex max-w-2xl items-center justify-between px-6 py-4">
-          <span className="font-display text-2xl font-medium tracking-tight">Wenche</span>
-          <a
-            href="https://www.wenche.cloud"
-            className="text-xs text-muted-foreground transition hover:text-spruce"
-          >
-            ← wenche.cloud
-          </a>
-        </div>
-      </header>
-      <main className="mx-auto max-w-2xl px-6 py-12">{children}</main>
-    </div>
-  );
-}
-
 function KunInviterte() {
   return (
     <Kort>
@@ -72,11 +72,12 @@ function KunInviterte() {
   );
 }
 
+// Koble systembruker (BankID i Altinn). Vises på Hjem når selskapet ikke er koblet ennå.
 function Onboarding({ org, onApproved }: { org?: string | null; onApproved: () => void }) {
   const [confirmUrl, setConfirmUrl] = useState<string | null>(null);
   const [feil, setFeil] = useState<string | null>(null);
   const [kobler, setKobler] = useState(false);
-  const [venter, setVenter] = useState(false); // venter på godkjenning i Altinn
+  const [venter, setVenter] = useState(false);
 
   const koble = async () => {
     setFeil(null);
@@ -84,9 +85,8 @@ function Onboarding({ org, onApproved }: { org?: string | null; onApproved: () =
     setKobler(true);
     try {
       const r = await api.systembrukerRequest();
-      if (r.godkjent || r.status === "AlreadyApproved") {
-        onApproved();
-      } else {
+      if (r.godkjent || r.status === "AlreadyApproved") onApproved();
+      else {
         setConfirmUrl(r.confirm_url ?? null);
         setVenter(true);
       }
@@ -108,8 +108,8 @@ function Onboarding({ org, onApproved }: { org?: string | null; onApproved: () =
     }
   };
 
-  // Mens vi venter på godkjenning i Altinn: poll status, så UI-et går videre av seg selv
-  // når daglig leder/styreleder har godkjent (uten at brukeren må trykke noe).
+  // Poll status mens vi venter, så UI-et går videre av seg selv når daglig leder/styreleder
+  // har godkjent i Altinn.
   useEffect(() => {
     if (!venter) return;
     const id = setInterval(async () => {
@@ -124,13 +124,12 @@ function Onboarding({ org, onApproved }: { org?: string | null; onApproved: () =
       }
     }, 4000);
     return () => clearInterval(id);
-    // onApproved utelatt med vilje: den er funksjonelt stabil (frisker opp me).
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [venter]);
 
   return (
     <Kort>
-      <p className={monoLabel}>Steg 1 · Koble selskap</p>
+      <p className={monoLabel}>Tilkobling</p>
       <h2 className="mt-3 font-display text-2xl font-normal">Koble til selskapet ditt</h2>
       {org ? (
         <>
@@ -171,9 +170,7 @@ function Onboarding({ org, onApproved }: { org?: string | null; onApproved: () =
             <button className={btnOutline} onClick={sjekkNaa}>
               Jeg har godkjent, sjekk nå
             </button>
-            {venter && (
-              <span className="text-xs text-muted-foreground">Venter på godkjenning…</span>
-            )}
+            {venter && <span className="text-xs text-muted-foreground">Venter på godkjenning…</span>}
           </div>
         </div>
       )}
@@ -182,19 +179,144 @@ function Onboarding({ org, onApproved }: { org?: string | null; onApproved: () =
   );
 }
 
-function Innsending({ env }: { env?: string }) {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [config, setConfig] = useState<any | null>(null);
+// Hjem: tilkoblingsstatus. Koblet → bekreftelse + «sjekk tilkobling». Ikke koblet → onboarding.
+function HjemFane({ me, onChange }: { me: Me; onChange: () => void }) {
+  const [sjekker, setSjekker] = useState(false);
+  const [melding, setMelding] = useState<string | null>(null);
 
-  // Klienten er fasit: vi holder config lokalt og sender den med innsendings-requesten.
-  // Ingenting lagres server-side mellom kall (bedre personvern + tåler at serveren sover).
-  const lagre = async (c: unknown) => {
-    setConfig(c);
+  // Bekreft at en godkjent systembruker fortsatt finnes for selskapet. Bruker `request`
+  // (ikke `status`): en allerede godkjent kunde har ingen ventende forespørsel, så `status`
+  // ville svart «ingen aktiv forespørsel» selv om tilkoblingen er aktiv. `request` sjekker
+  // eksisterende systembrukere og returnerer «AlreadyApproved» uten å lage en ny forespørsel.
+  const sjekk = async () => {
+    setSjekker(true);
+    setMelding(null);
+    try {
+      const r = await api.systembrukerRequest();
+      if (r.godkjent || r.status === "AlreadyApproved") {
+        setMelding("✓ Tilkoblingen er aktiv.");
+      } else {
+        setMelding("Tilkoblingen er ikke lenger aktiv. Last siden på nytt for å koble på nytt.");
+      }
+    } catch (e) {
+      setMelding((e as Error).message);
+    } finally {
+      setSjekker(false);
+    }
   };
 
-  // Innsending med selvhelende systembruker-binding: en 409 betyr at bindingen gikk tapt
-  // (serveren sov/restartet). Den reises FØR noen innsending skjer, så det er trygt å
-  // rebinde (AlreadyApproved, ingen BankID) og prøve én gang til — ingen dobbeltinnsending.
+  if (!me.kunde_org) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h2 className="font-display text-2xl font-normal">Velkommen</h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Koble selskapet ditt til Altinn for å komme i gang. Maskinporten-oppsettet er
+            allerede gjort for deg.
+          </p>
+        </div>
+        <Onboarding org={me.invite_org} onApproved={onChange} />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="font-display text-2xl font-normal">Hjem</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Fyll inn tallene under «Tall», se over dokumentene, og send inn under «Send».
+        </p>
+      </div>
+      <Kort accent>
+        <p className={monoLabel}>Tilkobling</p>
+        <p className="mt-2 font-display text-lg text-spruce">
+          ✓ Selskapet ditt (org {me.kunde_org}) er koblet til Altinn
+        </p>
+        <p className="mt-2 text-sm text-muted-foreground">
+          Wenche kan sende inn på vegne av selskapet. Du kan når som helst kontrollere at
+          tilkoblingen fortsatt er aktiv.
+        </p>
+        <div className="mt-4 flex flex-wrap items-center gap-4">
+          <button
+            className="font-mono text-[11px] uppercase tracking-[0.15em] text-spruce underline-offset-2 hover:underline disabled:opacity-40"
+            onClick={sjekk}
+            disabled={sjekker}
+          >
+            {sjekker ? "Sjekker…" : "Sjekk tilkobling"}
+          </button>
+          {melding && <span className="text-sm text-muted-foreground">{melding}</span>}
+        </div>
+      </Kort>
+    </div>
+  );
+}
+
+// Tall: skjema + noter. Klienten er fasit (ingen disk); lagring setter App-config-en.
+function TallFane({
+  config,
+  env,
+  org,
+  onLagret,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  config: any;
+  env?: string;
+  org?: string | null;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  onLagret: (c: any) => void;
+}) {
+  const [noter, setNoter] = useState<NoterData>(() => noterFraConfig(config));
+  const [lagret, setLagret] = useState(false);
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const lagre = async (formConfig: any) => {
+    onLagret({ ...formConfig, noter });
+    setLagret(true);
+  };
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="font-display text-2xl font-normal">Tall</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Fyll inn selskapsopplysninger, regnskap, balanse, skattemelding og aksjonærer. Trykk
+          «Lagre data», så kan du se over dokumentene og sende inn.
+        </p>
+      </div>
+      <Kort>
+        <DataSkjema
+          onLagre={lagre}
+          visEksempel={env === "test"}
+          initial={config ?? undefined}
+          laastOrg={org ?? undefined}
+          ekstraSeksjon={<NoterSeksjon noter={noter} setNoter={setNoter} />}
+        />
+      </Kort>
+      {lagret && <p className="text-sm text-spruce">✓ Lagret. Gå videre til «Dokumenter» eller «Send».</p>}
+    </div>
+  );
+}
+
+// Send: dry-run + bekreft + ekte innsending, med selvhelende 409-rebind.
+function SendFane({ config, me }: { config: any; me: Me }) {
+  if (!me.kunde_org) {
+    return (
+      <Panel tone="advarsel" tittel="Ikke koblet ennå">
+        Koble selskapet ditt til Altinn på «Hjem» før du sender inn.
+      </Panel>
+    );
+  }
+  if (!config) {
+    return (
+      <Panel tone="advarsel" tittel="Ingen data ennå">
+        Fyll inn og lagre tallene under «Tall» før du sender inn.
+      </Panel>
+    );
+  }
+
+  // Selvhelende systembruker-binding: en 409 betyr at bindingen gikk tapt (serveren sov/
+  // restartet). Den reises FØR innsending, så det er trygt å rebinde og prøve én gang til.
   const innsending: InnsendingFn = async (type, dryRun, cfg) => {
     try {
       return await api.innsending(type, dryRun, cfg);
@@ -207,56 +329,28 @@ function Innsending({ env }: { env?: string }) {
     }
   };
 
-  const o = config ? oppsummer(config) : null;
-
+  const o = oppsummer(config);
   return (
     <div className="space-y-6">
-      <SeksjonsNav
-        lenker={[
-          ["#selskap", "Selskap"],
-          ["#resultatregnskap", "Regnskap"],
-          ["#skattemelding", "Skattemelding"],
-          ["#aksjonaerer", "Aksjonærer"],
-          ...(o ? ([["#send", "Send"]] as [string, string][]) : []),
-        ]}
-      />
-      <Kort>
-        <DataSkjema onLagre={lagre} visEksempel={env === "test"} />
-      </Kort>
-      {o && (
-        <SendSeksjon
-          config={config}
-          innsending={innsending}
-          env={env}
-          org={o.org}
-          samtykke={HOSTET_SAMTYKKE}
-        />
-      )}
-    </div>
-  );
-}
-
-function Hjem({ me, onChange }: { me: Me; onChange: () => void }) {
-  return (
-    <div className="space-y-6">
-      <div className="flex items-center justify-between">
-        <span className={monoLabel}>
-          Innlogget{me.kunde_org ? ` · org ${me.kunde_org}` : ""}
-        </span>
-        <button
-          className="text-sm text-muted-foreground underline-offset-2 hover:text-spruce hover:underline"
-          onClick={() => api.logout().then(onChange)}
-        >
-          Logg ut
-        </button>
+      <div>
+        <h2 className="font-display text-2xl font-normal">Send inn</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Wenche kontrollerer tallene og viser en oppsummering før noe sendes til myndighetene.
+        </p>
       </div>
-      {me.kunde_org ? <Innsending env={me.env} /> : <Onboarding org={me.invite_org} onApproved={onChange} />}
+      <SendSeksjon
+        config={config}
+        innsending={innsending}
+        env={me.env}
+        org={o.org}
+        samtykke={HOSTET_SAMTYKKE}
+      />
     </div>
   );
 }
 
-// Manuell Umami-pageview (auto-track er av i index.html). Kalles FØRST etter at
-// invite-tokenet er fjernet fra URL-en, så tokenet aldri sendes til analytics.
+// Manuell Umami-pageview (auto-track er av i index.html). Kalles FØRST etter at invite-tokenet
+// er fjernet fra URL-en, så tokenet aldri sendes til analytics.
 function sporVisning() {
   const w = window as Window & { umami?: { track?: () => void } };
   const kjor = () => w.umami?.track?.();
@@ -266,9 +360,11 @@ function sporVisning() {
 
 export default function App() {
   const [me, setMe] = useState<Me | null>(null);
+  const [fane, setFane] = useState<FaneId>("hjem");
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [config, setConfig] = useState<any | null>(null);
 
-  const refresh = () =>
-    api.me().then(setMe).catch(() => setMe({ invited: false }));
+  const refresh = () => api.me().then(setMe).catch(() => setMe({ invited: false }));
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
@@ -289,9 +385,8 @@ export default function App() {
   }, []);
 
   // Keep-alive-heartbeat: holder Fly-maskinen våken mens appen er i AKTIV bruk, så scale-to-zero
-  // ikke sovner midt i en økt. Pinger KUN når fanen er synlig OG brukeren har vært aktiv siste
-  // 10 min, så en glemt åpen fane lar maskinen sove (ingen løpsk kostnad). Trygt å la den sove
-  // takket være at klienten er fasit + selvhelende binding.
+  // ikke sovner midt i en økt. Pinger kun når fanen er synlig og brukeren har vært aktiv siste
+  // 10 min, så en glemt åpen fane lar maskinen sove.
   useEffect(() => {
     let sisteAktivitet = Date.now();
     const merkAktiv = () => {
@@ -310,15 +405,79 @@ export default function App() {
     };
   }, []);
 
+  const naviger = (id: string) => {
+    setFane(id as FaneId);
+    window.scrollTo({ top: 0 });
+  };
+
+  const invited = !!me?.invited;
+
   return (
-    <Skall>
-      {!me ? (
-        <p className="text-sm text-muted-foreground">Laster…</p>
-      ) : !me.invited ? (
-        <KunInviterte />
-      ) : (
-        <Hjem me={me} onChange={refresh} />
-      )}
-    </Skall>
+    <div className="min-h-screen">
+      <header className="sticky top-0 z-50 border-b border-border bg-background/85 backdrop-blur-sm">
+        <div className="mx-auto max-w-2xl px-6">
+          <div className="flex items-center justify-between py-4">
+            <div className="flex items-baseline gap-2">
+              <span className="font-display text-2xl font-medium tracking-tight">Wenche</span>
+              {me?.env === "test" && (
+                <span className="rounded-full bg-amber-100 px-2 py-0.5 font-mono text-[10px] uppercase tracking-[0.2em] text-amber-800">
+                  Test
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-4 text-xs">
+              {invited && (
+                <button
+                  className="text-muted-foreground transition hover:text-spruce"
+                  onClick={() => api.logout().then(refresh)}
+                >
+                  Logg ut
+                </button>
+              )}
+              <a
+                href="https://www.wenche.cloud"
+                className="text-muted-foreground transition hover:text-spruce"
+              >
+                ← wenche.cloud
+              </a>
+            </div>
+          </div>
+          {/* Steg-navet vises først når selskapet er koblet — før det er appen kun en
+              tilkoblingsskjerm, så man ikke kan ta i bruk løsningen uten systembruker. */}
+          {invited && me?.kunde_org && (
+            <nav className="pb-1">
+              <StegNav faner={FANER} aktiv={fane} onNaviger={naviger} />
+            </nav>
+          )}
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-2xl px-6 py-12">
+        {!me ? (
+          <p className="text-sm text-muted-foreground">Laster…</p>
+        ) : !me.invited ? (
+          <KunInviterte />
+        ) : !me.kunde_org ? (
+          // Port: før selskapet er koblet er dette den eneste skjermen (ingen steg).
+          <HjemFane me={me} onChange={refresh} />
+        ) : (
+          <>
+            {fane === "hjem" && <HjemFane me={me} onChange={refresh} />}
+            {fane === "tall" && (
+              <TallFane config={config} env={me.env} org={me.kunde_org} onLagret={setConfig} />
+            )}
+            {fane === "dokumenter" && <Dokumenter config={config} dokument={api.dokument} />}
+            {fane === "send" && <SendFane config={config} me={me} />}
+            <GaaVidere
+              faner={FANER}
+              aktiv={fane}
+              onNaviger={naviger}
+              disabled={fane === "tall" && !harMinimumsdata(config)}
+              disabledHint="Fyll inn selskapsnavn, daglig leder og styreleder, og trykk «Lagre data»."
+            />
+          </>
+        )}
+      </main>
+    </div>
   );
 }

--- a/hosted/web/src/api.ts
+++ b/hosted/web/src/api.ts
@@ -16,4 +16,7 @@ export const api = {
       method: "POST",
       body: JSON.stringify(config),
     }),
+  // Genererer dokumenter for nedlasting/gjennomgang (ingenting sendes inn).
+  dokument: (type: string, config: unknown) =>
+    req(`/api/dokumenter/${type}`, { method: "POST", body: JSON.stringify(config) }),
 };

--- a/packages/ui/src/dokumenter.tsx
+++ b/packages/ui/src/dokumenter.tsx
@@ -1,15 +1,33 @@
+// Delt dokument-nedlasting (hostet + self-hosted). Generer dokumentene for gjennomgang før
+// innsending; ingenting sendes inn her. Hver app injiserer sin `dokument`-binding.
 import { useState } from "react";
-import { Kort, Panel, monoLabel, btnOutlineLett } from "@wenche/ui";
-import { api, lastNed } from "./api";
+import { Kort, Panel } from "./komponenter";
+import { monoLabel, btnOutlineLett } from "./styles";
+import { lastNed, type NedlastFil } from "./nedlasting";
 
-const DOKUMENTER: { type: string; navn: string; beskrivelse: string }[] = [
+export type DokumentFn = (
+  type: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  config: any,
+) => Promise<{ filer: NedlastFil[] }>;
+
+const STANDARD_DOKUMENTER: { type: string; navn: string; beskrivelse: string }[] = [
   { type: "skattemelding", navn: "Skattemelding", beskrivelse: "Tekstsammendrag av skattemelding og næringsspesifikasjon." },
   { type: "aarsregnskap", navn: "Årsregnskap (XML)", beskrivelse: "Hoved- og underskjema slik de sendes til Brønnøysund." },
   { type: "aksjonaer", navn: "Aksjonærregister (XML)", beskrivelse: "RF-1086 hovedskjema + ett underskjema per aksjonær." },
-  { type: "noter", navn: "Noter", beskrivelse: "De obligatoriske notene til årsregnskapet (signeres av styret)." },
+  { type: "noter", navn: "Noter", beskrivelse: "De obligatoriske notene til årsregnskapet (signeres av styret, sendes ikke inn)." },
 ];
 
-export default function Dokumenter({ config }: { config: any }) {
+export function Dokumenter({
+  config,
+  dokument,
+  dokumenter = STANDARD_DOKUMENTER,
+}: {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  config: any;
+  dokument: DokumentFn;
+  dokumenter?: { type: string; navn: string; beskrivelse: string }[];
+}) {
   const [feil, setFeil] = useState<string | null>(null);
   const [laster, setLaster] = useState<string | null>(null);
 
@@ -17,7 +35,7 @@ export default function Dokumenter({ config }: { config: any }) {
     setFeil(null);
     setLaster(type);
     try {
-      const r = await api.dokument(type, config);
+      const r = await dokument(type, config);
       lastNed(r.filer);
     } catch (e) {
       setFeil((e as Error).message);
@@ -29,7 +47,7 @@ export default function Dokumenter({ config }: { config: any }) {
   if (!config) {
     return (
       <Panel tone="advarsel" tittel="Ingen data ennå">
-        Fyll inn og lagre tallene under «Tall» før du genererer dokumenter.
+        Fyll inn tallene under «Tall» før du genererer dokumenter.
       </Panel>
     );
   }
@@ -48,7 +66,7 @@ export default function Dokumenter({ config }: { config: any }) {
         </Panel>
       )}
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        {DOKUMENTER.map((d) => (
+        {dokumenter.map((d) => (
           <Kort key={d.type}>
             <p className={monoLabel}>Dokument</p>
             <h3 className="mt-2 font-display text-lg font-normal">{d.navn}</h3>

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -3,10 +3,18 @@ export * from "./styles";
 export * from "./komponenter";
 export { req } from "./api";
 export type { ApiFeil } from "./api";
-export { DataSkjema, kr, oppsummer } from "./skjema";
+export { DataSkjema, kr, oppsummer, harMinimumsdata } from "./skjema";
 export {
   SendSeksjon,
   Resultatpanel,
   SeksjonsNav,
 } from "./send";
 export type { Utfall, Validering, InnsendingFn } from "./send";
+export { lastNed } from "./nedlasting";
+export type { NedlastFil } from "./nedlasting";
+export { Dokumenter } from "./dokumenter";
+export type { DokumentFn } from "./dokumenter";
+export { NoterSeksjon, tomtLaan, noterFraConfig } from "./noter";
+export type { Laan, NoterData } from "./noter";
+export { StegNav, GaaVidere } from "./stegnav";
+export type { Fane } from "./stegnav";

--- a/packages/ui/src/nedlasting.ts
+++ b/packages/ui/src/nedlasting.ts
@@ -1,0 +1,23 @@
+// Last ned base64-kodede filer fra dokument-endepunktene (delt mellom hostet og self-hosted).
+
+export interface NedlastFil {
+  filnavn: string;
+  mime: string;
+  base64: string;
+}
+
+export function lastNed(filer: NedlastFil[]): void {
+  for (const f of filer) {
+    const bin = atob(f.base64);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    const url = URL.createObjectURL(new Blob([bytes], { type: f.mime }));
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = f.filnavn;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    URL.revokeObjectURL(url);
+  }
+}

--- a/packages/ui/src/noter.tsx
+++ b/packages/ui/src/noter.tsx
@@ -1,0 +1,104 @@
+// Delt noter-redigering (antall ansatte + lån til nærstående). Notene sendes ikke inn, men
+// brukes til å generere notedokumentet under «Dokumenter» og lagres i config under `noter`.
+// Rendres som en seksjon (ikke eget kort) slik at den passer sist i datainntastings-skjemaet.
+import { Inn } from "./komponenter";
+import { btnOutlineLett } from "./styles";
+
+export interface Laan {
+  motpart: string;
+  saldo: number;
+  retning: string;
+  rente_prosent: number;
+  sikkerhet: string;
+}
+export interface NoterData {
+  antall_ansatte: number;
+  laan_til_naerstaaende: Laan[];
+}
+
+export function tomtLaan(): Laan {
+  return { motpart: "", saldo: 0, retning: "långiver", rente_prosent: 0, sikkerhet: "" };
+}
+
+// Bygg NoterData fra en config-dict (tåler manglende/delvise felt).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function noterFraConfig(config: any): NoterData {
+  return {
+    antall_ansatte: config?.noter?.antall_ansatte ?? 0,
+    laan_til_naerstaaende: (config?.noter?.laan_til_naerstaaende ?? []).map((l: Partial<Laan>) => ({
+      ...tomtLaan(),
+      ...l,
+    })),
+  };
+}
+
+export function NoterSeksjon({
+  noter,
+  setNoter,
+}: {
+  noter: NoterData;
+  setNoter: (n: NoterData) => void;
+}) {
+  const settLaan = (i: number, felt: keyof Laan, val: string | number) =>
+    setNoter({
+      ...noter,
+      laan_til_naerstaaende: noter.laan_til_naerstaaende.map((l, j) =>
+        j === i ? { ...l, [felt]: val } : l,
+      ),
+    });
+  return (
+    <section className="border-t border-border pt-6">
+      <h3 className="mb-1 font-display text-xl font-normal">Obligatoriske noter</h3>
+      <p className="mb-4 text-sm text-muted-foreground">
+        Regnskapsloven krever noter til årsregnskapet. De sendes ikke inn digitalt, men kan
+        lastes ned under «Dokumenter», undertegnes av styret og oppbevares av selskapet.
+      </p>
+      <div className="max-w-xs">
+        <Inn
+          label="Antall ansatte i regnskapsåret"
+          type="number"
+          value={noter.antall_ansatte}
+          onChange={(v) => setNoter({ ...noter, antall_ansatte: Number(v) || 0 })}
+        />
+      </div>
+
+      <div className="mt-6 space-y-4">
+        {noter.laan_til_naerstaaende.map((l, i) => (
+          <div key={i} className="rounded-sm border border-border bg-background p-4">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+              <Inn label="Motpart (nærstående)" value={l.motpart} onChange={(v) => settLaan(i, "motpart", v)} />
+              <Inn label="Saldo per 31.12 (kr)" type="number" value={l.saldo} onChange={(v) => settLaan(i, "saldo", Number(v) || 0)} />
+              <label className="block">
+                <span className="mb-1 block text-xs text-muted-foreground">Retning</span>
+                <select
+                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none focus:border-spruce"
+                  value={l.retning}
+                  onChange={(e) => settLaan(i, "retning", e.target.value)}
+                >
+                  <option value="långiver">Selskapet har lånt ut til nærstående</option>
+                  <option value="låntaker">Nærstående har lånt til selskapet</option>
+                </select>
+              </label>
+              <Inn label="Rente (%)" type="number" value={l.rente_prosent} onChange={(v) => settLaan(i, "rente_prosent", Number(v) || 0)} />
+              <Inn label="Sikkerhet" value={l.sikkerhet} onChange={(v) => settLaan(i, "sikkerhet", v)} />
+            </div>
+            <button
+              className="mt-3 text-xs text-muted-foreground underline-offset-2 hover:text-red-700 hover:underline"
+              onClick={() =>
+                setNoter({ ...noter, laan_til_naerstaaende: noter.laan_til_naerstaaende.filter((_, j) => j !== i) })
+              }
+            >
+              Fjern lån
+            </button>
+          </div>
+        ))}
+      </div>
+      <button
+        className={`${btnOutlineLett} mt-4`}
+        onClick={() => setNoter({ ...noter, laan_til_naerstaaende: [...noter.laan_til_naerstaaende, tomtLaan()] })}
+      >
+        + Legg til lån til nærstående
+      </button>
+    </section>
+  );
+}

--- a/packages/ui/src/skjema.tsx
+++ b/packages/ui/src/skjema.tsx
@@ -225,21 +225,35 @@ export function oppsummer(config: any) {
   };
 }
 
+// Sann når de grunnleggende selskapsopplysningene er fylt inn. Brukes til å gate «Gå videre»
+// fra Tall-steget, så man ikke havner på en tom Dokumenter-/Send-side.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function harMinimumsdata(config: any): boolean {
+  if (!config) return false;
+  const s = config.selskap ?? {};
+  return ["navn", "org_nummer", "daglig_leder", "styreleder"].every(
+    (k) => String(s[k] ?? "").trim() !== "",
+  );
+}
+
 function Feltrutenett({
   felter,
   config,
   oppdater,
+  laasteFelter = [],
 }: {
   felter: Felt[];
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   config: any;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   oppdater: (key: string, val: any) => void;
+  laasteFelter?: string[];
 }) {
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-      {felter.map((f) =>
-        f.type === "checkbox" ? (
+      {felter.map((f) => {
+        const laast = laasteFelter.includes(f.key);
+        return f.type === "checkbox" ? (
           <label key={f.key} className="flex items-center gap-2 text-sm">
             <input
               type="checkbox"
@@ -256,16 +270,18 @@ function Feltrutenett({
               {f.help ? ` (${f.help})` : ""}
             </span>
             <input
-              className={input}
+              className={`${input} ${laast ? "cursor-not-allowed opacity-60" : ""}`}
               type={f.type === "number" ? "number" : "text"}
               value={hent(config, f.key) ?? ""}
+              disabled={laast}
+              title={laast ? "Låst til selskapet i invitasjonen" : undefined}
               onChange={(e) =>
                 oppdater(f.key, f.type === "number" ? Number(e.target.value) || 0 : e.target.value)
               }
             />
           </label>
-        ),
-      )}
+        );
+      })}
     </div>
   );
 }
@@ -275,6 +291,8 @@ export function DataSkjema({
   visEksempel = false,
   initial,
   lagreEtikett = "Lagre data",
+  ekstraSeksjon,
+  laastOrg,
 }: {
   onLagre: (config: unknown) => Promise<void>;
   visEksempel?: boolean;
@@ -282,9 +300,22 @@ export function DataSkjema({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   initial?: any;
   lagreEtikett?: string;
+  // Valgfri tilleggsseksjon (f.eks. noter) som vises sist, rett før «Lagre data», slik at
+  // den lagres sammen med resten av skjemaet i ett trykk.
+  ekstraSeksjon?: React.ReactNode;
+  // Hostet kjenner selskapet fra invitasjonen: org.nr forhåndsutfylles, låses i feltet, og
+  // tvinges tilbake ved import/eksempeldata (innsending krever at config-org == kunde-org).
+  laastOrg?: string;
 }) {
+  const laasteFelter = laastOrg ? ["selskap.org_nummer"] : [];
+  // Tving org til det låste selskapet (brukes ved start, Bodil-import og eksempeldata).
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const [config, setConfig] = useState<any>(() => initial ?? grunnConfig());
+  const medLaastOrg = (c: any): any =>
+    laastOrg ? { ...c, selskap: { ...(c?.selskap ?? {}), org_nummer: laastOrg } } : c;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const startConfig = (): any => medLaastOrg(initial ?? grunnConfig());
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const [config, setConfig] = useState<any>(startConfig);
   const [lagrer, setLagrer] = useState(false);
   const [visBodil, setVisBodil] = useState(false);
   const [importMelding, setImportMelding] = useState<string | null>(null);
@@ -294,7 +325,7 @@ export function DataSkjema({
   // Advar mot å forlate siden (logo-/tilbake-klikk, nettleser-tilbake, lukke fane) hvis
   // skjemaet har ulagret innhold, så en bruker ikke mister utfyllingen ved et uhell.
   // Baseline er startverdien (lastet config regnes ikke som «ulagret»).
-  const pristine = useRef(JSON.stringify(initial ?? grunnConfig()));
+  const pristine = useRef(JSON.stringify(startConfig()));
   const configRef = useRef(config);
   configRef.current = config;
   useEffect(() => {
@@ -346,7 +377,7 @@ export function DataSkjema({
         setImportMelding("Dette ser ikke ut som en Wenche/Bodil config.yaml.");
         return;
       }
-      setConfig(parsed);
+      setConfig(medLaastOrg(parsed));
       setVisBodil(false);
     } catch (e) {
       setImportMelding("Kunne ikke lese filen: " + (e as Error).message);
@@ -370,7 +401,7 @@ export function DataSkjema({
           {visEksempel && (
             <button
               className="text-xs text-muted-foreground underline-offset-2 hover:text-spruce hover:underline"
-              onClick={() => setConfig(structuredClone(EKSEMPEL))}
+              onClick={() => setConfig(medLaastOrg(structuredClone(EKSEMPEL)))}
             >
               Fyll inn eksempeldata (test)
             </button>
@@ -479,7 +510,7 @@ export function DataSkjema({
       {SEKSJONER.map((s) => (
         <section key={s.tittel} id={s.id} className="scroll-mt-32">
           <h3 className="mb-4 font-display text-xl font-normal">{s.tittel}</h3>
-          <Feltrutenett felter={s.felter} config={config} oppdater={oppdater} />
+          <Feltrutenett felter={s.felter} config={config} oppdater={oppdater} laasteFelter={laasteFelter} />
           {s.id === "balanse" && (
             <div className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-1 text-sm">
               <span className="text-muted-foreground">Sum eiendeler: {kr(sumEiendeler)}</span>
@@ -539,6 +570,8 @@ export function DataSkjema({
           + Legg til aksjonær
         </button>
       </section>
+
+      {ekstraSeksjon}
 
       <button className={btnPrimar} onClick={lagre} disabled={lagrer}>
         {lagrer ? "Lagrer…" : lagreEtikett}

--- a/packages/ui/src/stegnav.tsx
+++ b/packages/ui/src/stegnav.tsx
@@ -1,0 +1,90 @@
+// Delt stegvis navigasjon (hostet + self-hosted): nummererte faner med tydelig aktiv-tilstand,
+// og en «Gå videre»-knapp som leder til neste steg. Rent presentasjonelt; hver app eier sin
+// header og fane-liste.
+import { btnPrimar } from "./styles";
+
+export interface Fane {
+  id: string;
+  navn: string;
+  steg?: number; // nummer på arbeidssteg; utelatt for dashboard-faner (f.eks. Hjem)
+}
+
+export function StegNav({
+  faner,
+  aktiv,
+  onNaviger,
+}: {
+  faner: Fane[];
+  aktiv: string;
+  onNaviger: (id: string) => void;
+}) {
+  return (
+    <nav className="flex flex-wrap gap-x-5 gap-y-1">
+      {faner.map(({ id, navn, steg }) => {
+        const er = aktiv === id;
+        return (
+          <button
+            key={id}
+            onClick={() => onNaviger(id)}
+            aria-current={er ? "page" : undefined}
+            className={`group -mb-px flex items-center gap-2 border-b-2 pb-3 pt-1 transition ${
+              er ? "border-spruce" : "border-transparent"
+            }`}
+          >
+            {steg !== undefined && (
+              <span
+                className={`flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-medium transition ${
+                  er ? "bg-spruce text-background" : "bg-border text-muted-foreground group-hover:text-foreground"
+                }`}
+              >
+                {steg}
+              </span>
+            )}
+            <span
+              className={`font-mono text-[11px] uppercase tracking-[0.15em] transition ${
+                er ? "font-medium text-spruce" : "text-muted-foreground group-hover:text-foreground"
+              }`}
+            >
+              {navn}
+            </span>
+          </button>
+        );
+      })}
+    </nav>
+  );
+}
+
+// «Gå videre»-knapp som leder til neste fane, så tab-menyen ikke er eneste vei gjennom flyten.
+// Vises på alle faner unntatt den siste. På første fane står det «Kom i gang».
+export function GaaVidere({
+  faner,
+  aktiv,
+  onNaviger,
+  disabled = false,
+  disabledHint,
+}: {
+  faner: Fane[];
+  aktiv: string;
+  onNaviger: (id: string) => void;
+  disabled?: boolean;
+  disabledHint?: string;
+}) {
+  const idx = faner.findIndex((f) => f.id === aktiv);
+  const neste = faner[idx + 1];
+  if (!neste) return null;
+  return (
+    <div className="mt-12 flex flex-wrap items-center justify-end gap-x-4 gap-y-2 border-t border-border pt-6">
+      {disabled && disabledHint && (
+        <span className="text-xs text-muted-foreground">{disabledHint}</span>
+      )}
+      <button
+        className={btnPrimar}
+        disabled={disabled}
+        onClick={() => !disabled && onNaviger(neste.id)}
+      >
+        {idx === 0 ? "Kom i gang" : "Gå videre"}: {neste.steg ? `${neste.steg}. ` : ""}
+        {neste.navn} →
+      </button>
+    </div>
+  );
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.26.0"
+version = "0.27.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_hosted_dokumenter.py
+++ b/tests/test_hosted_dokumenter.py
@@ -1,0 +1,92 @@
+"""
+Dokument-endepunktene for hostet Wenche (HTTP-nivå).
+
+- Uten invite er dokumentgenerering stengt.
+- Med invite genereres alle fire dokumenttyper (skattemelding, årsregnskap, aksjonær, noter)
+  som base64-filer, rett fra config-en i request-body (ingen nettverk, ingenting lagres).
+- Ugyldig årsregnskap (balansen går ikke opp) gir 422 uten å generere.
+"""
+import base64
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hosted.api.auth import lag_invite_token
+
+_INVITE_SECRET = "test-invite-secret"
+
+
+@pytest.fixture
+def klient(monkeypatch):
+    monkeypatch.setenv("WENCHE_ENV", "test")
+    monkeypatch.setenv("HOSTED_SESSION_SECRET", "test-session-secret")
+    monkeypatch.setenv("HOSTED_INVITE_SECRET", _INVITE_SECRET)
+    from hosted.api import config
+
+    config.settings.cache_clear()
+    from hosted.api import main as main_mod
+
+    importlib.reload(main_mod)
+    with TestClient(main_mod.app) as klient:
+        yield klient
+    config.settings.cache_clear()
+
+
+def _gyldig_config(org="314273818"):
+    """Komplett, balansert årsregnskap-config (eiendeler = EK = 30000), med noter."""
+    return {
+        "selskap": {"navn": "Test AS", "org_nummer": org, "daglig_leder": "D L",
+                    "styreleder": "D L", "forretningsadresse": "Vei 1, 0001 OSLO",
+                    "stiftelsesaar": 2018, "aksjekapital": 30000, "kontakt_epost": "a@b.no"},
+        "regnskapsaar": 2024,
+        "resultatregnskap": {
+            "driftsinntekter": {"salgsinntekter": 0, "andre_driftsinntekter": 0},
+            "driftskostnader": {"loennskostnader": 0, "avskrivninger": 0, "andre_driftskostnader": 0},
+            "finansposter": {"utbytte_fra_datterselskap": 0, "andre_finansinntekter": 0,
+                             "rentekostnader": 0, "andre_finanskostnader": 0}},
+        "balanse": {
+            "eiendeler": {"anleggsmidler": {"aksjer_i_datterselskap": 0, "andre_aksjer": 0, "langsiktige_fordringer": 0},
+                          "omloepmidler": {"kortsiktige_fordringer": 0, "bankinnskudd": 30000}},
+            "egenkapital_og_gjeld": {
+                "egenkapital": {"aksjekapital": 30000, "overkursfond": 0, "annen_egenkapital": 0},
+                "langsiktig_gjeld": {"laan_fra_aksjonaer": 0, "andre_langsiktige_laan": 0},
+                "kortsiktig_gjeld": {"leverandoergjeld": 0, "skyldige_offentlige_avgifter": 0,
+                                     "annen_kortsiktig_gjeld": 0}}},
+        "skattemelding": {"anvend_fritaksmetoden": False, "boersnotert": False,
+                          "underskudd_til_fremfoering": 0, "formuesverdi_aksjer": 0},
+        "aksjonaerer": [{"navn": "X", "fodselsnummer": "24847799354", "antall_aksjer": 300,
+                         "aksjeklasse": "ordinære", "utbytte_utbetalt": 0,
+                         "innbetalt_kapital_per_aksje": 100}],
+        "noter": {"antall_ansatte": 0, "laan_til_naerstaaende": []},
+    }
+
+
+def _inviter(klient, org="314273818"):
+    klient.post("/api/auth/invite", json={"token": lag_invite_token(org)})
+
+
+def test_dokumenter_stengt_uten_invite(klient):
+    r = klient.post("/api/dokumenter/noter", json=_gyldig_config())
+    assert r.status_code == 401
+
+
+@pytest.mark.parametrize("type_", ["skattemelding", "aarsregnskap", "aksjonaer", "noter"])
+def test_dokumenter_genereres_med_invite(klient, type_):
+    _inviter(klient)
+    r = klient.post(f"/api/dokumenter/{type_}", json=_gyldig_config())
+    assert r.status_code == 200, r.text
+    filer = r.json()["filer"]
+    assert filer, "forventet minst én fil"
+    for f in filer:
+        assert f["filnavn"] and f["mime"]
+        base64.b64decode(f["base64"])  # gyldig base64
+
+
+def test_aarsregnskap_uten_balanse_gir_422(klient):
+    _inviter(klient)
+    cfg = _gyldig_config()
+    cfg["balanse"]["eiendeler"]["omloepmidler"]["bankinnskudd"] = 999  # balansen går ikke opp
+    r = klient.post("/api/dokumenter/aarsregnskap", json=cfg)
+    assert r.status_code == 422
+    assert "feil" in r.json()["detail"]

--- a/tests/test_hosted_innsending_feil.py
+++ b/tests/test_hosted_innsending_feil.py
@@ -1,0 +1,59 @@
+"""
+Feilhåndtering i hostet innsending: Altinn/SKD-feil skal aldri bli en rå 500 til brukeren.
+
+`_utfor` pakker innsendingen og gjør de tre feilklassene domeneklientene melder om til lesbare
+HTTP-svar: valideringsfeil → 422, rå httpx-feil (Altinn) og RuntimeError (SKD-klienten) → 502.
+"""
+import httpx
+import pytest
+from fastapi import HTTPException
+
+from hosted.api.innsending import _utfor
+from wenche.innsending import InnsendingValideringsfeil
+from wenche.skd_skattemelding_client import SkattemeldingValideringsfeil
+
+
+def _hev(exc):
+    def fn():
+        raise exc
+    return fn
+
+
+def test_altinn_serverfeil_blir_502_ikke_500():
+    req = httpx.Request("POST", "https://brg.apps.tt02.altinn.no/brg/x/instances")
+    feil = httpx.HTTPStatusError("500", request=req, response=httpx.Response(500, request=req))
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(feil))
+    assert ei.value.status_code == 502
+    assert "serverfeil" in str(ei.value.detail).lower()
+
+
+def test_altinn_403_blir_lesbar_502():
+    req = httpx.Request("POST", "https://brg.apps.tt02.altinn.no/brg/x/instances")
+    feil = httpx.HTTPStatusError("403", request=req, response=httpx.Response(403, request=req))
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(feil))
+    assert ei.value.status_code == 502
+
+
+def test_skd_runtimeerror_blir_502():
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(RuntimeError("Feil ved henting av forhåndsutfylt skattemelding: 403")))
+    assert ei.value.status_code == 502
+
+
+def test_aarsregnskap_valideringsfeil_blir_422():
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(InnsendingValideringsfeil(["Balansen går ikke opp"])))
+    assert ei.value.status_code == 422
+    assert ei.value.detail == {"feil": ["Balansen går ikke opp"]}
+
+
+def test_skattemelding_valideringsfeil_blir_422():
+    resultat = {"resultat": "validertMedFeil", "aarsak": "tekniskFeil",
+                "avvik_ved_validering": [{"avvikstype": "tekniskFeil"}],
+                "avvik_etter_beregning": [], "veiledning": []}
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(SkattemeldingValideringsfeil(resultat)))
+    assert ei.value.status_code == 422
+    assert "validering" in ei.value.detail

--- a/wenche/web/frontend/src/App.tsx
+++ b/wenche/web/frontend/src/App.tsx
@@ -1,17 +1,16 @@
 import { useEffect, useState } from "react";
-import { btnPrimar } from "@wenche/ui";
+import { StegNav, GaaVidere, Dokumenter, harMinimumsdata, type Fane } from "@wenche/ui";
 import { api } from "./api";
 import Hjem from "./Hjem";
 import Oppsett from "./Oppsett";
 import Tall from "./Tall";
-import Dokumenter from "./Dokumenter";
 import Send from "./Send";
 
-type Fane = "hjem" | "oppsett" | "tall" | "dokumenter" | "send";
+type FaneId = "hjem" | "oppsett" | "tall" | "dokumenter" | "send";
 
-// Hjem er dashboardet (oversikt/frister); de fire arbeidsstegene nummereres 1–4 for å vise
+// Hjem er dashboardet (oversikt/frister); de fire arbeidsstegene nummereres 1-4 for å vise
 // at de gjennomgås i sekvens.
-const FANER: { id: Fane; navn: string; steg?: number }[] = [
+const FANER: Fane[] = [
   { id: "hjem", navn: "Hjem" },
   { id: "oppsett", navn: "Oppsett", steg: 1 },
   { id: "tall", navn: "Tall", steg: 2 },
@@ -39,7 +38,7 @@ function Oppdateringsbanner({ info }: { info: UpdateInfo }) {
 export default function App() {
   const [env, setEnv] = useState<string>("prod");
   const [versjon, setVersjon] = useState<string>("");
-  const [fane, setFane] = useState<Fane>("hjem");
+  const [fane, setFane] = useState<FaneId>("hjem");
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [config, setConfig] = useState<any | null>(null);
   const [oppdatering, setOppdatering] = useState<UpdateInfo | null>(null);
@@ -54,8 +53,8 @@ export default function App() {
   }, []);
 
   // Bytt fane og rull til toppen, så brukeren alltid starter øverst i det nye steget.
-  const naviger = (f: Fane) => {
-    setFane(f);
+  const naviger = (id: string) => {
+    setFane(id as FaneId);
     window.scrollTo({ top: 0 });
   };
 
@@ -75,38 +74,7 @@ export default function App() {
             </div>
             {versjon && <span className="font-mono text-[11px] text-muted-foreground">v{versjon}</span>}
           </div>
-          <nav className="flex flex-wrap gap-x-5 gap-y-1">
-            {FANER.map(({ id, navn, steg }) => {
-              const aktiv = fane === id;
-              return (
-                <button
-                  key={id}
-                  onClick={() => naviger(id)}
-                  aria-current={aktiv ? "page" : undefined}
-                  className={`group -mb-px flex items-center gap-2 border-b-2 pb-3 pt-1 transition ${
-                    aktiv ? "border-spruce" : "border-transparent"
-                  }`}
-                >
-                  {steg !== undefined && (
-                    <span
-                      className={`flex h-4 w-4 items-center justify-center rounded-full text-[9px] font-medium transition ${
-                        aktiv ? "bg-spruce text-background" : "bg-border text-muted-foreground group-hover:text-foreground"
-                      }`}
-                    >
-                      {steg}
-                    </span>
-                  )}
-                  <span
-                    className={`font-mono text-[11px] uppercase tracking-[0.15em] transition ${
-                      aktiv ? "font-medium text-spruce" : "text-muted-foreground group-hover:text-foreground"
-                    }`}
-                  >
-                    {navn}
-                  </span>
-                </button>
-              );
-            })}
-          </nav>
+          <StegNav faner={FANER} aktiv={fane} onNaviger={naviger} />
         </div>
       </header>
 
@@ -114,27 +82,17 @@ export default function App() {
         {fane === "hjem" && <Hjem />}
         {fane === "oppsett" && <Oppsett env={env} />}
         {fane === "tall" && <Tall config={config} env={env} onLagret={setConfig} />}
-        {fane === "dokumenter" && <Dokumenter config={config} />}
+        {fane === "dokumenter" && <Dokumenter config={config} dokument={api.dokument} />}
         {fane === "send" && <Send config={config} env={env} />}
 
-        <GaaVidere fane={fane} naviger={naviger} />
+        <GaaVidere
+          faner={FANER}
+          aktiv={fane}
+          onNaviger={naviger}
+          disabled={fane === "tall" && !harMinimumsdata(config)}
+          disabledHint="Fyll inn selskapsnavn, org.nr., daglig leder og styreleder, og trykk «Lagre data»."
+        />
       </main>
-    </div>
-  );
-}
-
-// «Gå videre»-knapp som tar brukeren til neste steg, så tab-menyen ikke er eneste vei
-// gjennom flyten. Vises på alle faner unntatt den siste (Send er sluttsteget).
-function GaaVidere({ fane, naviger }: { fane: Fane; naviger: (f: Fane) => void }) {
-  const idx = FANER.findIndex((f) => f.id === fane);
-  const neste = FANER[idx + 1];
-  if (!neste) return null;
-  return (
-    <div className="mt-12 flex justify-end border-t border-border pt-6">
-      <button className={btnPrimar} onClick={() => naviger(neste.id)}>
-        {fane === "hjem" ? "Kom i gang" : "Gå videre"}: {neste.steg ? `${neste.steg}. ` : ""}
-        {neste.navn} →
-      </button>
     </div>
   );
 }

--- a/wenche/web/frontend/src/Tall.tsx
+++ b/wenche/web/frontend/src/Tall.tsx
@@ -1,90 +1,6 @@
 import { useState } from "react";
-import { DataSkjema, Kort, Inn, monoLabel, btnOutlineLett } from "@wenche/ui";
+import { DataSkjema, Kort, NoterSeksjon, noterFraConfig, type NoterData } from "@wenche/ui";
 import { api } from "./api";
-
-interface Laan {
-  motpart: string;
-  saldo: number;
-  retning: string;
-  rente_prosent: number;
-  sikkerhet: string;
-}
-interface NoterData {
-  antall_ansatte: number;
-  laan_til_naerstaaende: Laan[];
-}
-
-function tomtLaan(): Laan {
-  return { motpart: "", saldo: 0, retning: "långiver", rente_prosent: 0, sikkerhet: "" };
-}
-
-// Noter-redigering (antall ansatte + lån til nærstående). Sendes ikke inn, men brukes til å
-// generere notedokumentet under «Dokumenter» og lagres i config under `noter`.
-function NoterSeksjon({ noter, setNoter }: { noter: NoterData; setNoter: (n: NoterData) => void }) {
-  const settLaan = (i: number, felt: keyof Laan, val: string | number) =>
-    setNoter({
-      ...noter,
-      laan_til_naerstaaende: noter.laan_til_naerstaaende.map((l, j) =>
-        j === i ? { ...l, [felt]: val } : l,
-      ),
-    });
-  return (
-    <Kort>
-      <p className={monoLabel}>Noter</p>
-      <h3 className="mt-2 font-display text-xl font-normal">Obligatoriske noter</h3>
-      <p className="mt-2 text-sm text-muted-foreground">
-        Regnskapsloven krever noter til årsregnskapet. De sendes ikke inn digitalt, men kan
-        lastes ned under «Dokumenter», undertegnes av styret og oppbevares av selskapet.
-      </p>
-      <div className="mt-4 max-w-xs">
-        <Inn
-          label="Antall ansatte i regnskapsåret"
-          type="number"
-          value={noter.antall_ansatte}
-          onChange={(v) => setNoter({ ...noter, antall_ansatte: Number(v) || 0 })}
-        />
-      </div>
-
-      <div className="mt-6 space-y-4">
-        {noter.laan_til_naerstaaende.map((l, i) => (
-          <div key={i} className="rounded-sm border border-border bg-background p-4">
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              <Inn label="Motpart (nærstående)" value={l.motpart} onChange={(v) => settLaan(i, "motpart", v)} />
-              <Inn label="Saldo per 31.12 (kr)" type="number" value={l.saldo} onChange={(v) => settLaan(i, "saldo", Number(v) || 0)} />
-              <label className="block">
-                <span className="mb-1 block text-xs text-muted-foreground">Retning</span>
-                <select
-                  className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm outline-none focus:border-spruce"
-                  value={l.retning}
-                  onChange={(e) => settLaan(i, "retning", e.target.value)}
-                >
-                  <option value="långiver">Selskapet har lånt ut til nærstående</option>
-                  <option value="låntaker">Nærstående har lånt til selskapet</option>
-                </select>
-              </label>
-              <Inn label="Rente (%)" type="number" value={l.rente_prosent} onChange={(v) => settLaan(i, "rente_prosent", Number(v) || 0)} />
-              <Inn label="Sikkerhet" value={l.sikkerhet} onChange={(v) => settLaan(i, "sikkerhet", v)} />
-            </div>
-            <button
-              className="mt-3 text-xs text-muted-foreground underline-offset-2 hover:text-red-700 hover:underline"
-              onClick={() =>
-                setNoter({ ...noter, laan_til_naerstaaende: noter.laan_til_naerstaaende.filter((_, j) => j !== i) })
-              }
-            >
-              Fjern lån
-            </button>
-          </div>
-        ))}
-      </div>
-      <button
-        className={`${btnOutlineLett} mt-4`}
-        onClick={() => setNoter({ ...noter, laan_til_naerstaaende: [...noter.laan_til_naerstaaende, tomtLaan()] })}
-      >
-        + Legg til lån til nærstående
-      </button>
-    </Kort>
-  );
-}
 
 export default function Tall({
   config,
@@ -97,13 +13,7 @@ export default function Tall({
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onLagret: (c: any) => void;
 }) {
-  const [noter, setNoter] = useState<NoterData>(() => ({
-    antall_ansatte: config?.noter?.antall_ansatte ?? 0,
-    laan_til_naerstaaende: (config?.noter?.laan_til_naerstaaende ?? []).map((l: Partial<Laan>) => ({
-      ...tomtLaan(),
-      ...l,
-    })),
-  }));
+  const [noter, setNoter] = useState<NoterData>(() => noterFraConfig(config));
   const [kvittering, setKvittering] = useState<string | null>(null);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -124,10 +34,13 @@ export default function Tall({
         </p>
       </div>
 
-      <NoterSeksjon noter={noter} setNoter={setNoter} />
-
       <Kort>
-        <DataSkjema onLagre={lagre} visEksempel={env === "test"} initial={config ?? undefined} />
+        <DataSkjema
+          onLagre={lagre}
+          visEksempel={env === "test"}
+          initial={config ?? undefined}
+          ekstraSeksjon={<NoterSeksjon noter={noter} setNoter={setNoter} />}
+        />
       </Kort>
 
       {kvittering && <p className="text-sm text-spruce">✓ {kvittering}</p>}

--- a/wenche/web/frontend/src/api.ts
+++ b/wenche/web/frontend/src/api.ts
@@ -32,20 +32,3 @@ export const api = {
       body: JSON.stringify(config),
     }),
 };
-
-// Last ned base64-kodede filer fra dokument-endepunktene.
-export function lastNed(filer: { filnavn: string; mime: string; base64: string }[]): void {
-  for (const f of filer) {
-    const bin = atob(f.base64);
-    const bytes = new Uint8Array(bin.length);
-    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-    const url = URL.createObjectURL(new Blob([bytes], { type: f.mime }));
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = f.filnavn;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
-  }
-}


### PR DESCRIPTION
## Bakgrunn

Den hostede tjenesten var en enkelt lang side. Denne PR-en løfter self-hosted-funksjoner (dokument-nedlasting, stegvis flyt) over til hosted, tilpasset hosted-modellen der operatøren eier Maskinporten og brukeren ikke konfigurerer noe selv.

## Endringer

- **Delt designsystem**: `Dokumenter`, `NoterSeksjon`, `StegNav`/`GaaVidere` og `lastNed` flyttet
  til `packages/ui`, så hosted og self-hosted bruker samme kode (self-hosted dedupet).
- **Hosted dokument-nedlasting**: nytt endepunkt for skattemelding, årsregnskap, aksjonær og
  noter. Genereres fra config i request-body, ingenting lagres, krever kun gyldig invite.
- **Hosted stegvis skall**: Hjem (tilkoblingsstatus + «sjekk tilkobling») + `1 Tall · 2 Dokumenter
  · 3 Send`. Tilkobling er en port — ingen steg vises før systembruker er koblet.
- **UX**: org.nr forhåndsutfylles og låses fra invitasjonen (hindrer 409-mismatch); «Gå videre»
  gates på lagrede minimumsdata; noter flyttet nederst i Tall.
- **Prod-fiks**: lesbar feilhåndtering i hosted innsending — Altinn/SKD-feil gir 422/502 med
  forklaring i stedet for rå 500 + stacktrace.
- Versjon bumpet til **0.27.0**.

## Test plan

- [x] `pytest` grønt (319, +11 nye: hosted dokument-endepunkter + feilhåndtering)
- [x] Begge SPA-er bygger (tsc + vite); self-hosted CSS uendret
- [x] Hosted dev mot tt02: Hjem-port → 1 Tall (org låst, noter nederst) → 2 Dokumenter (lastet ned alle fire) → 3 Send (faktisk innsending OK)
- [x] Self-hosted regresjon: Tall/Dokumenter/Send uendret etter dedupe
- [x] CI: `Tester` + `Docker-bygg` grønne på PR-en
