### PR TITLE
fix(build): ta med bygd SPA i sdist så wheelen ikke mister den

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,8 @@ jobs:
           node-version: "20"
 
       - name: Bygg self-hosted SPA
-        # Den bygde SPA-en (wenche/web/static) force-includes i wheelen (pip-brukere har
-        # ikke Node). Må bygges før `python -m build`.
+        # Den bygde SPA-en (wenche/web/static) tas med i sdist og wheel via `artifacts` i
+        # pyproject.toml (pip-brukere har ikke Node). Må bygges før `python -m build`.
         run: |
           npm ci
           npm run build --workspace wenche/web/frontend
@@ -34,6 +34,13 @@ jobs:
         run: |
           pip install build
           python -m build
+
+      - name: Verifiser at SPA-en er med i wheelen
+        # Vakt mot regresjon av issue #121: en wheel uten den bygde SPA-en gir 404 på `/`
+        # for pip-brukere. Feil høylytt her heller enn å publisere en ødelagt wheel.
+        run: |
+          unzip -l dist/*.whl | grep -q "wenche/web/static/index.html" \
+            || { echo "ERROR: SPA (wenche/web/static) mangler i wheelen"; exit 1; }
 
       - name: Last opp til PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.31.0"
+version = "0.31.1"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -43,11 +43,16 @@ Issues = "https://github.com/olefredrik/wenche/issues"
 [project.scripts]
 wenche = "wenche.cli:main"
 
+# Den bygde SPA-en (wenche/web/static) er git-ignorert (bygges ved release).
+# `artifacts` ligger på topp-nivå så den gjelder BÅDE sdist og wheel. Det er kritisk:
+# `python -m build` (uten flagg) bygger sdist først og bygger så wheelen FRA sdist-en, så
+# hvis static bare var deklarert under wheel-target ville den falle ut av sdist-en og dermed
+# mangle i wheel-bygget-fra-sdist (issue #121). `artifacts` (i motsetning til force-include)
+# feiler heller ikke når mappen mangler (editable-install, bidragsytere uten bygd frontend).
+[tool.hatch.build]
+artifacts = ["wenche/web/static/**"]
+
 [tool.hatch.build.targets.wheel]
 packages = ["wenche"]
 # Frontend-kilden (TS/Vite) hører ikke hjemme i wheelen, kun den bygde SPA-en serveres.
 exclude = ["wenche/web/frontend"]
-# Den bygde SPA-en ligger i wenche/web/static, som er git-ignorert (bygges ved release).
-# `artifacts` tar den med i wheelen når den finnes, men feiler ikke når den mangler (CI,
-# editable-install, bidragsytere som ikke har bygd front-enden) — i motsetning til force-include.
-artifacts = ["wenche/web/static/**"]


### PR DESCRIPTION
`python -m build` (uten flagg) bygger sdist først og bygger så wheelen FRA sdist-en. `artifacts` var bare deklarert under wheel-target, så den git-ignorerte wenche/web/static falt ut av sdist-en og manglet dermed i wheel-bygget-fra-sdist. Resultat: pip-installerte 0.30.0 og 0.31.0 ga HTTP 404 på `/`.

Løft `artifacts` til topp-nivå [tool.hatch.build] så den gjelder både sdist og wheel. `artifacts` (ikke force-include) beholder at bygget ikke feiler når mappen mangler (editable-install, bidragsytere uten bygd frontend).

Legg til en vakt i publish.yml som feiler hvis SPA-en mangler i wheelen, så en regresjon stopper før publisering.

Closes #121