### PR TITLE
feat(ui): gjeninnfør SAF-T-import i webgrensesnittet

### DIFF
--- a/docs/avansert/cli.md
+++ b/docs/avansert/cli.md
@@ -175,4 +175,4 @@ Følgende felt fylles inn automatisk så langt det lar seg gjøre fra SAF-T, men
 - `skattemelding.underskudd_til_fremfoering` estimeres fra åpningssaldoen på konto 2080 (udekket tap). Verdien er regnskapsmessig og kan avvike fra det skattemessige fremførbare underskuddet; verifiser mot fjorårets skattemelding hvis selskapet har ikke-fradragsberettigede kostnader
 
 !!! tip "I webgrensesnittet"
-    SAF-T-import gjøres fra kommandolinjen (`wenche importer-saft`). I `wenche`-webgrensesnittet (fanen **Tall**) finner du i stedet **Hent tall fra Bodil**, som laster opp en ferdig `config.yaml`.
+    Denne kommandoen er for skripting og avansert bruk. I `wenche`-webgrensesnittet (fanen **Tall**) finner du **Importer fra SAF-T**, som gjør det samme uten kommandolinjen, og i tillegg lar deg laste opp en egen SAF-T for fjoråret for å fylle inn sammenligningstallene.

--- a/docs/hostet.md
+++ b/docs/hostet.md
@@ -22,6 +22,10 @@ tallene, eventuelt laste ned dokumentene (skattemelding, årsregnskap, aksjonær
 for gjennomgang, og så sende inn. Noter sendes ikke inn digitalt, men kan lastes ned for
 signering og arkivering hos selskapet.
 
+Under **Tall** kan du fylle inn manuelt, hente tallene fra [Bodil](https://github.com/olefredrik/Bodil),
+eller **importere fra SAF-T**. Laster du opp en SAF-T-fil, behandles den i minnet i EØS
+(Stockholm) for å fylle inn skjemaet, og forkastes umiddelbart, den lagres ikke.
+
 !!! note "For operatører"
     Drifts- og deploy-dokumentasjon (Docker, Fly.io, secrets) ligger i `hosted/README.md`
     i kodebasen, ikke her. Denne siden er kun ment for sluttbrukere.

--- a/docs/oppsett.md
+++ b/docs/oppsett.md
@@ -192,7 +192,7 @@ Klikk **Lagre konfigurasjon** i Steg 1. Wenche lagrer verdiene til `~/.wenche/.e
 I Wenche, gå til fanen **Tall** og fyll inn selskapets opplysninger, regnskapstall, balanse, skattemelding-innstillinger og aksjonærdata, alt på én side. Alle beløp oppgis i hele kroner (NOK). Klikk **Lagre data** når du er ferdig, dataene lagres til `config.yaml` i den mappen du startet Wenche fra.
 
 !!! tip "Fører du regnskapet i Bodil, eller har du SAF-T?"
-    Under **Tall** finner du **Hent tall fra Bodil**, der du laster opp en `config.yaml` fra [Bodil](https://github.com/olefredrik/Bodil) og får regnskapstallene fylt inn. Har du i stedet en SAF-T-eksport fra regnskapssystemet, kan du generere `config.yaml` fra kommandolinjen med `wenche importer-saft` (se [Kommandolinje](avansert/cli.md)). Daglig leder, styreleder og aksjonærdata fyller du inn manuelt.
+    Under **Tall** finner du to importknapper. **Hent tall fra Bodil** laster opp en `config.yaml` fra [Bodil](https://github.com/olefredrik/Bodil). **Importer fra SAF-T** lar deg laste opp en SAF-T Financial-fil eksportert fra regnskapssystemet (Fiken, Tripletex, Visma, PowerOffice m.fl.), så fylles resultat og balanse inn for deg, både for inneværende år og, via en egen fil for fjoråret, sammenligningstallene. Begge forhåndsfyller bare skjemaet, du ser over alt og lagrer selv. Daglig leder, styreleder og aksjonærdata finnes ikke i SAF-T og fylles inn manuelt. (SAF-T-import finnes også på kommandolinjen, se [Kommandolinje](avansert/cli.md).)
 
 ---
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -75,8 +75,8 @@ Wenche viser fortløpende om balansen går opp, sum eiendeler skal være lik sum
 
 Klikk **Lagre data** nederst for å skrive til `config.yaml`.
 
-!!! tip "Fører du regnskapet i Bodil?"
-    Klikk **Hent tall fra Bodil** øverst i skjemaet og last opp `config.yaml` fra [Bodil](https://github.com/olefredrik/Bodil), så fylles regnskapstallene inn for deg. Har du en SAF-T-eksport fra regnskapssystemet i stedet, kan du generere `config.yaml` fra kommandolinjen med `wenche importer-saft`, se [Kommandolinje](avansert/cli.md).
+!!! tip "Fører du regnskapet i Bodil, eller har du SAF-T?"
+    Klikk **Hent tall fra Bodil** øverst i skjemaet og last opp `config.yaml` fra [Bodil](https://github.com/olefredrik/Bodil), så fylles regnskapstallene inn for deg. Har du en SAF-T-eksport fra regnskapssystemet i stedet, klikk **Importer fra SAF-T** og last opp filen. Begge forhåndsfyller skjemaet, du ser over og lagrer selv. (SAF-T finnes også på kommandolinjen med `wenche importer-saft`, se [Kommandolinje](avansert/cli.md).)
 
 ---
 

--- a/hosted/api/main.py
+++ b/hosted/api/main.py
@@ -21,6 +21,7 @@ from .auth import router as auth_router
 from .config import settings
 from .dokumenter import router as dokumenter_router
 from .innsending import router as innsending_router
+from .saft import router as saft_router
 from .systembruker import router as systembruker_router
 
 s = settings()
@@ -48,6 +49,7 @@ app.include_router(auth_router)
 app.include_router(systembruker_router)
 app.include_router(innsending_router)
 app.include_router(dokumenter_router)
+app.include_router(saft_router)
 
 
 @app.get("/api/health")

--- a/hosted/api/saft.py
+++ b/hosted/api/saft.py
@@ -1,0 +1,47 @@
+"""
+SAF-T Financial-import for hostet Wenche.
+
+Tar imot en opplastet SAF-T XML som rå request-body, parser den i minnet (wenche.saft) og
+returnerer en config-dict som klienten forhåndsfyller skjemaet med. Krever gyldig invite, ikke
+vendor/kunde-org, siden ingenting sendes inn. Personvern: bytene leses inn i minnet, parses og
+forkastes. Ingenting skrives til disk eller lagres (sesjonen er fasit). Behandlingen skjer i
+EØS (Fly arn/Stockholm). Org-låsen i klienten gjør at SAF-T-ens org ikke endrer kundeidentitet.
+"""
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from wenche.saft import importer_bytes
+
+from .deps import krev_invitert
+
+router = APIRouter(prefix="/api/saft", tags=["saft"])
+
+# Romslig tak. En SAF-T for et passivt holdingselskap er noen få kB; grensen hindrer at en stor
+# opplasting spiller over til en temp-fil på disk og holder behandlingen i minnet.
+_MAKS_BYTES = 1_000_000
+
+
+@router.post("/import")
+async def importer_saft(request: Request, foregaaende: bool = Query(False)) -> dict:
+    krev_invitert(request)
+    lengde = request.headers.get("content-length")
+    if lengde and lengde.isdigit() and int(lengde) > _MAKS_BYTES:
+        raise HTTPException(status_code=413, detail="SAF-T-filen er for stor (maks 1 MB).")
+    data = await request.body()
+    if not data:
+        raise HTTPException(status_code=400, detail="Tom forespørsel: last opp en SAF-T-fil.")
+    if len(data) > _MAKS_BYTES:
+        raise HTTPException(status_code=413, detail="SAF-T-filen er for stor (maks 1 MB).")
+    try:
+        config = importer_bytes(data)
+    except Exception as e:  # ugyldig/uventet XML
+        raise HTTPException(status_code=422, detail=f"Kunne ikke lese SAF-T-filen: {e}")
+    if foregaaende:
+        # Fjorårets SAF-T: dens sluttsaldoer er fjorårets resultat og balanse (sammenligningstall).
+        return {
+            "regnskapsaar": config.get("regnskapsaar"),
+            "foregaaende_aar": {
+                "resultatregnskap": config["resultatregnskap"],
+                "balanse": config["balanse"],
+            },
+        }
+    return config

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -301,6 +301,8 @@ function TallFane({
           visEksempel={env === "test"}
           initial={config ?? undefined}
           laastOrg={org ?? undefined}
+          importerSaft={api.importerSaft}
+          saftMerknad="SAF-T-filen behandles i minnet i EØS (Stockholm) og lagres ikke."
           ekstraSeksjon={<NoterSeksjon noter={noter} setNoter={setNoter} />}
         />
       </Kort>

--- a/hosted/web/src/api.ts
+++ b/hosted/web/src/api.ts
@@ -19,4 +19,11 @@ export const api = {
   // Genererer dokumenter for nedlasting/gjennomgang (ingenting sendes inn).
   dokument: (type: string, config: unknown) =>
     req(`/api/dokumenter/${type}`, { method: "POST", body: JSON.stringify(config) }),
+  // Parser en opplastet SAF-T i minnet (lagres ikke) og returnerer config for forhåndsfylling.
+  importerSaft: (file: File, foregaaende: boolean) =>
+    req(`/api/saft/import?foregaaende=${foregaaende}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/xml" },
+      body: file,
+    }),
 };

--- a/packages/ui/src/skjema.tsx
+++ b/packages/ui/src/skjema.tsx
@@ -293,6 +293,8 @@ export function DataSkjema({
   lagreEtikett = "Lagre data",
   ekstraSeksjon,
   laastOrg,
+  importerSaft,
+  saftMerknad,
 }: {
   onLagre: (config: unknown) => Promise<void>;
   visEksempel?: boolean;
@@ -306,6 +308,13 @@ export function DataSkjema({
   // Hostet kjenner selskapet fra invitasjonen: org.nr forhåndsutfylles, låses i feltet, og
   // tvinges tilbake ved import/eksempeldata (innsending krever at config-org == kunde-org).
   laastOrg?: string;
+  // Valgfri SAF-T-import: parser en opplastet SAF-T Financial-fil til config-form. Hver app
+  // injiserer sin binding (self-hosted/hostet backend). Uten denne vises ikke SAF-T-knappen.
+  // foregaaende=true => kun fjorårets sammenligningstall hentes (egen fil for fjoråret).
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  importerSaft?: (file: File, foregaaende: boolean) => Promise<any>;
+  // Valgfri merknad i SAF-T-modalen (hostet bruker den til personvern-info om EØS/ingen lagring).
+  saftMerknad?: React.ReactNode;
 }) {
   const laasteFelter = laastOrg ? ["selskap.org_nummer"] : [];
   // Tving org til det låste selskapet (brukes ved start, Bodil-import og eksempeldata).
@@ -321,6 +330,13 @@ export function DataSkjema({
   const [importMelding, setImportMelding] = useState<string | null>(null);
   const [dragOver, setDragOver] = useState(false);
   const filRef = useRef<HTMLInputElement>(null);
+  const [visSaft, setVisSaft] = useState(false);
+  const [saftMelding, setSaftMelding] = useState<string | null>(null);
+  const [saftFeil, setSaftFeil] = useState(false);
+  const [saftLaster, setSaftLaster] = useState(false);
+  const [saftDrag, setSaftDrag] = useState<string | null>(null);
+  const saftRef = useRef<HTMLInputElement>(null);
+  const saftFjorRef = useRef<HTMLInputElement>(null);
 
   // Advar mot å forlate siden (logo-/tilbake-klikk, nettleser-tilbake, lukke fane) hvis
   // skjemaet har ulagret innhold, så en bruker ikke mister utfyllingen ved et uhell.
@@ -384,6 +400,50 @@ export function DataSkjema({
     }
   };
 
+  // SAF-T mangler styringsdata (daglig leder, styreleder, stiftelsesår, aksjonærer). Behold
+  // det brukeren allerede har fylt inn (eller hentet fra Bodil) i stedet for å blanke det.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const flettStyring = (saft: any, eks: any): any => {
+    const s = eks?.selskap ?? {};
+    return {
+      ...saft,
+      selskap: {
+        ...saft.selskap,
+        daglig_leder: saft.selskap?.daglig_leder || s.daglig_leder || "",
+        styreleder: saft.selskap?.styreleder || s.styreleder || "",
+        stiftelsesaar: saft.selskap?.stiftelsesaar || s.stiftelsesaar || 0,
+        kontakt_epost: saft.selskap?.kontakt_epost || s.kontakt_epost || "",
+      },
+      aksjonaerer: saft.aksjonaerer?.length ? saft.aksjonaerer : (eks?.aksjonaerer ?? []),
+    };
+  };
+
+  const importerSaftFil = async (file: File, foregaaende: boolean) => {
+    if (!importerSaft) return;
+    setSaftMelding(null);
+    setSaftFeil(false);
+    setSaftLaster(true);
+    try {
+      const data = await importerSaft(file, foregaaende);
+      const aar = data?.regnskapsaar ? ` ${data.regnskapsaar}` : "";
+      if (foregaaende) {
+        // Kun fjorårets sammenligningstall: merge inn i gjeldende config, rør ikke resten.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        setConfig((c: any) => ({ ...c, foregaaende_aar: data.foregaaende_aar }));
+        setSaftMelding(`Sammenligningstall for fjoråret importert fra SAF-T${aar}.`);
+      } else {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        setConfig((c: any) => medLaastOrg(flettStyring(data, c)));
+        setSaftMelding(`Tall importert fra SAF-T${aar}. Se over og lagre.`);
+      }
+    } catch (e) {
+      setSaftFeil(true);
+      setSaftMelding("Kunne ikke importere SAF-T: " + (e as Error).message);
+    } finally {
+      setSaftLaster(false);
+    }
+  };
+
   return (
     <div className="space-y-10">
       <div className="flex flex-wrap items-center justify-between gap-2">
@@ -398,6 +458,18 @@ export function DataSkjema({
           >
             Hent tall fra Bodil
           </button>
+          {importerSaft && (
+            <button
+              className="text-xs font-medium text-spruce underline-offset-2 hover:underline"
+              onClick={() => {
+                setSaftMelding(null);
+                setSaftFeil(false);
+                setVisSaft(true);
+              }}
+            >
+              Importer fra SAF-T
+            </button>
+          )}
           {visEksempel && (
             <button
               className="text-xs text-muted-foreground underline-offset-2 hover:text-spruce hover:underline"
@@ -500,6 +572,103 @@ export function DataSkjema({
                 Hva er Bodil?
               </a>
               <button className={btnOutline} onClick={() => setVisBodil(false)}>
+                Lukk
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {visSaft && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-foreground/50 p-4"
+          onClick={() => setVisSaft(false)}
+        >
+          <div
+            className="w-full max-w-md rounded-sm border border-border bg-background p-6 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <p className={monoLabel}>Importer fra SAF-T</p>
+            <h3 className="mt-2 font-display text-xl font-normal">Hent tall fra regnskapssystemet</h3>
+            <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+              Eksporter en SAF-T Financial-fil fra regnskapssystemet ditt (Fiken, Tripletex,
+              Visma, PowerOffice m.fl.), så fyller jeg inn regnskap og balanse for deg. Du ser
+              over alt og sender som vanlig.
+            </p>
+
+            {[
+              {
+                id: "naa",
+                ref: saftRef,
+                foregaaende: false,
+                tittel: "Inneværende år",
+                beskrivelse: "Fyller selskap, resultat og balanse for regnskapsåret.",
+              },
+              {
+                id: "fjor",
+                ref: saftFjorRef,
+                foregaaende: true,
+                tittel: "Foregående år (valgfritt)",
+                beskrivelse:
+                  "Egen SAF-T for fjoråret. Fyller kun sammenligningstallene (fjorårets resultatregnskap finnes ikke i årets fil).",
+              },
+            ].map((sone) => (
+              <div key={sone.id} className="mt-5">
+                <p className="text-sm font-medium">{sone.tittel}</p>
+                <p className="mt-0.5 text-xs text-muted-foreground">{sone.beskrivelse}</p>
+                <div
+                  role="button"
+                  tabIndex={0}
+                  className={`mt-2 flex flex-col items-center justify-center rounded-sm border-2 border-dashed px-6 py-6 text-center transition ${
+                    saftDrag === sone.id ? "border-spruce bg-spruce-soft" : "border-border hover:border-spruce/60"
+                  } ${saftLaster ? "pointer-events-none opacity-60" : ""}`}
+                  onClick={() => sone.ref.current?.click()}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter" || e.key === " ") {
+                      e.preventDefault();
+                      sone.ref.current?.click();
+                    }
+                  }}
+                  onDragOver={(e) => {
+                    e.preventDefault();
+                    setSaftDrag(sone.id);
+                  }}
+                  onDragLeave={() => setSaftDrag(null)}
+                  onDrop={(e) => {
+                    e.preventDefault();
+                    setSaftDrag(null);
+                    const f = e.dataTransfer.files?.[0];
+                    if (f) importerSaftFil(f, sone.foregaaende);
+                  }}
+                >
+                  <p className="text-sm">
+                    Dra og slipp <code className="font-mono">.xml</code> her, eller{" "}
+                    <span className="text-spruce underline-offset-2 hover:underline">velg fil</span>
+                  </p>
+                  <input
+                    ref={sone.ref}
+                    type="file"
+                    accept=".xml,text/xml,application/xml"
+                    className="hidden"
+                    onChange={(e) => {
+                      const f = e.target.files?.[0];
+                      if (f) importerSaftFil(f, sone.foregaaende);
+                      e.target.value = "";
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+
+            {saftLaster && <p className="mt-3 text-sm text-muted-foreground">Importerer…</p>}
+            {saftMelding && (
+              <p className={`mt-3 text-sm ${saftFeil ? "text-red-700" : "text-spruce"}`}>{saftMelding}</p>
+            )}
+            {saftMerknad && (
+              <p className="mt-4 text-xs leading-relaxed text-muted-foreground">{saftMerknad}</p>
+            )}
+            <div className="mt-6 flex justify-end">
+              <button className={btnOutline} onClick={() => setVisSaft(false)}>
                 Lukk
               </button>
             </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.29.0"
+version = "0.30.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_hosted_saft.py
+++ b/tests/test_hosted_saft.py
@@ -1,0 +1,74 @@
+"""
+SAF-T-import-endepunktet for hostet Wenche (HTTP-nivå).
+
+- Uten invite er importen stengt (401).
+- Med invite parses en opplastet SAF-T og config-dict returneres for forhåndsfylling.
+- foregaaende=true returnerer kun fjorårets sammenligningstall.
+- Ugyldig XML gir 422, for stor fil gir 413.
+"""
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hosted.api.auth import lag_invite_token
+from tests.test_saft import KONTOER, _saft_xml
+
+_INVITE_SECRET = "test-invite-secret"
+
+
+@pytest.fixture
+def klient(monkeypatch):
+    monkeypatch.setenv("WENCHE_ENV", "test")
+    monkeypatch.setenv("HOSTED_SESSION_SECRET", "test-session-secret")
+    monkeypatch.setenv("HOSTED_INVITE_SECRET", _INVITE_SECRET)
+    from hosted.api import config
+
+    config.settings.cache_clear()
+    from hosted.api import main as main_mod
+
+    importlib.reload(main_mod)
+    with TestClient(main_mod.app) as klient:
+        yield klient
+    config.settings.cache_clear()
+
+
+def _inviter(klient, org="314273818"):
+    klient.post("/api/auth/invite", json={"token": lag_invite_token(org)})
+
+
+def test_saft_stengt_uten_invite(klient):
+    r = klient.post("/api/saft/import", content=_saft_xml(KONTOER))
+    assert r.status_code == 401
+
+
+def test_saft_import_med_invite(klient):
+    _inviter(klient)
+    r = klient.post("/api/saft/import", content=_saft_xml(KONTOER))
+    assert r.status_code == 200, r.text
+    cfg = r.json()
+    assert cfg["selskap"]["navn"] == "Testholding AS"
+    assert cfg["resultatregnskap"]["driftsinntekter"]["salgsinntekter"] == 100000
+    assert cfg["balanse"]["egenkapital_og_gjeld"]["langsiktig_gjeld"]["laan_fra_aksjonaer"] == 200000
+
+
+def test_saft_foregaaende_returnerer_kun_sammenligningstall(klient):
+    _inviter(klient)
+    r = klient.post("/api/saft/import?foregaaende=true", content=_saft_xml(KONTOER))
+    assert r.status_code == 200, r.text
+    data = r.json()
+    assert set(data.keys()) == {"regnskapsaar", "foregaaende_aar"}
+    assert "resultatregnskap" in data["foregaaende_aar"]
+    assert "balanse" in data["foregaaende_aar"]
+
+
+def test_saft_ugyldig_xml_gir_422(klient):
+    _inviter(klient)
+    r = klient.post("/api/saft/import", content=b"ikke xml")
+    assert r.status_code == 422
+
+
+def test_saft_for_stor_fil_gir_413(klient):
+    _inviter(klient)
+    r = klient.post("/api/saft/import", content=b"x" * 1_000_001)
+    assert r.status_code == 413

--- a/tests/test_saft.py
+++ b/tests/test_saft.py
@@ -1,0 +1,152 @@
+"""
+SAF-T Financial-import (wenche/saft.py).
+
+Verifiserer at parseren mapper SAF-T-kontoer (GroupingCategory/GroupingCode) til
+Wenches config-format: årets tall fra sluttsaldoer, foregående års balanse fra
+åpningssaldoer, fremførbart underskudd fra åpningssaldoen på konto 2080, og en
+stub-noteoppføring for lån fra aksjonær (konto 2250). Dekker også at
+importer_bytes() gir samme resultat som importer() (in-memory-stien web-UI-ene bruker).
+"""
+
+from pathlib import Path
+
+import pytest
+
+from wenche.saft import importer, importer_bytes
+
+_NS = "urn:StandardAuditFile-Taxation-Financial:NO"
+
+
+def _konto(kategori, kode, *, ub_debet=0, ub_kredit=0, ib_debet=0, ib_kredit=0):
+    """Bygg et <Account>-element. ub = utgående (closing), ib = inngående (opening)."""
+    return f"""
+    <Account>
+      <GroupingCategory>{kategori}</GroupingCategory>
+      <GroupingCode>{kode}</GroupingCode>
+      <OpeningDebitBalance>{ib_debet}</OpeningDebitBalance>
+      <OpeningCreditBalance>{ib_kredit}</OpeningCreditBalance>
+      <ClosingDebitBalance>{ub_debet}</ClosingDebitBalance>
+      <ClosingCreditBalance>{ub_kredit}</ClosingCreditBalance>
+    </Account>"""
+
+
+def _saft_xml(kontoer: str, *, aar: int = 2024) -> bytes:
+    return f"""<?xml version="1.0" encoding="utf-8"?>
+<AuditFile xmlns="{_NS}">
+  <Header>
+    <SelectionCriteria>
+      <PeriodStartYear>{aar}</PeriodStartYear>
+    </SelectionCriteria>
+    <Company>
+      <RegistrationNumber>310137715</RegistrationNumber>
+      <Name>Testholding AS</Name>
+      <Address>
+        <StreetName>Storgata 1</StreetName>
+        <PostalCode>0001</PostalCode>
+        <City>Oslo</City>
+      </Address>
+      <Contact>
+        <Email>post@testholding.no</Email>
+      </Contact>
+    </Company>
+  </Header>
+  <MasterFiles>
+    <GeneralLedgerAccounts>{kontoer}</GeneralLedgerAccounts>
+  </MasterFiles>
+</AuditFile>""".encode("utf-8")
+
+
+# Et lite, men representativt holdingselskap-regnskap.
+KONTOER = (
+    _konto("salgsinntekt", "3000", ub_kredit=100000)
+    + _konto("finansinntekt", "8040", ub_kredit=50000)          # utbytte fra datterselskap
+    + _konto("finansinntekt", "8050", ub_kredit=5000)           # andre finansinntekter
+    + _konto("finanskostnad", "8150", ub_debet=2000)            # rentekostnader
+    + _konto("balanseverdiForAnleggsmiddel", "1300",
+             ub_debet=1000000, ib_debet=900000)                 # aksjer i datterselskap
+    + _konto("balanseverdiForOmloepsmiddel", "1920",
+             ub_debet=200000, ib_debet=150000)                  # bankinnskudd
+    + _konto("egenkapital", "2000", ub_kredit=30000, ib_kredit=30000)   # aksjekapital
+    + _konto("egenkapital", "2080", ib_debet=40000)             # udekket tap (åpning)
+    + _konto("langsiktigGjeld", "2250", ub_kredit=200000)       # lån fra aksjonær
+)
+
+
+@pytest.fixture
+def cfg():
+    return importer_bytes(_saft_xml(KONTOER))
+
+
+def test_selskapsopplysninger(cfg):
+    s = cfg["selskap"]
+    assert s["navn"] == "Testholding AS"
+    assert s["org_nummer"] == "310137715"
+    assert s["forretningsadresse"] == "Storgata 1, 0001 Oslo"
+    assert s["kontakt_epost"] == "post@testholding.no"
+    assert s["aksjekapital"] == 30000
+    # Felter som ikke finnes i SAF-T skal være tomme/0.
+    assert s["daglig_leder"] == ""
+    assert s["styreleder"] == ""
+    assert cfg["aksjonaerer"] == []
+
+
+def test_regnskapsaar(cfg):
+    assert cfg["regnskapsaar"] == 2024
+
+
+def test_resultatregnskap_aarets_tall(cfg):
+    r = cfg["resultatregnskap"]
+    assert r["driftsinntekter"]["salgsinntekter"] == 100000
+    assert r["finansposter"]["utbytte_fra_datterselskap"] == 50000
+    assert r["finansposter"]["andre_finansinntekter"] == 5000
+    assert r["finansposter"]["rentekostnader"] == 2000
+
+
+def test_balanse_aarets_tall(cfg):
+    b = cfg["balanse"]
+    assert b["eiendeler"]["anleggsmidler"]["aksjer_i_datterselskap"] == 1000000
+    assert b["eiendeler"]["omloepmidler"]["bankinnskudd"] == 200000
+    assert b["egenkapital_og_gjeld"]["egenkapital"]["aksjekapital"] == 30000
+    assert b["egenkapital_og_gjeld"]["langsiktig_gjeld"]["laan_fra_aksjonaer"] == 200000
+
+
+def test_foregaaende_aar_balanse_fra_aapningssaldo(cfg):
+    """Foregående års balanse hentes fra åpningssaldoene (inngående balanse)."""
+    fa = cfg["foregaaende_aar"]["balanse"]
+    assert fa["eiendeler"]["anleggsmidler"]["aksjer_i_datterselskap"] == 900000
+    assert fa["eiendeler"]["omloepmidler"]["bankinnskudd"] == 150000
+    # Foregående års resultatregnskap finnes ikke i SAF-T → skal være 0.
+    assert cfg["foregaaende_aar"]["resultatregnskap"]["driftsinntekter"]["salgsinntekter"] == 0
+
+
+def test_fremfoerbart_underskudd_fra_konto_2080(cfg):
+    """Åpningssaldoen (debet) på 2080 estimerer fremførbart underskudd."""
+    assert cfg["skattemelding"]["underskudd_til_fremfoering"] == 40000
+
+
+def test_laan_fra_aksjonaer_gir_note_stub(cfg):
+    laan = cfg["noter"]["laan_til_naerstaaende"]
+    assert len(laan) == 1
+    assert laan[0]["saldo"] == 200000
+    assert laan[0]["retning"] == "låntaker"
+    # Motpart/rente/sikkerhet finnes ikke i SAF-T og fylles inn manuelt.
+    assert laan[0]["motpart"] == ""
+
+
+def test_ingen_laan_gir_tom_note():
+    cfg = importer_bytes(_saft_xml(_konto("salgsinntekt", "3000", ub_kredit=100000)))
+    assert cfg["noter"]["laan_til_naerstaaende"] == []
+
+
+def test_importer_bytes_samme_som_importer(tmp_path: Path):
+    """In-memory-stien (web-UI) skal gi identisk resultat som fil-stien (CLI)."""
+    xml = _saft_xml(KONTOER)
+    fil = tmp_path / "saft.xml"
+    fil.write_bytes(xml)
+    assert importer_bytes(xml) == importer(fil)
+
+
+def test_manglende_header_gir_feil():
+    xml = f'<?xml version="1.0"?><AuditFile xmlns="{_NS}"></AuditFile>'.encode("utf-8")
+    with pytest.raises(ValueError, match="Header"):
+        importer_bytes(xml)

--- a/tests/test_selfhosted_saft.py
+++ b/tests/test_selfhosted_saft.py
@@ -1,0 +1,41 @@
+"""
+SAF-T-import-endepunktet for self-hosted Wenche (HTTP-nivå).
+
+Ingen invite/auth lokalt: ruten parser opplastet SAF-T og returnerer config for forhåndsfylling.
+Verifiserer foregaaende-grenen og størrelsesgrensen; selve mappingen dekkes av test_saft.py.
+"""
+import pytest
+from fastapi.testclient import TestClient
+
+from tests.test_saft import KONTOER, _saft_xml
+from wenche.web.backend.app import lag_app
+
+
+@pytest.fixture
+def klient():
+    with TestClient(lag_app(env="test", serve_spa=False)) as klient:
+        yield klient
+
+
+def test_import_returnerer_full_config(klient):
+    r = klient.post("/api/saft/import", content=_saft_xml(KONTOER))
+    assert r.status_code == 200, r.text
+    cfg = r.json()
+    assert cfg["selskap"]["org_nummer"] == "310137715"
+    assert cfg["skattemelding"]["underskudd_til_fremfoering"] == 40000
+
+
+def test_foregaaende_kun_sammenligningstall(klient):
+    r = klient.post("/api/saft/import?foregaaende=true", content=_saft_xml(KONTOER))
+    assert r.status_code == 200, r.text
+    assert set(r.json().keys()) == {"regnskapsaar", "foregaaende_aar"}
+
+
+def test_tom_body_gir_400(klient):
+    r = klient.post("/api/saft/import", content=b"")
+    assert r.status_code == 400
+
+
+def test_for_stor_fil_gir_413(klient):
+    r = klient.post("/api/saft/import", content=b"x" * 1_000_001)
+    assert r.status_code == 413

--- a/wenche/saft.py
+++ b/wenche/saft.py
@@ -244,8 +244,20 @@ def importer(saft_fil: str | Path) -> dict:
     RF-1028 hvis det er aktuelt.
     """
     tree = ET.parse(str(saft_fil))
-    root = tree.getroot()
+    return _fra_root(tree.getroot())
 
+
+def importer_bytes(data: bytes) -> dict:
+    """
+    Som importer(), men leser SAF-T fra rå bytes i minnet i stedet for en
+    diskfil. Brukt av web-UI-ene (hostet + self-hosted) slik at en opplastet
+    SAF-T-fil aldri skrives til disk: den parses i minnet og forkastes.
+    """
+    return _fra_root(ET.fromstring(data))
+
+
+def _fra_root(root: ET.Element) -> dict:
+    """Felles kjerne: bygg config-dict fra et parset SAF-T-rotelement."""
     header = root.find(_tag("Header"))
     if header is None:
         raise ValueError("Finner ingen Header i SAF-T-filen.")

--- a/wenche/web/backend/app.py
+++ b/wenche/web/backend/app.py
@@ -25,6 +25,7 @@ from .ruter_dokumenter import router as dokumenter_router
 from .ruter_frister import router as frister_router
 from .ruter_innsending import router as innsending_router
 from .ruter_oppsett import router as oppsett_router
+from .ruter_saft import router as saft_router
 
 _STATIC_DIR = Path(__file__).resolve().parent.parent / "static"
 _INDEX_HTML = _STATIC_DIR / "index.html"
@@ -39,6 +40,7 @@ def lag_app(env: str = "prod", serve_spa: bool = True) -> FastAPI:
     app.include_router(frister_router)
     app.include_router(dokumenter_router)
     app.include_router(innsending_router)
+    app.include_router(saft_router)
 
     @app.get("/api/health")
     def health() -> dict:

--- a/wenche/web/backend/ruter_saft.py
+++ b/wenche/web/backend/ruter_saft.py
@@ -1,0 +1,50 @@
+"""
+SAF-T Financial-import for self-hosted Wenche.
+
+Tar imot en opplastet SAF-T XML som rå request-body, parser den i minnet (wenche.saft) og
+returnerer en config-dict som SPA-en forhåndsfyller skjemaet med. Ingenting skrives til disk
+eller lagres: bytene leses inn i minnet, parses og forkastes. Brukeren ser over og lagrer selv.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException, Query, Request
+
+from wenche.saft import importer_bytes
+
+router = APIRouter(prefix="/api/saft", tags=["saft"])
+
+# Romslig tak. En SAF-T for et passivt holdingselskap er noen få kB; grensen hindrer at en stor
+# opplasting spiller over til en temp-fil på disk og holder behandlingen i minnet.
+_MAKS_BYTES = 1_000_000
+
+
+def _les_med_grense(data: bytes) -> dict:
+    if not data:
+        raise HTTPException(status_code=400, detail="Tom forespørsel: last opp en SAF-T-fil.")
+    if len(data) > _MAKS_BYTES:
+        raise HTTPException(status_code=413, detail="SAF-T-filen er for stor (maks 1 MB).")
+    try:
+        return importer_bytes(data)
+    except HTTPException:
+        raise
+    except Exception as e:  # ugyldig/uventet XML
+        raise HTTPException(status_code=422, detail=f"Kunne ikke lese SAF-T-filen: {e}")
+
+
+@router.post("/import")
+async def importer_saft(request: Request, foregaaende: bool = Query(False)) -> dict:
+    lengde = request.headers.get("content-length")
+    if lengde and lengde.isdigit() and int(lengde) > _MAKS_BYTES:
+        raise HTTPException(status_code=413, detail="SAF-T-filen er for stor (maks 1 MB).")
+    config = _les_med_grense(await request.body())
+    if foregaaende:
+        # Brukeren lastet opp fjorårets SAF-T. Dens sluttsaldoer er fjorårets resultat og
+        # balanse, altså nettopp sammenligningstallene. Klienten merger kun dette inn.
+        return {
+            "regnskapsaar": config.get("regnskapsaar"),
+            "foregaaende_aar": {
+                "resultatregnskap": config["resultatregnskap"],
+                "balanse": config["balanse"],
+            },
+        }
+    return config

--- a/wenche/web/frontend/src/Tall.tsx
+++ b/wenche/web/frontend/src/Tall.tsx
@@ -39,6 +39,8 @@ export default function Tall({
           onLagre={lagre}
           visEksempel={env === "test"}
           initial={config ?? undefined}
+          importerSaft={api.importerSaft}
+          saftMerknad="SAF-T-filen behandles lokalt på din egen maskin og lagres ikke."
           ekstraSeksjon={<NoterSeksjon noter={noter} setNoter={setNoter} />}
         />
       </Kort>

--- a/wenche/web/frontend/src/api.ts
+++ b/wenche/web/frontend/src/api.ts
@@ -26,6 +26,13 @@ export const api = {
   dokument: (type: string, config: unknown) =>
     req(`/api/dokumenter/${type}`, { method: "POST", body: JSON.stringify(config) }),
 
+  importerSaft: (file: File, foregaaende: boolean) =>
+    req(`/api/saft/import?foregaaende=${foregaaende}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/xml" },
+      body: file,
+    }),
+
   innsending: (type: string, dryRun: boolean, config: unknown) =>
     req(`/api/innsending/${type}?dry_run=${dryRun}`, {
       method: "POST",


### PR DESCRIPTION
## Bakgrunn

Brukere som ikke fører i Bodil har bedt om å kunne importere en SAF-T-eksport fra regnskapssystemet i overgangen til Wenche. Parseren (`wenche/saft.py`) overlevde NiceGUI-migreringen, men UI-koblingen forsvant. Denne PR-en gjeninnfører
den, både for self-hosted og hostet.

## Endringer

- **Delt UI:** ny «Importer fra SAF-T»-knapp ved siden av «Hent tall fra Bodil»
  i `DataSkjema`, med opplasting for inneværende og foregående år. Begge
  forhåndsfyller bare skjemaet (samme `onLagre`-sti), så de er konfliktfrie
  søsken. Allerede utfylte styringsfelter (daglig leder, styreleder, aksjonærer)
  bevares ved import.
- **Parser:** `importer_bytes()` leser SAF-T fra minnet i stedet for disk;
  `importer()` (CLI) er uendret.
- **Backends:** tynt `/api/saft/import` i begge apper (self-hosted lokalt,
  hostet bak `krev_invitert`). Knappen vises kun der bindingen er injisert.
- **Docs:** oppdatert oppsett/tutorial/cli/hostet.
- Bump 0.30.0.

## Personvern

SAF-T parses fra rå body i minnet, 1 MB-grense så ingenting spiller over til temp-fil, ingen logging, ingenting lagres. Hostet behandler i EØS (Stockholm). SAF-T inneholder ikke fødselsnummer. Verifisert empirisk: ingen fil skrives til disk under parsing.

## Test plan

- [x] Enhetstester for parseren (manglet før) + route-tester for begge apper
- [x] `pytest`: 340 grønt
- [x] `npm run build` begge SPA-er (typesjekket)
- [x] Manuell verifisering mot kjørende server: inneværende/foregående år, 422/413/400, ingen disk-skriving