### PR TITLE
feat(hosted): demo-miljø mot tt02 (demo.wenche.cloud)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Fullstendig veiledning for installasjon, oppsett og bruk:
 
 ## For utviklere
 
-Wenche kan kjøres mot Skatteetatens testmiljø (tt02) for å tørrtrene innsending uten å sende ekte data til myndighetene:
+Wenche kan kjøres mot Altinns testmiljø (tt02) for å tørrtrene innsending uten å sende ekte data til myndighetene:
 
 ```bash
 wenche dev

--- a/docs/avansert/testing.md
+++ b/docs/avansert/testing.md
@@ -3,7 +3,7 @@
 !!! info "For utviklere og bidragsytere"
     Denne siden er for de som vil utvikle på Wenche eller tørrtrene innsending uten å sende ekte data til myndighetene. Vanlig bruk dekkes av webgrensesnittet, se [Bruk](../bruk.md).
 
-Wenche kan kjøres mot Skatteetatens testmiljø (tt02) i stedet for produksjon. Testmiljøet er et separat økosystem:
+Wenche kan kjøres mot Altinns testmiljø (tt02) i stedet for produksjon. Testmiljøet er et separat økosystem:
 
 - Egne Maskinporten-klienter i Digdirs test-portal
 - Egen systembruker i Altinn tt02
@@ -18,7 +18,7 @@ Wenche kan kjøres mot Skatteetatens testmiljø (tt02) i stedet for produksjon. 
 wenche dev
 ```
 
-UI starter på `http://localhost:8080` med en diskret `TEST`-tag i headeren. Alle innsendinger går til Skatteetatens tt02-API, ingen ekte innsending til myndighetene.
+UI starter på `http://localhost:8080` med en diskret `TEST`-tag i headeren. Alle innsendinger går til testmiljøet (Altinn tt02 og Skatteetatens test-API), ingen ekte innsending til myndighetene.
 
 `wenche` (uten args) starter alltid mot produksjon. `wenche dev` starter alltid mot test. De to modusene er låst og kan ikke veksles mellom uten å starte UI på nytt.
 

--- a/fly.demo.toml
+++ b/fly.demo.toml
@@ -1,0 +1,41 @@
+# Fly.io-konfig for DEMO-utgaven av hostet Wenche (mot Skatteetatens testmiljø tt02).
+# Helt separat fra prod-appen (app.wenche.cloud / fly.toml): egne test-vendor-creds og
+# WENCHE_ENV=test, så en demo aldri kan røre ekte Altinn. Samme image/Dockerfile som prod.
+#
+# Deploy: `flyctl deploy -c fly.demo.toml`. Hemmeligheter settes med
+# `flyctl secrets set -a wenche-demo ...`, ALDRI her (denne fila er åpen kildekode).
+
+app = "wenche-demo"
+primary_region = "arn"         # Stockholm, EØS (samme som prod).
+
+[build]
+  dockerfile = "Dockerfile"
+
+[env]
+  # TEST: peker mot tt02. Bruker test-vendor-creds (satt som secrets på wenche-demo).
+  WENCHE_ENV = "test"
+  # App-URL brukt i invite-lenkene (demo-lenken bak «Demo»-knappen på wenche-web).
+  HOSTED_PUBLIC_URL = "https://demo.wenche.cloud"
+  # Viser «dette er en demo mot tt02»-banner i SPA-en. Rent informativt.
+  HOSTED_DEMO_MODE = "1"
+
+[http_service]
+  internal_port = 8080
+  force_https = true
+  # Scale-to-zero for minimal kostnad: maskinen sovner når ingen bruker den, og våkner
+  # automatisk på første request. SPA-ens keep-alive-heartbeat hindrer dvale midt i en økt.
+  # Kun én maskin (in-memory-sesjon må ikke spres mellom maskiner).
+  auto_stop_machines = "stop"
+  auto_start_machines = true
+  min_machines_running = 0
+
+  [[http_service.checks]]
+    method = "get"
+    path = "/api/health"
+    interval = "15s"
+    timeout = "3s"
+    grace_period = "10s"
+
+[[vm]]
+  size = "shared-cpu-1x"
+  memory = "256mb"

--- a/hosted/README.md
+++ b/hosted/README.md
@@ -106,7 +106,7 @@ Roter `HOSTED_INVITE_SECRET` for å ugyldiggjøre alle utdelte lenker på én ga
 
 ## Demo-miljø (demo.wenche.cloud, mot tt02)
 
-En **helt separat** Fly-app som lar hvem som helst prøve tjenesten mot Skatteetatens testmiljø
+En **helt separat** Fly-app som lar hvem som helst prøve tjenesten mot Altinns testmiljø (tt02)
 uten invitasjon, på syntetiske data. Den deler aldri prod-creds eller `env=prod`: egen app, egne
 **test**-vendor-creds, `WENCHE_ENV=test`. Konfig ligger i `fly.demo.toml`. Banneren i SPA-en
 styres av `HOSTED_DEMO_MODE=1` (rent informativt, endrer ikke funksjonalitet).

--- a/hosted/README.md
+++ b/hosted/README.md
@@ -103,3 +103,40 @@ Scriptet velger metode automatisk: **lokalt** hvis `~/.wenche/hosted-prod.env` f
 (krever `flyctl ssh issue --agent` én gang), slik at secret-en kan bli værende kun på
 serveren. Del lenken via en privat kanal, den er knyttet til ett organisasjonsnummer.
 Roter `HOSTED_INVITE_SECRET` for å ugyldiggjøre alle utdelte lenker på én gang.
+
+## Demo-miljø (demo.wenche.cloud, mot tt02)
+
+En **helt separat** Fly-app som lar hvem som helst prøve tjenesten mot Skatteetatens testmiljø
+uten invitasjon, på syntetiske data. Den deler aldri prod-creds eller `env=prod`: egen app, egne
+**test**-vendor-creds, `WENCHE_ENV=test`. Konfig ligger i `fly.demo.toml`. Banneren i SPA-en
+styres av `HOSTED_DEMO_MODE=1` (rent informativt, endrer ikke funksjonalitet).
+
+Engangsoppsett:
+
+1. **Opprett appen:** `flyctl apps create wenche-demo`.
+2. **Sett test-hemmeligheter** (de samme test-vendor-creds `dev_local.py` bruker mot tt02):
+   ```sh
+   flyctl secrets set -a wenche-demo \
+     HOSTED_SESSION_SECRET="$(openssl rand -hex 32)" \
+     HOSTED_INVITE_SECRET="$(openssl rand -hex 32)" \
+     HOSTED_VENDOR_ORGNR="<test-orgnr>" \
+     HOSTED_VENDOR_CLIENT_ID="<maskinporten-klient-id, test>" \
+     HOSTED_VENDOR_KID="<kid, test>" \
+     HOSTED_VENDOR_KEY_PEM="$(cat maskinporten_privat.pem)"
+   ```
+3. **Deploy:** `flyctl deploy -c fly.demo.toml --ha=false`. `--ha=false` hindrer at Fly lager to
+   maskiner — appen MÅ kjøre på **én** maskin (in-memory-sesjon kan ikke spres mellom maskiner,
+   samme grunn som prod). Lagde du to: `flyctl scale count 1 -a wenche-demo`.
+4. **Domene:** `flyctl certs add demo.wenche.cloud -a wenche-demo`, legg deretter til DNS-postene
+   Fly oppgir hos domene.shop. Vent til `flyctl certs show demo.wenche.cloud -a wenche-demo` er grønt.
+5. **Forhåndsgodkjenn systembruker** for et syntetisk Tenor-demo-org (engang): åpne demo-appen via
+   en demo-invite (steg 6), klikk «Koble systembruker», godkjenn i tt02-Altinn. Etterpå får alle
+   demo-besøkende `AlreadyApproved` uten BankID.
+6. **Offentlig demo-lenke:** mynt en invite-lenke for demo-org-et mot demo-appen (secret/URL
+   hentes fra demo-appens eget miljø via ssh, så lenken peker på demo.wenche.cloud):
+   ```sh
+   WENCHE_HOSTED_APP=wenche-demo WENCHE_HOSTED_HEALTH=https://demo.wenche.cloud/api/health \
+     hosted/invite.sh <demo-orgnr>
+   ```
+   Legg den bak «Demo»-knappen på wenche-web. Roter `HOSTED_INVITE_SECRET` på demo-appen for å
+   ugyldiggjøre lenken. (Uten `WENCHE_HOSTED_APP`-overstyringen mynter scriptet for **prod**.)

--- a/hosted/api/auth.py
+++ b/hosted/api/auth.py
@@ -63,11 +63,13 @@ def me(request: Request) -> dict:
         return {"invited": False}
     sid = request.session.get("sid")
     st = sesjon.hent(sid) if sid else None
+    s = settings()
     return {
         "invited": True,
         "invite_org": request.session.get("invite_org"),
         "kunde_org": st.kunde_org if st else None,
-        "env": settings().env,
+        "env": s.env,
+        "demo": s.demo_mode,
     }
 
 

--- a/hosted/api/config.py
+++ b/hosted/api/config.py
@@ -34,6 +34,9 @@ class Settings:
         ]
         # Brukes til å bygge invite-lenken (peker på app-en der invitten løses inn).
         self.public_url: str = os.getenv("HOSTED_PUBLIC_URL", "http://localhost:5173")
+        # Demo-modus: viser en «dette er en demo mot tt02»-banner i SPA-en. Rent informativt,
+        # endrer ikke funksjonalitet. Settes kun på demo-appen (aldri i prod).
+        self.demo_mode: bool = os.getenv("HOSTED_DEMO_MODE", "").lower() in ("1", "true", "yes")
         self.vendor_orgnr = os.getenv("HOSTED_VENDOR_ORGNR")
         self._vendor_client_id = os.getenv("HOSTED_VENDOR_CLIENT_ID")
         self._vendor_kid = os.getenv("HOSTED_VENDOR_KID")

--- a/hosted/dev_local.py
+++ b/hosted/dev_local.py
@@ -1,5 +1,5 @@
 """
-Lokal dev-kjøring av den hostede appen mot Skatteetatens testmiljø (tt02).
+Lokal dev-kjøring av den hostede appen mot Altinns testmiljø (tt02).
 IKKE for produksjon.
 
 Mapper Wenches eksisterende _TEST-credentials (fra ~/.wenche/.env og repoets .env) til

--- a/hosted/invite.sh
+++ b/hosted/invite.sh
@@ -29,8 +29,10 @@ if [ -z "$ORG" ]; then
   exit 1
 fi
 
-# Rask vei: mynt lokalt med secret fra den untrackede env-fila.
-if [ -f "$ENV_FILE" ]; then
+# Rask vei: mynt lokalt med secret fra den untrackede env-fila. KUN for prod-appen — fila har
+# prod-secret + prod-URL, så for andre apper (f.eks. wenche-demo) ville den gitt feil lenke.
+# Andre apper går alltid via ssh, så secret/URL hentes fra den appens eget miljø.
+if [ "$APP" = "wenche-hosted" ] && [ -f "$ENV_FILE" ]; then
   set -a; . "$ENV_FILE"; set +a
   exec "$ROOT/.venv/bin/python" "$ROOT/hosted/mint_invite.py" "$ORG"
 fi

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -25,6 +25,16 @@ interface Me {
   invite_org?: string | null;
   kunde_org?: string | null;
   env?: string;
+  demo?: boolean;
+}
+
+function DemoBanner() {
+  return (
+    <div className="border-b border-amber-300 bg-amber-50 px-6 py-2 text-center text-sm text-amber-900">
+      Demo mot Skatteetatens testmiljø (tt02). Ingenting sendes til ekte myndigheter, fyll gjerne
+      inn eksempeldata.
+    </div>
+  );
 }
 
 type FaneId = "hjem" | "tall" | "dokumenter" | "send";
@@ -414,6 +424,7 @@ export default function App() {
 
   return (
     <div className="min-h-screen">
+      {me?.demo && <DemoBanner />}
       <header className="sticky top-0 z-50 border-b border-border bg-background/85 backdrop-blur-sm">
         <div className="mx-auto max-w-2xl px-6">
           <div className="flex items-center justify-between py-4">

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -31,7 +31,7 @@ interface Me {
 function DemoBanner() {
   return (
     <div className="border-b border-amber-300 bg-amber-50 px-6 py-2 text-center text-sm text-amber-900">
-      Demo mot Skatteetatens testmiljø (tt02). Ingenting sendes til ekte myndigheter, fyll gjerne
+      Demo mot Altinns testmiljø (tt02). Ingenting sendes til ekte myndigheter, fyll gjerne
       inn eksempeldata.
     </div>
   );

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.27.0"
+version = "0.28.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_hosted_demo.py
+++ b/tests/test_hosted_demo.py
@@ -1,0 +1,40 @@
+"""
+Demo-flagget for hostet Wenche.
+
+HOSTED_DEMO_MODE styrer kun et informasjons-flagg i /api/auth/me (banner i SPA-en), ikke
+funksjonalitet. Settes på demo-appen (mot tt02), aldri i prod.
+"""
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hosted.api.auth import lag_invite_token
+
+
+def _klient(monkeypatch, demo: bool):
+    monkeypatch.setenv("WENCHE_ENV", "test")
+    monkeypatch.setenv("HOSTED_SESSION_SECRET", "test-session-secret")
+    monkeypatch.setenv("HOSTED_INVITE_SECRET", "test-invite-secret")
+    if demo:
+        monkeypatch.setenv("HOSTED_DEMO_MODE", "1")
+    else:
+        monkeypatch.delenv("HOSTED_DEMO_MODE", raising=False)
+    from hosted.api import config
+
+    config.settings.cache_clear()
+    from hosted.api import main as main_mod
+
+    importlib.reload(main_mod)
+    klient = TestClient(main_mod.app)
+    klient.post("/api/auth/invite", json={"token": lag_invite_token("314273818")})
+    return klient, config
+
+
+@pytest.mark.parametrize("demo", [True, False])
+def test_demo_flagg_i_me(monkeypatch, demo):
+    klient, config = _klient(monkeypatch, demo)
+    try:
+        assert klient.get("/api/auth/me").json()["demo"] is demo
+    finally:
+        config.settings.cache_clear()


### PR DESCRIPTION
## Bakgrunn

Prod er invitasjonsbasert, så prospekter kunne ikke prøve tjenesten. Denne PR-en gjør koden klar for en åpen demo mot Altinns testmiljø (tt02), på en separat, isolert Fly-app.

## Endringer

- **Demo-flagg:** `HOSTED_DEMO_MODE` → `/api/auth/me` → en «demo mot tt02»-banner i SPA-en.
  Rent informativt, endrer ikke funksjonalitet; prod setter det ikke.
- **`fly.demo.toml`:** egen demo-app (`wenche-demo`, `env=test`, test-vendor-creds,
  scale-to-zero, én maskin). Samme image som prod, helt isolert.
- **`invite.sh`:** respekter `WENCHE_HOSTED_APP`, så demo-lenker myntes mot demo-appen.
- **Docs:** demo-seksjon i `hosted/README.md`, og presisering av at **tt02 er Altinns**
  testmiljø (ikke Skatteetatens) i banner + docs/README.
- **Test:** dekker demo-flagget i `/api/auth/me`.
- Versjon bumpet til **0.28.0**.

## Status / kjent begrensning

Demoen er allerede deployet til `demo.wenche.cloud` (fra denne branchen), og «Prøv demo» er primær CTA på www.wenche.cloud. Årsregnskap, aksjonærregister, dry-run og dokument-nedlasting virker. **Skattemelding-innsending** i demo viser en lesbar «Skatteplikt ikke registrert» til Skatteetaten gir oss et syntetisk test-org med forhåndsutfylt (SSV-5329).

## Test plan

- [x] `pytest` grønt (321, inkl. demo-flagg-test)
- [x] Hosted SPA bygger (tsc + vite)
- [x] Demo mot tt02: Hjem-status, Tall, Dokumenter, årsregnskap + aksjonær sendt
- [x] CI: `Tester` + `Docker-bygg` grønne på PR-en
