### PR TITLE
fix(skattemelding): gjør eksempeldata gyldige og rett villedende valideringsforklaring

### DIFF
--- a/packages/ui/src/skjema.tsx
+++ b/packages/ui/src/skjema.tsx
@@ -154,8 +154,8 @@ function grunnConfig(): any {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const EKSEMPEL: any = {
   selskap: {
-    navn: "KORREKT FRISK TIGER AS",
-    org_nummer: "314273818",
+    navn: "MOTSTANDSDYKTIG ENTUSIASTISK TIGER AS",
+    org_nummer: "310137715",
     daglig_leder: "Daglig Leder",
     styreleder: "Daglig Leder",
     forretningsadresse: "Bergveien 23, 1890 RAKKESTAD",
@@ -163,7 +163,7 @@ const EKSEMPEL: any = {
     aksjekapital: 30000,
     kontakt_epost: "test@example.no",
   },
-  regnskapsaar: 2024,
+  regnskapsaar: 2025,
   resultatregnskap: {
     driftsinntekter: { salgsinntekter: 0, andre_driftsinntekter: 0 },
     driftskostnader: { loennskostnader: 0, avskrivninger: 0, andre_driftskostnader: 0 },
@@ -176,11 +176,11 @@ const EKSEMPEL: any = {
   },
   balanse: {
     eiendeler: {
-      anleggsmidler: { aksjer_i_datterselskap: 0, andre_aksjer: 0, langsiktige_fordringer: 0 },
+      anleggsmidler: { aksjer_i_datterselskap: 100000, andre_aksjer: 0, langsiktige_fordringer: 0 },
       omloepmidler: { kortsiktige_fordringer: 0, bankinnskudd: 30000 },
     },
     egenkapital_og_gjeld: {
-      egenkapital: { aksjekapital: 30000, overkursfond: 0, annen_egenkapital: 0 },
+      egenkapital: { aksjekapital: 30000, overkursfond: 0, annen_egenkapital: 100000 },
       langsiktig_gjeld: { laan_fra_aksjonaer: 0, andre_langsiktige_laan: 0 },
       kortsiktig_gjeld: {
         leverandoergjeld: 0,
@@ -189,11 +189,44 @@ const EKSEMPEL: any = {
       },
     },
   },
+  // Fjorårets balanse er identisk (passivt holding uten bevegelse i året), så
+  // egenkapitalavstemmingen går i null mot årsresultat 0. Uten foregående år
+  // ville hele utgående EK telt som «årets overskudd» og gitt avvik mot SKD.
+  foregaaende_aar: {
+    resultatregnskap: {
+      driftsinntekter: { salgsinntekter: 0, andre_driftsinntekter: 0 },
+      driftskostnader: { loennskostnader: 0, avskrivninger: 0, andre_driftskostnader: 0 },
+      finansposter: {
+        utbytte_fra_datterselskap: 0,
+        andre_finansinntekter: 0,
+        rentekostnader: 0,
+        andre_finanskostnader: 0,
+      },
+    },
+    balanse: {
+      eiendeler: {
+        anleggsmidler: { aksjer_i_datterselskap: 100000, andre_aksjer: 0, langsiktige_fordringer: 0 },
+        omloepmidler: { kortsiktige_fordringer: 0, bankinnskudd: 30000 },
+      },
+      egenkapital_og_gjeld: {
+        egenkapital: { aksjekapital: 30000, overkursfond: 0, annen_egenkapital: 100000 },
+        langsiktig_gjeld: { laan_fra_aksjonaer: 0, andre_langsiktige_laan: 0 },
+        kortsiktig_gjeld: {
+          leverandoergjeld: 0,
+          skyldige_offentlige_avgifter: 0,
+          annen_kortsiktig_gjeld: 0,
+        },
+      },
+    },
+  },
   skattemelding: {
     underskudd_til_fremfoering: 0,
-    anvend_fritaksmetoden: false,
+    anvend_fritaksmetoden: true,
     boersnotert: false,
-    formuesverdi_aksjer: 0,
+    // Formuesverdi av aksjene i datterselskapet (RF-1088S), erstatter bokført
+    // verdi i formuesgrunnlaget. Gir skattemeldingen formue-innhold så den ikke
+    // er «tom» mot næringsspesifikasjonen (UP_HAR_NÆRINGSSPESIFIKASJON_MANGLER_SKATTEMELDING).
+    formuesverdi_aksjer: 1200000,
   },
   aksjonaerer: [
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.31.1"
+version = "0.31.2"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_valideringskode_forklaringer.py
+++ b/tests/test_valideringskode_forklaringer.py
@@ -31,7 +31,7 @@ def test_forklarer_kjent_veiledningskode():
     )
     ut = formater_valideringsresultat(res)
     assert "Hva betyr dette?" in ut
-    assert "passive holdingselskaper" in ut
+    assert "passivt holdingselskap" in ut
     assert "utenfor" in ut
     assert "skatteetaten.no" in ut
 
@@ -58,4 +58,4 @@ def test_duplikate_koder_forklares_kun_en_gang():
         veiledning=[{"veiledningstype": kode, "hjelpetekst": "x"}],
     )
     ut = formater_valideringsresultat(res)
-    assert ut.count("passive holdingselskaper") == 1
+    assert ut.count("passivt holdingselskap") == 1

--- a/wenche/skd_skattemelding_client.py
+++ b/wenche/skd_skattemelding_client.py
@@ -316,10 +316,12 @@ def _parse_valideringsrespons(raw: bytes) -> dict:
 _KODE_FORKLARINGER = {
     "UP_HAR_NÆRINGSSPESIFIKASJON_MANGLER_SKATTEMELDING": (
         "Skattemeldingen inneholder ingen skattepliktige poster, mens "
-        "næringsspesifikasjonen har innhold. Wenche støtter kun passive "
-        "holdingselskaper (aksjeinntekt under fritaksmetoden). Selskaper med "
-        "ordinær drift og skattepliktig over- eller underskudd er utenfor "
-        "Wenches støtteområde og må levere via skatteetaten.no eller et "
+        "næringsspesifikasjonen har innhold. For et passivt holdingselskap "
+        "betyr det som regel at formuesgrunnlaget mangler: fyll inn "
+        "«Formuesverdi aksjer» (formuesverdien av aksjene i datterselskapet), "
+        "så får skattemeldingen et formuesgrunnlag bak aksjene. Har selskapet "
+        "derimot ordinær drift med skattepliktig over- eller underskudd, er det "
+        "utenfor Wenches støtteområde og må leveres via skatteetaten.no eller et "
         "regnskapsprogram."
     ),
     "innkommendeForespoerselManglerReferanseTilGjeldendeSkattemelding": (


### PR DESCRIPTION
## Bakgrunn

Demoen mot tt02 (`demo.wenche.cloud`) ble låst opp da Skatteetaten klargjorde demo-org 310137715 med forhåndsutfylt skattemelding for inntektsår 2024 og 2025. Første ende-til-ende-forsøk feilet likevel: eksempeldataene var tomme (alt på 0), så skattemeldingen ble uten skattepliktige poster mens næringsspesifikasjonen hadde innhold, og Skatteetaten avviste innsendingen med `UP_HAR_NÆRINGSSPESIFIKASJON_MANGLER_SKATTEMELDING`.

## Endringer

- **Gyldige eksempeldata** (`packages/ui/src/skjema.tsx`): EKSEMPEL er nå et realistisk passivt holdingselskap. `formuesverdi_aksjer` gir skattemeldingen et formuesgrunnlag, og `foregaaende_aar` gjør at egenkapitalavstemmingen går i null (fjerner også § 6-6-advarselen om manglende sammenligningstall). Org/navn/år
  satt til demo-org 310137715 / 2025.
- **Treffsikker feilforklaring** (`wenche/skd_skattemelding_client.py`): forklaringen for koden sa feilaktig at et gyldig passivt holding var «utenfor støtteområde». Den peker nå på manglende formuesverdi som vanligste årsak, og
  nevner ordinær drift kun som det sekundære tilfellet.
- **Versjon**: 0.31.1 → 0.31.2 (PATCH).

## Test plan

- [x] `pytest` (347 passerer), inkl. oppdatert `test_valideringskode_forklaringer`
- [x] Bygger: `npm run build --workspace hosted/web`
- [x] `valider` mot tt02 for 310137715 / 2025 → `validertOK`, ingen avvik/merknader
- [x] `valider_aarsregnskap` / `_aksjonaer` / `_skattemelding` → ok, ingen advarsler
- [x] Verifisert ende-til-ende i deployet demo (årsregnskap + aksjonær + skattemelding)
