### PR TITLE
feat(hosted): selvbetjent testbruker-tilgang via Enhetsregisteret

### DIFF
--- a/hosted/README.md
+++ b/hosted/README.md
@@ -9,6 +9,13 @@ Status: **live på https://app.wenche.cloud** (invite-only). Onboarding: en **pe
 invite-lenke** som invite-only-port, og Altinn systembruker-godkjenning (BankID) som selve
 autorisasjonen. Ingen e-post, passord eller database.
 
+Valgfritt kan **selvbetjent tilgang** skrus på (`HOSTED_SELVBETJENING=1`): en bruker som står
+som aktiv daglig leder eller styremedlem i Enhetsregisteret for et orgnr får da tilgang med en
+gang, uten manuell invitasjon. Navnet brukes kun transient til ett oppslag mot åpne
+registerdata og lagres ikke. Det er proporsjonal støydemping, ikke identitetsbevis, så
+AlreadyApproved-snarveien (binding uten BankID) gjelder ikke for selvbetjente økter; et
+alt-onboardet selskap krever fortsatt manuell invitasjon. Av som standard.
+
 ## Komponenter
 - `api/` — FastAPI JSON-API (importerer `wenche`).
 - `web/` — SPA (React + Vite + TypeScript + Tailwind 4). Tynn happy-path: innlogging →
@@ -36,6 +43,8 @@ Per-org invite-lenker lages med `./.venv/bin/python hosted/mint_invite.py <orgnr
 | `HOSTED_INVITE_SECRET` | Signerer invite-lenken. Roter for å ugyldiggjøre utdelte lenker. |
 | `HOSTED_CORS_ORIGINS` | Tillatte frontend-origins (default `http://localhost:5173`). |
 | `HOSTED_PUBLIC_URL` | App-origin som invite-lenken peker på (default `http://localhost:5173`). |
+| `HOSTED_SELVBETJENING` | (valgfri) `1`/`true` skrur på selvbetjent tilgang (navn + orgnr verifiseres mot Enhetsregisteret). Av som standard. |
+| `HOSTED_KONTAKT` | (valgfri) Kontaktvei som vises når selvbetjent verifisering ikke gir treff. `mailto:`- eller https-URL (default `mailto:hello@olefredrik.com`). |
 | `HOSTED_VENDOR_ORGNR` | Operatørens organisasjonsnummer (vendor). |
 | `HOSTED_VENDOR_CLIENT_ID` | Operatørens Maskinporten-klient-ID. |
 | `HOSTED_VENDOR_KID` | Operatørens nøkkel-ID (KID). |

--- a/hosted/api/auth.py
+++ b/hosted/api/auth.py
@@ -10,10 +10,20 @@ Onboarding-modellen (besluttet): per-org invite-lenke + BankID.
   systembruker.py. En lekket invite-lenke er avgrenset til det ene selskapet i tokenet
   (og kan tilbakekalles ved rotasjon), ikke evnen til å sende inn for en vilkårlig org.
 
+Selvbetjent tilgang (be_om_tilgang): når operatøren har skrudd på HOSTED_SELVBETJENING kan en
+som står som aktiv daglig leder eller styremedlem i Enhetsregisteret for et orgnr få tilgang
+med en gang, uten manuell utdeling. Verifiseringen er en proporsjonal støydempingssjekk, ikke
+en festning: den hindrer at noen trigger en Altinn-systembruker-forespørsel mot et vilkårlig
+selskap de ikke har noe med å gjøre, mens BankID-godkjenningen i Altinn forblir den reelle
+porten. Navnet brukes kun transient til matching mot åpne registerdata og lagres aldri.
+
 Ingen e-post, ingen passord, ingen database.
 """
 import secrets
+import time
+from collections import defaultdict, deque
 
+import httpx
 from fastapi import APIRouter, Request
 from itsdangerous import BadSignature, URLSafeSerializer
 from pydantic import BaseModel
@@ -25,6 +35,20 @@ router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 _SALT = "invite"
 
+# Enhetsregisterets åpne rolle-endepunkt (gratis, ingen auth). Gir navn på daglig leder og
+# styre som offentlig data, slik at vi kan bekrefte at forespørgeren plausibelt hører til
+# orgnummeret uten å samle inn eller lagre noe.
+_BRREG_ROLLER_URL = "https://data.brreg.no/enhetsregisteret/api/enheter/{org}/roller"
+
+# Lett, in-memory rate-limit (én worker med vilje, så et dict holder). Demper enumerering av
+# registeret via tilgangsskjemaet; nullstilles ved restart, helt greit for formålet.
+_RATE: dict[str, deque] = defaultdict(deque)
+_RATE_VINDU = 600.0  # sekunder
+_RATE_MAKS = 20
+
+# MOD11-vekter for organisasjonsnummerets kontrollsiffer.
+_MOD11_VEKTER = (3, 2, 7, 6, 5, 4, 3, 2)
+
 
 def _serializer() -> URLSafeSerializer:
     return URLSafeSerializer(settings().invite_secret, salt=_SALT)
@@ -35,8 +59,86 @@ def lag_invite_token(org: str) -> str:
     return _serializer().dumps({"org": str(org).strip()})
 
 
+def _normaliser_orgnr(raa: str) -> str:
+    return "".join(c for c in raa if c.isdigit())
+
+
+def _gyldig_orgnr(orgnr: str) -> bool:
+    """Ni siffer med gyldig MOD11-kontrollsiffer. Avviser åpenbart ugyldige før registeroppslag."""
+    if len(orgnr) != 9 or not orgnr.isdigit():
+        return False
+    sum_ = sum(int(orgnr[i]) * _MOD11_VEKTER[i] for i in range(8))
+    rest = sum_ % 11
+    kontroll = 0 if rest == 0 else 11 - rest
+    return kontroll != 10 and kontroll == int(orgnr[8])
+
+
+def _tokens(navn: str) -> set[str]:
+    return {t for t in navn.lower().replace("-", " ").split() if t}
+
+
+def _navn_matcher(innsendt: str, kandidater: list[str]) -> bool:
+    """
+    Tolerant navnematch: den minste navnemengden må være en delmengde av den andre, og begge
+    må ha minst to ledd. Håndterer utelatt/ekstra mellomnavn begge veier (f.eks. «Ole Lie» mot
+    «Ole Fredrik Lie»), uten å matche på et enkelt vanlig navneledd alene.
+    """
+    inn = _tokens(innsendt)
+    if len(inn) < 2:
+        return False
+    for kand in kandidater:
+        k = _tokens(kand)
+        if len(k) < 2:
+            continue
+        liten, stor = (inn, k) if len(inn) <= len(k) else (k, inn)
+        if liten <= stor:
+            return True
+    return False
+
+
+def _hent_rolleinnehavere(orgnr: str) -> list[str]:
+    """Navn på aktive daglig leder/styre fra Enhetsregisteret. Tom liste om selskapet/rollen mangler."""
+    resp = httpx.get(
+        _BRREG_ROLLER_URL.format(org=orgnr),
+        headers={"Accept": "application/json"},
+        timeout=10,
+    )
+    if resp.status_code == 404:
+        return []
+    resp.raise_for_status()
+    navn: list[str] = []
+    for gruppe in resp.json().get("rollegrupper", []):
+        for rolle in gruppe.get("roller", []):
+            if rolle.get("fratraadt") or rolle.get("avregistrert"):
+                continue
+            person = rolle.get("person") or {}
+            if person.get("erDoed"):
+                continue
+            n = person.get("navn") or {}
+            fullt = " ".join(d for d in (n.get("fornavn"), n.get("mellomnavn"), n.get("etternavn")) if d)
+            if fullt:
+                navn.append(fullt)
+    return navn
+
+
+def _rate_ok(nokkel: str) -> bool:
+    naa = time.monotonic()
+    q = _RATE[nokkel]
+    while q and naa - q[0] > _RATE_VINDU:
+        q.popleft()
+    if len(q) >= _RATE_MAKS:
+        return False
+    q.append(naa)
+    return True
+
+
 class InviteBody(BaseModel):
     token: str
+
+
+class TilgangBody(BaseModel):
+    navn: str
+    org: str
 
 
 @router.post("/invite")
@@ -49,21 +151,78 @@ def bruk_invite(body: InviteBody, request: Request) -> dict:
     org = payload.get("org") if isinstance(payload, dict) else None
     if not org:
         return {"invited": False, "feil": "Ugyldig invite-lenke."}
+    _grant(request, str(org).strip(), via_selvbetjening=False)
+    return {"invited": True, "invite_org": str(org).strip()}
+
+
+def _grant(request: Request, orgnr: str, *, via_selvbetjening: bool) -> None:
+    """
+    Bind sesjonen til orgnr, samme effekt som en innløst invite-lenke.
+
+    via_selvbetjening skiller tillitsanker: en operatør-myntet invite-lenke (False) er en
+    manuell, verifisert utdeling, mens selvbetjening (True) bare er et navneoppslag mot
+    offentlige data. Skillet brukes til å nekte AlreadyApproved-snarveien for selvbetjente
+    økter (se systembruker.request_systembruker), så BankID forblir reell port der.
+    """
     request.session["invited"] = True
-    request.session["invite_org"] = str(org).strip()
+    request.session["invite_org"] = orgnr
+    request.session["via_selvbetjening"] = via_selvbetjening
     if not request.session.get("sid"):
         request.session["sid"] = secrets.token_urlsafe(16)
-    return {"invited": True, "invite_org": str(org).strip()}
+
+
+@router.post("/be-om-tilgang")
+def be_om_tilgang(body: TilgangBody, request: Request) -> dict:
+    """
+    Selvbetjent tilgang: bekreft at navnet står som aktiv daglig leder/styremedlem for orgnr
+    i Enhetsregisteret, og gi i så fall tilgang med en gang (ingen e-post, ingenting lagret).
+    Ved bom returneres en kontaktvei for manuelle tilfeller.
+    """
+    s = settings()
+    if not s.selvbetjening:
+        return {"invited": False, "feil": "Selvbetjent tilgang er ikke åpen ennå.", "kontakt": s.kontakt}
+
+    klient_ip = request.headers.get("fly-client-ip") or (request.client.host if request.client else "ukjent")
+    if not _rate_ok(klient_ip):
+        return {"invited": False, "feil": "For mange forsøk. Vent litt og prøv igjen.", "kontakt": s.kontakt}
+
+    orgnr = _normaliser_orgnr(body.org)
+    if not _gyldig_orgnr(orgnr):
+        return {"invited": False, "feil": "Ugyldig organisasjonsnummer.", "kontakt": s.kontakt}
+    if len(_tokens(body.navn)) < 2:
+        return {"invited": False, "feil": "Skriv inn fullt navn (fornavn og etternavn).", "kontakt": s.kontakt}
+
+    try:
+        rolleinnehavere = _hent_rolleinnehavere(orgnr)
+    except httpx.HTTPError:
+        return {
+            "invited": False,
+            "feil": "Fikk ikke kontakt med Enhetsregisteret. Prøv igjen om litt.",
+            "kontakt": s.kontakt,
+        }
+
+    if not _navn_matcher(body.navn, rolleinnehavere):
+        return {
+            "invited": False,
+            "feil": "Jeg fant ikke navnet ditt som registrert daglig leder eller styremedlem "
+            "for dette selskapet.",
+            "kontakt": s.kontakt,
+        }
+
+    _grant(request, orgnr, via_selvbetjening=True)
+    return {"invited": True, "invite_org": orgnr}
 
 
 @router.get("/me")
 def me(request: Request) -> dict:
     """Sesjonsstatus: invitert?, hvilket selskap invitasjonen gjelder, og evt. bundet kunde-org."""
+    s = settings()
     if not request.session.get("invited"):
-        return {"invited": False}
+        # Gatesiden trenger å vite om den skal vise selvbetjeningsskjemaet og hvor man ellers
+        # tar kontakt. Begge er ikke-sensitiv config.
+        return {"invited": False, "selvbetjening": s.selvbetjening, "kontakt": s.kontakt}
     sid = request.session.get("sid")
     st = sesjon.hent(sid) if sid else None
-    s = settings()
     return {
         "invited": True,
         "invite_org": request.session.get("invite_org"),

--- a/hosted/api/config.py
+++ b/hosted/api/config.py
@@ -37,6 +37,15 @@ class Settings:
         # Demo-modus: viser en «dette er en demo mot tt02»-banner i SPA-en. Rent informativt,
         # endrer ikke funksjonalitet. Settes kun på demo-appen (aldri i prod).
         self.demo_mode: bool = os.getenv("HOSTED_DEMO_MODE", "").lower() in ("1", "true", "yes")
+        # Selvbetjent tilgang: når på, kan en som står som aktiv daglig leder eller
+        # styremedlem i Enhetsregisteret for et orgnr få tilgang umiddelbart, uten manuell
+        # invitasjon. Verifiseringen skjer mot åpne data og lagrer ingenting; den er bare
+        # støydemping (BankID-godkjenningen i Altinn er den reelle porten). Av som standard,
+        # skru på når testbetaen skal åpnes, og av igjen for å stenge selvbetjeningen.
+        self.selvbetjening: bool = os.getenv("HOSTED_SELVBETJENING", "").lower() in ("1", "true", "yes")
+        # Kontaktvei som vises når selvbetjent verifisering ikke gir treff (skjermet person,
+        # navneavvik, selskap uten registrert rolleinnehaver). mailto:- eller https-URL.
+        self.kontakt: str = os.getenv("HOSTED_KONTAKT", "mailto:hello@olefredrik.com")
         self.vendor_orgnr = os.getenv("HOSTED_VENDOR_ORGNR")
         self._vendor_client_id = os.getenv("HOSTED_VENDOR_CLIENT_ID")
         self._vendor_kid = os.getenv("HOSTED_VENDOR_KID")

--- a/hosted/api/systembruker.py
+++ b/hosted/api/systembruker.py
@@ -16,6 +16,7 @@ from fastapi import APIRouter, HTTPException, Request
 
 from wenche import systembruker as wsb
 
+from .config import settings
 from .deps import admin_token, krev_invite_org, krev_invitert, krev_vendor
 
 logger = logging.getLogger("wenche.hosted.systembruker")
@@ -33,6 +34,11 @@ def request_systembruker(request: Request) -> dict:
     Gjenkommende kunde: har org allerede en godkjent systembruker for vårt system,
     bindes kunde-org direkte (ingen ny BankID-godkjenning). Ny kunde: opprett
     forespørsel og returner godkjenningslenke.
+
+    Unntak for selvbetjente økter: AlreadyApproved-snarveien hopper over BankID, og
+    selvbetjent tilgang er bare et navneoppslag mot offentlige data (ikke identitetsbevis).
+    Å honorere snarveien der ville latt en som kjenner et offentlig styremedlemsnavn sende
+    inn for et alt-onboardet selskap. Slike krever derfor manuell invitasjon.
     """
     st = krev_invitert(request)
     org = krev_invite_org(request)
@@ -40,6 +46,12 @@ def request_systembruker(request: Request) -> dict:
     token = admin_token(creds)
     eksisterende = wsb.hent_systembrukere(token, vendor_orgnr)
     if any(b.get("reporteeOrgNo") == org for b in eksisterende):
+        if request.session.get("via_selvbetjening"):
+            raise HTTPException(
+                status_code=409,
+                detail="Dette selskapet er allerede satt opp i Wenche. Av sikkerhetsgrunner "
+                "kobles slike bare via en invitasjon. Ta kontakt: " + settings().kontakt + ".",
+            )
         st.kunde_org = org
         st.pending_org = None
         st.request_id = None

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, type FormEvent } from "react";
 import { api } from "./api";
 import { sporSidevisning, sporHendelse } from "./sporing";
 import {
@@ -27,6 +27,8 @@ interface Me {
   kunde_org?: string | null;
   env?: string;
   demo?: boolean;
+  selvbetjening?: boolean;
+  kontakt?: string | null;
 }
 
 function DemoBanner() {
@@ -70,15 +72,108 @@ const HOSTET_SAMTYKKE = (
   </span>
 );
 
-function KunInviterte() {
+// Vis en kontaktvei (mailto: eller https) som en klikkbar lenke, med lesbar tekst.
+function KontaktLenke({ kontakt }: { kontakt?: string | null }) {
+  if (!kontakt) return null;
+  const tekst = kontakt.startsWith("mailto:") ? kontakt.slice("mailto:".length) : kontakt.replace(/^https?:\/\//, "");
+  return (
+    <a
+      href={kontakt}
+      target={kontakt.startsWith("mailto:") ? undefined : "_blank"}
+      rel="noopener noreferrer"
+      className="text-spruce underline-offset-2 hover:underline"
+    >
+      {tekst}
+    </a>
+  );
+}
+
+const tilgangInput =
+  "w-full rounded-md border border-border bg-background px-4 py-2.5 text-sm outline-none focus:border-spruce";
+
+function KunInviterte({ me, onApproved }: { me: Me; onApproved: () => void }) {
+  const [navn, setNavn] = useState("");
+  const [org, setOrg] = useState("");
+  const [sender, setSender] = useState(false);
+  const [feil, setFeil] = useState<string | null>(null);
+
+  const send = async (e: FormEvent) => {
+    e.preventDefault();
+    setFeil(null);
+    setSender(true);
+    try {
+      const r = await api.beOmTilgang(navn, org);
+      if (r.invited) {
+        sporHendelse("tilgang-innvilget");
+        onApproved();
+      } else {
+        sporHendelse("tilgang-avvist");
+        setFeil(r.feil ?? "Kunne ikke gi tilgang.");
+      }
+    } catch (err) {
+      setFeil((err as Error).message);
+    } finally {
+      setSender(false);
+    }
+  };
+
   return (
     <Kort>
       <p className={monoLabel}>Tilgang</p>
-      <h1 className="mt-3 font-display text-3xl font-normal">Wenche er kun for inviterte</h1>
+      <h1 className="mt-3 font-display text-3xl font-normal">Wenche er foreløpig for inviterte</h1>
       <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
-        Har du en invite-lenke, åpne den for å komme i gang. Ellers er tjenesten foreløpig
-        lukket.
+        Tjenesten er ennå i en lukket testfase mens jeg får den gjennomtestet og stabil.
       </p>
+
+      {me.selvbetjening ? (
+        <>
+          <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+            Vil du være testbruker? Skriv inn navnet ditt og organisasjonsnummeret til selskapet du
+            vil sende inn for. Står du som daglig leder eller styremedlem i Enhetsregisteret, får du
+            tilgang med en gang. Navnet ditt brukes bare til dette oppslaget og lagres ikke.
+          </p>
+          <form className="mt-6 space-y-4" onSubmit={send}>
+            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+              <label className="block">
+                <span className="mb-1 block text-xs text-muted-foreground">Fullt navn</span>
+                <input
+                  className={tilgangInput}
+                  autoComplete="name"
+                  value={navn}
+                  onChange={(e) => setNavn(e.target.value)}
+                  aria-invalid={!!feil}
+                  required
+                />
+              </label>
+              <label className="block">
+                <span className="mb-1 block text-xs text-muted-foreground">Organisasjonsnummer</span>
+                <input
+                  className={tilgangInput}
+                  inputMode="numeric"
+                  autoComplete="off"
+                  value={org}
+                  onChange={(e) => setOrg(e.target.value)}
+                  aria-invalid={!!feil}
+                  required
+                />
+              </label>
+            </div>
+            <button className={`${btnPrimar} w-full sm:w-auto`} type="submit" disabled={sender}>
+              {sender ? "Sjekker…" : "Be om tilgang"}
+            </button>
+          </form>
+          {feil && (
+            <p role="alert" className="mt-4 text-sm leading-relaxed text-red-700">
+              {feil} Stemmer ikke dette, eller har du skjermet adresse, ta kontakt:{" "}
+              <KontaktLenke kontakt={me.kontakt} />.
+            </p>
+          )}
+        </>
+      ) : (
+        <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+          Vil du være testbruker? Ta kontakt: <KontaktLenke kontakt={me.kontakt} />.
+        </p>
+      )}
     </Kort>
   );
 }
@@ -476,7 +571,7 @@ export default function App() {
         {!me ? (
           <p className="text-sm text-muted-foreground">Laster…</p>
         ) : !me.invited ? (
-          <KunInviterte />
+          <KunInviterte me={me} onApproved={refresh} />
         ) : !me.kunde_org ? (
           // Port: før selskapet er koblet er dette den eneste skjermen (ingen steg).
           <HjemFane me={me} onChange={refresh} />

--- a/hosted/web/src/api.ts
+++ b/hosted/web/src/api.ts
@@ -6,6 +6,9 @@ export const api = {
   me: () => req("/api/auth/me"),
   invite: (token: string) =>
     req("/api/auth/invite", { method: "POST", body: JSON.stringify({ token }) }),
+  // Selvbetjent tilgang: navn + orgnr verifiseres mot Enhetsregisteret. Navnet lagres ikke.
+  beOmTilgang: (navn: string, org: string) =>
+    req("/api/auth/be-om-tilgang", { method: "POST", body: JSON.stringify({ navn, org }) }),
   logout: () => req("/api/auth/logout", { method: "POST" }),
   systembrukerRequest: () => req("/api/systembruker/request", { method: "POST" }),
   systembrukerStatus: () => req("/api/systembruker/status", { method: "POST" }),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.30.0"
+version = "0.31.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_hosted_invite.py
+++ b/tests/test_hosted_invite.py
@@ -76,8 +76,17 @@ def _gyldig_config(org="314273818"):
 
 
 def test_uten_invite_er_stengt(klient):
-    assert klient.get("/api/auth/me").json() == {"invited": False}
+    me = klient.get("/api/auth/me").json()
+    assert me["invited"] is False
+    assert me["selvbetjening"] is False  # av som standard
     assert klient.post("/api/systembruker/request").status_code == 401
+
+
+def test_be_om_tilgang_av_som_standard(klient):
+    """Selvbetjening er av med mindre operatøren skrur den på; skjemaet skal avvises da."""
+    r = klient.post("/api/auth/be-om-tilgang", json={"navn": "Ole Lie", "org": "922020523"})
+    assert r.json()["invited"] is False
+    assert klient.get("/api/auth/me").json()["invited"] is False
 
 
 def test_ugyldig_og_gammelt_token_avvises(klient):
@@ -169,6 +178,123 @@ def test_innsending_uten_binding_gir_409(klient, monkeypatch):
     # Ingen systembruker/request → kunde_org ikke bundet i serverminnet.
     r = klient.post("/api/innsending/aarsregnskap?dry_run=false", json=_gyldig_config())
     assert r.status_code == 409
+
+
+@pytest.fixture
+def klient_selvbetjening(monkeypatch):
+    """Som klient, men med selvbetjent tilgang påskrudd og en kjent kontaktvei."""
+    monkeypatch.setenv("WENCHE_ENV", "test")
+    monkeypatch.setenv("HOSTED_SESSION_SECRET", "test-session-secret")
+    monkeypatch.setenv("HOSTED_INVITE_SECRET", _INVITE_SECRET)
+    monkeypatch.setenv("HOSTED_SELVBETJENING", "1")
+    monkeypatch.setenv("HOSTED_KONTAKT", "mailto:test@wenche.cloud")
+    from hosted.api import config
+
+    config.settings.cache_clear()
+    from hosted.api import main as main_mod
+
+    importlib.reload(main_mod)
+    import hosted.api.auth as auth_mod
+
+    auth_mod._RATE.clear()  # in-memory rate-limit lever på tvers av tester
+    with TestClient(main_mod.app) as klient:
+        yield klient
+    config.settings.cache_clear()
+
+
+def _brreg_rollesvar(*navn):
+    """Fake Enhetsregister-rollesvar med gitte 'Fornavn Etternavn'-strenger som styremedlemmer."""
+    roller = []
+    for fullt in navn:
+        deler = fullt.split()
+        roller.append({
+            "type": {"kode": "MEDL"},
+            "fratraadt": False,
+            "avregistrert": False,
+            "person": {"erDoed": False, "navn": {"fornavn": " ".join(deler[:-1]), "etternavn": deler[-1]}},
+        })
+    return SimpleNamespace(
+        status_code=200,
+        raise_for_status=lambda: None,
+        json=lambda: {"rollegrupper": [{"type": {"kode": "STYR"}, "roller": roller}]},
+    )
+
+
+def _stub_brreg(monkeypatch, svar):
+    import hosted.api.auth as auth_mod
+
+    monkeypatch.setattr(auth_mod.httpx, "get", lambda *a, **k: svar)
+
+
+def test_me_eksponerer_selvbetjening(klient_selvbetjening):
+    me = klient_selvbetjening.get("/api/auth/me").json()
+    assert me["invited"] is False
+    assert me["selvbetjening"] is True
+    assert me["kontakt"] == "mailto:test@wenche.cloud"
+
+
+def test_be_om_tilgang_match_gir_tilgang(klient_selvbetjening, monkeypatch):
+    """Navn som matcher en aktiv rolleinnehaver gir tilgang umiddelbart, bundet til orgnr."""
+    _stub_brreg(monkeypatch, _brreg_rollesvar("Ole Fredrik Lie"))
+    # «Ole Lie» er en delmengde av «Ole Fredrik Lie» → match til tross for utelatt mellomnavn.
+    r = klient_selvbetjening.post(
+        "/api/auth/be-om-tilgang", json={"navn": "Ole Lie", "org": "922 020 523"}
+    ).json()
+    assert r == {"invited": True, "invite_org": "922020523"}
+    me = klient_selvbetjening.get("/api/auth/me").json()
+    assert me["invited"] is True and me["invite_org"] == "922020523"
+
+
+def test_be_om_tilgang_uten_match_avvises(klient_selvbetjening, monkeypatch):
+    _stub_brreg(monkeypatch, _brreg_rollesvar("Kari Nordmann"))
+    r = klient_selvbetjening.post(
+        "/api/auth/be-om-tilgang", json={"navn": "Ole Lie", "org": "922020523"}
+    ).json()
+    assert r["invited"] is False
+    assert r["kontakt"] == "mailto:test@wenche.cloud"
+    assert klient_selvbetjening.get("/api/auth/me").json()["invited"] is False
+
+
+def test_be_om_tilgang_ugyldig_orgnr_uten_oppslag(klient_selvbetjening, monkeypatch):
+    """Ugyldig MOD11 avvises før vi i det hele tatt slår opp i registeret."""
+    import hosted.api.auth as auth_mod
+
+    def feil(*a, **k):
+        raise AssertionError("skal ikke slå opp i Enhetsregisteret ved ugyldig orgnr")
+
+    monkeypatch.setattr(auth_mod.httpx, "get", feil)
+    r = klient_selvbetjening.post(
+        "/api/auth/be-om-tilgang", json={"navn": "Ole Lie", "org": "123456789"}
+    ).json()
+    assert r["invited"] is False and "rganisasjonsnummer" in r["feil"]
+
+
+def test_be_om_tilgang_krever_fullt_navn(klient_selvbetjening, monkeypatch):
+    _stub_brreg(monkeypatch, _brreg_rollesvar("Ole Fredrik Lie"))
+    r = klient_selvbetjening.post(
+        "/api/auth/be-om-tilgang", json={"navn": "Ole", "org": "922020523"}
+    ).json()
+    assert r["invited"] is False
+
+
+def test_selvbetjening_nektes_already_approved_snarvei(klient_selvbetjening, monkeypatch):
+    """
+    Sikkerhetsegenskap: selvbetjent tilgang er bare et offentlig navneoppslag, så
+    AlreadyApproved-snarveien (binding uten BankID) skal IKKE gjelde. Et alt-onboardet
+    selskap kan dermed ikke kapres av en som kjenner et offentlig styremedlemsnavn.
+    """
+    _stub_vendor(monkeypatch)
+    # Selskapet har alt en godkjent systembruker:
+    monkeypatch.setattr(sb.wsb, "hent_systembrukere", lambda tok, vendor: [{"reporteeOrgNo": "922020523"}])
+    _stub_brreg(monkeypatch, _brreg_rollesvar("Ole Fredrik Lie"))
+
+    assert klient_selvbetjening.post(
+        "/api/auth/be-om-tilgang", json={"navn": "Ole Lie", "org": "922020523"}
+    ).json()["invited"] is True
+    # Snarveien nektes; kunde-org blir aldri bundet uten manuell invitasjon.
+    r = klient_selvbetjening.post("/api/systembruker/request")
+    assert r.status_code == 409
+    assert klient_selvbetjening.get("/api/auth/me").json()["kunde_org"] is None
 
 
 def test_prod_uten_secrets_nekter_oppstart(monkeypatch):


### PR DESCRIPTION
## Bakgrunn

Den hostede tjenesten har vært ren invite-only, der hver tilgang krever en manuelt myntet, utdelt invite-lenke. For å åpne en testbeta uten å basere meg på å sende ut lenker (og uten å samle inn e-post/orgnr via en tredjepart med GDPR-byrde), legger denne PR-en til en valgfri selvbetjent tilgang.

## Endringer

- **Selvbetjeningsskjema på gatesiden:** bruker skriver inn navn + orgnr. Backend (`/api/auth/be-om-tilgang`) slår opp aktive daglig leder/styre i Enhetsregisterets åpne rolle-API og binder økten til selskapet ved navnematch, samme effekt som en innløst invite-lenke. Navnet brukes kun transient til oppslaget og lagres ikke. MOD11-validering, tolerant navnematch og lett in-memory rate-limit.
- **Sikkerhetsvakt:** AlreadyApproved-snarveien (binding uten BankID) nektes for selvbetjente økter, så BankID-godkjenningen i Altinn forblir reell port. Uten dette kunne en som kjenner et offentlig styremedlemsnavn sendt inn for et alt-onboardet selskap. Invite-lenke-flyten er uberørt.
- **Av som standard** bak `HOSTED_SELVBETJENING`; kontaktvei ved bom via `HOSTED_KONTAKT`. Toggles på Fly uten deploy.
- **Gateside omskrevet:** beta-forklaring (manuell-lenke-setning fjernet), to-kolonners skjema med synlige labels + ARIA, kontaktvei ved bom.
- README oppdatert med de to nye env-variablene. Versjonsbump 0.30.0 → 0.31.0.

## Vurdert og avslått

- **Async waitlist / e-post-utsending:** krever en kanal for å levere lenken tilbake, og lagring av kontaktdata. Synkron verifisering sidesteg begge.
- **ID-porten/reportees på app-nivå:** for tungt/dyrt for en gratis testbeta; brreg-rolle-sjekk + BankID-backstop er proporsjonalt.

## Test plan

- [x] Match (utelatt mellomnavn) gir tilgang, bundet til orgnr
- [x] Feil navn / ugyldig MOD11-orgnr / bare fornavn avvises med kontaktvei
- [x] Selvbetjent økt mot alt-onboardet selskap nektes AlreadyApproved (409)
- [x] Selvbetjening av som standard; `/me` eksponerer flagg + kontakt
- [x] Hele suiten grønn (347), SPA bygger rent