### PR TITLE
feat(hosted): spor fanebytte og hendelser i Umami, konfinert til hosted/web

### DIFF
--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { api } from "./api";
+import { sporSidevisning, sporHendelse } from "./sporing";
 import {
   DataSkjema,
   SendSeksjon,
@@ -328,12 +329,17 @@ function SendFane({ config, me }: { config: any; me: Me }) {
   // Selvhelende systembruker-binding: en 409 betyr at bindingen gikk tapt (serveren sov/
   // restartet). Den reises FØR innsending, så det er trygt å rebinde og prøve én gang til.
   const innsending: InnsendingFn = async (type, dryRun, cfg) => {
+    if (dryRun) sporHendelse("send-start", { type });
     try {
-      return await api.innsending(type, dryRun, cfg);
+      const data = await api.innsending(type, dryRun, cfg);
+      if (!dryRun) sporHendelse("send-ok", { type });
+      return data;
     } catch (e) {
       if (!dryRun && (e as { status?: number }).status === 409) {
         await api.systembrukerRequest();
-        return await api.innsending(type, dryRun, cfg);
+        const data = await api.innsending(type, dryRun, cfg);
+        sporHendelse("send-ok", { type });
+        return data;
       }
       throw e;
     }
@@ -418,6 +424,7 @@ export default function App() {
   const naviger = (id: string) => {
     setFane(id as FaneId);
     window.scrollTo({ top: 0 });
+    sporSidevisning(`/${id}`); // virtuell pageview (URL-en endres ikke i SPA-en)
   };
 
   const invited = !!me?.invited;
@@ -477,7 +484,17 @@ export default function App() {
             {fane === "tall" && (
               <TallFane config={config} env={me.env} org={me.kunde_org} onLagret={setConfig} />
             )}
-            {fane === "dokumenter" && <Dokumenter config={config} dokument={api.dokument} />}
+            {fane === "dokumenter" && (
+              <Dokumenter
+                config={config}
+                dokument={(type, cfg) =>
+                  api.dokument(type, cfg).then((r) => {
+                    sporHendelse("dokument-last-ned", { type });
+                    return r;
+                  })
+                }
+              />
+            )}
             {fane === "send" && <SendFane config={config} me={me} />}
             <GaaVidere
               faner={FANER}

--- a/hosted/web/src/sporing.ts
+++ b/hosted/web/src/sporing.ts
@@ -1,0 +1,21 @@
+// Umami-sporing — KUN for den hostede tjenesten (demo + prod). Bevisst utenfor packages/ui og
+// wenche/web, så den open-source/self-hostede koden forblir analytics-fri. No-op hvis Umami
+// ikke er lastet. Vi sporer kun fane-/hendelsesnavn, aldri skjemadata (fnr o.l.).
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function track(...args: any[]): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (window as any).umami?.track?.(...args);
+}
+
+// Virtuell sidevisning for SPA-navigasjon (URL-en endres ikke). Gir en funnel i Umami.
+export function sporSidevisning(sti: string): void {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  track((props: any) => ({ ...props, url: sti }));
+}
+
+// Egendefinert hendelse, f.eks. «send-ok» med { type }.
+export function sporHendelse(navn: string, data?: Record<string, unknown>): void {
+  if (data) track(navn, data);
+  else track(navn);
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.28.0"
+version = "0.29.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Sammendrag

URL-en endres ikke når brukeren bytter fane i SPA-en, så Umami fikk verken funnel eller hendelser. Denne PR-en legger til virtuelle pageviews og noen få nøkkelhendelser, og holder all sporing inne i den hostede tjenesten.

## Endringer

- Ny `hosted/web/src/sporing.ts`: tynn Umami-helper (`sporSidevisning`,
  `sporHendelse`), no-op uten Umami, sender kun fane-/hendelsesnavn
- `hosted/web/src/App.tsx`: virtuell pageview ved fanebytte, og hendelsene
  `send-start`, `send-ok` (inkl. etter 409-rebind) og `dokument-last-ned`
- Bump versjon til 0.29.0

## Personvern og arkitektur

- Sporingen ligger bevisst i `hosted/web`, utenfor `packages/ui` og
  `wenche/web`, slik at den open-source/self-hostede koden (det som havner i PyPI-wheelen) forblir helt analytics-fri
- Aldri skjemadata (fnr o.l.), kun fane-/hendelsesnavn; invite-token er allerede strippet fra URL-en før sporing

## Test plan

- [x] `npm run build` hostet + self-hosted grønt
- [x] `pytest`: 321 passerte
- [x] Bekreftet ingen umami/sporing-treff i `packages/ui/src` eller `wenche/web/frontend/src`
- [x] Etter deploy: bekreft pageviews + hendelser i Umami for demo og hostet prod
