### PR TITLE
fix(hosted): ikke vis mailto:-skjema i kontakttekst ved blokkert selvbetjening

### DIFF
--- a/hosted/api/config.py
+++ b/hosted/api/config.py
@@ -55,6 +55,15 @@ class Settings:
         self._vendor_key_path = os.getenv("HOSTED_VENDOR_KEY_PATH")
         self._fail_closed_i_prod()
 
+    @property
+    def kontakt_tekst(self) -> str:
+        """Kontaktverdien uten URL-skjema, for innfelling i ren tekst. `kontakt` lagres med
+        skjema (mailto:/https://) fordi den brukes som href; skjemaet skal ikke leses av en
+        bruker. Speiler KontaktLenke i frontend."""
+        if self.kontakt.startswith("mailto:"):
+            return self.kontakt[len("mailto:") :]
+        return self.kontakt.removeprefix("https://").removeprefix("http://")
+
     def _fail_closed_i_prod(self) -> None:
         """Nekt oppstart i prod hvis hemmelighetene ikke er overstyrt fra dev-standardene."""
         if self.env != "prod":

--- a/hosted/api/systembruker.py
+++ b/hosted/api/systembruker.py
@@ -50,7 +50,7 @@ def request_systembruker(request: Request) -> dict:
             raise HTTPException(
                 status_code=409,
                 detail="Dette selskapet er allerede satt opp i Wenche. Av sikkerhetsgrunner "
-                "kobles slike bare via en invitasjon. Ta kontakt: " + settings().kontakt + ".",
+                "kobles slike bare via en invitasjon. Ta kontakt: " + settings().kontakt_tekst + ".",
             )
         st.kunde_org = org
         st.pending_org = None

--- a/tests/test_hosted_invite.py
+++ b/tests/test_hosted_invite.py
@@ -294,6 +294,10 @@ def test_selvbetjening_nektes_already_approved_snarvei(klient_selvbetjening, mon
     # Snarveien nektes; kunde-org blir aldri bundet uten manuell invitasjon.
     r = klient_selvbetjening.post("/api/systembruker/request")
     assert r.status_code == 409
+    # Kontaktvei vises uten URL-skjema (ingen «mailto:» lekker inn i lesbar tekst).
+    detail = r.json()["detail"]
+    assert "test@wenche.cloud" in detail
+    assert "mailto:" not in detail
     assert klient_selvbetjening.get("/api/auth/me").json()["kunde_org"] is None
 
 


### PR DESCRIPTION
## Sammendrag

Ved blokkert selvbetjening (selskap alt onboardet, økt via navneoppslag) viste 409-meldingen
«Ta kontakt: **mailto:**» — URL-skjemaet lekket inn i lesbar tekst.
`kontakt` lagres med skjema fordi den brukes som href andre steder (`KontaktLenke` i frontend
stripper det), men denne backend-meldingen limte den inn som ren tekst.

## Endringer

- Ny `Settings.kontakt_tekst`-property som stripper `mailto:`/`https://`, brukt i 409-meldingen.
- Utvidet eksisterende test med assert på at `mailto:` ikke lekker inn i `detail`.

## Test plan

- [x] `pytest tests/test_hosted_invite.py` → 15/15
