### PR TITLE
feat(hosted): la en koblet økt fortsette på en annen enhet

### DIFF
--- a/hosted/README.md
+++ b/hosted/README.md
@@ -16,6 +16,13 @@ registerdata og lagres ikke. Det er proporsjonal støydemping, ikke identitetsbe
 AlreadyApproved-snarveien (binding uten BankID) gjelder ikke for selvbetjente økter; et
 alt-onboardet selskap krever fortsatt manuell invitasjon. Av som standard.
 
+**Fortsett på en annen enhet:** sesjonen lever per nettleser (signert cookie, ingen DB), så et
+andre apparat står i utgangspunktet uten tilkobling. En alt koblet økt kan derfor lage en
+kortvarig overføringslenke (vist som QR + lenke på Hjem), som den nye enheten åpner for å arve
+samme binding, uten ny BankID. Lenken er forankret i en alt verifisert økt (bundet `kunde_org`),
+ikke i offentlig registerkunnskap, og er ferskvare (5 min), så den omgår ikke selvbetjenings-
+sperren over.
+
 ## Komponenter
 - `api/` — FastAPI JSON-API (importerer `wenche`).
 - `web/` — SPA (React + Vite + TypeScript + Tailwind 4). Tynn happy-path: innlogging →

--- a/hosted/README.md
+++ b/hosted/README.md
@@ -18,10 +18,11 @@ alt-onboardet selskap krever fortsatt manuell invitasjon. Av som standard.
 
 **Fortsett på en annen enhet:** sesjonen lever per nettleser (signert cookie, ingen DB), så et
 andre apparat står i utgangspunktet uten tilkobling. En alt koblet økt kan derfor lage en
-kortvarig overføringslenke (vist som QR + lenke på Hjem), som den nye enheten åpner for å arve
-samme binding, uten ny BankID. Lenken er forankret i en alt verifisert økt (bundet `kunde_org`),
-ikke i offentlig registerkunnskap, og er ferskvare (5 min), så den omgår ikke selvbetjenings-
-sperren over.
+kortvarig lenke (vist som QR + lenke på Hjem), som den nye enheten åpner for å arve samme
+binding, uten ny BankID. Tilkoblingen **kopieres** (den flyttes ikke): begge enheter forblir
+koblet, og hver enhet logges ut for seg. Lenken er forankret i en alt verifisert økt (bundet
+`kunde_org`), ikke i offentlig registerkunnskap, og er ferskvare (5 min), så den omgår ikke
+selvbetjeningssperren over.
 
 ## Komponenter
 - `api/` — FastAPI JSON-API (importerer `wenche`).

--- a/hosted/api/auth.py
+++ b/hosted/api/auth.py
@@ -17,14 +17,21 @@ en festning: den hindrer at noen trigger en Altinn-systembruker-forespørsel mot
 selskap de ikke har noe med å gjøre, mens BankID-godkjenningen i Altinn forblir den reelle
 porten. Navnet brukes kun transient til matching mot åpne registerdata og lagres aldri.
 
+Fortsett på en annen enhet (handoff): sesjonen lever per nettleser (signert cookie, ingen DB),
+så en ny enhet har ingen binding. En alt fullført økt (bundet kunde_org, altså en enhet som
+har vært gjennom invite/BankID) kan lage en kortvarig, signert overføringslenke som den nye
+enheten åpner for å arve samme binding. Tilliten er forankret i en eksisterende, verifisert
+økt, ikke i offentlig registerkunnskap, så den er uavhengig av selvbetjeningssperren i
+systembruker.request_systembruker. Lenken er ferskvare (HANDOFF_MAKS_ALDER), ikke engangsbruk.
+
 Ingen e-post, ingen passord, ingen database.
 """
 import time
 from collections import defaultdict, deque
 
 import httpx
-from fastapi import APIRouter, Request
-from itsdangerous import BadSignature, URLSafeSerializer
+from fastapi import APIRouter, HTTPException, Request
+from itsdangerous import BadSignature, SignatureExpired, URLSafeSerializer, URLSafeTimedSerializer
 from pydantic import BaseModel
 
 from .config import settings
@@ -32,6 +39,10 @@ from .config import settings
 router = APIRouter(prefix="/api/auth", tags=["auth"])
 
 _SALT = "invite"
+_HANDOFF_SALT = "handoff"
+# Overføringslenken er ferskvare: kort nok til at den i praksis må brukes med en gang (skann
+# QR-en på den andre enheten), så et avlyttet/etterlatt token ikke kan løses inn senere.
+_HANDOFF_MAKS_ALDER = 300  # sekunder
 
 # Enhetsregisterets åpne rolle-endepunkt (gratis, ingen auth). Gir navn på daglig leder og
 # styre som offentlig data, slik at vi kan bekrefte at forespørgeren plausibelt hører til
@@ -50,6 +61,13 @@ _MOD11_VEKTER = (3, 2, 7, 6, 5, 4, 3, 2)
 
 def _serializer() -> URLSafeSerializer:
     return URLSafeSerializer(settings().invite_secret, salt=_SALT)
+
+
+def _handoff_serializer() -> URLSafeTimedSerializer:
+    # Egen salt på sesjons-secret-en: overføringslenken er en sesjonsforlengelse, ikke en
+    # operatør-utdelt invitasjon, og kan dermed ikke forveksles med (eller forfalskes fra)
+    # invite-tokens eller selve cookien.
+    return URLSafeTimedSerializer(settings().session_secret, salt=_HANDOFF_SALT)
 
 
 def lag_invite_token(org: str) -> str:
@@ -207,6 +225,53 @@ def be_om_tilgang(body: TilgangBody, request: Request) -> dict:
 
     _grant(request, orgnr, via_selvbetjening=True)
     return {"invited": True, "invite_org": orgnr}
+
+
+class HandoffBody(BaseModel):
+    token: str
+
+
+@router.post("/handoff/create")
+def lag_handoff(request: Request) -> dict:
+    """
+    Lag en kortvarig overføringslenke for å fortsette på en annen enhet.
+
+    Krever en alt fullført økt: kunde_org er kun satt etter en innløst invitasjon mot et
+    onboardet selskap eller en gjennomført BankID-godkjenning, så bare en enhet som er
+    forbi den reelle porten kan lage lenken. Den nye enheten arver nøyaktig samme binding.
+    """
+    org = request.session.get("kunde_org")
+    if not org:
+        raise HTTPException(
+            status_code=409,
+            detail="Koble selskapet på denne enheten først, så kan du fortsette på en annen.",
+        )
+    token = _handoff_serializer().dumps({"org": str(org)})
+    return {
+        "lenke": f"{settings().public_url}/?handoff={token}",
+        "gyldig_sekunder": _HANDOFF_MAKS_ALDER,
+    }
+
+
+@router.post("/handoff/use")
+def bruk_handoff(body: HandoffBody, request: Request) -> dict:
+    """Løs inn en overføringslenke på en ny enhet og arv selskapsbindingen direkte."""
+    try:
+        payload = _handoff_serializer().loads(body.token, max_age=_HANDOFF_MAKS_ALDER)
+    except SignatureExpired:
+        return {"invited": False, "feil": "Overføringslenken er utløpt. Lag en ny på den andre enheten."}
+    except BadSignature:
+        return {"invited": False, "feil": "Ugyldig overføringslenke."}
+    org = payload.get("org") if isinstance(payload, dict) else None
+    if not org:
+        return {"invited": False, "feil": "Ugyldig overføringslenke."}
+    org = str(org).strip()
+    # Forankret i en alt verifisert økt, så bindingen arves uten ny BankID. via_selvbetjening
+    # er irrelevant her (kunde_org er alt satt), men False markerer at dette ikke er en svak
+    # navneoppslag-økt.
+    _grant(request, org, via_selvbetjening=False)
+    request.session["kunde_org"] = org
+    return {"invited": True, "invite_org": org, "kunde_org": org}
 
 
 @router.get("/me")

--- a/hosted/api/systembruker.py
+++ b/hosted/api/systembruker.py
@@ -39,7 +39,8 @@ def request_systembruker(request: Request) -> dict:
     Unntak for selvbetjente økter: AlreadyApproved-snarveien hopper over BankID, og
     selvbetjent tilgang er bare et navneoppslag mot offentlige data (ikke identitetsbevis).
     Å honorere snarveien der ville latt en som kjenner et offentlig styremedlemsnavn sende
-    inn for et alt-onboardet selskap. Slike krever derfor manuell invitasjon.
+    inn for et alt-onboardet selskap. Slike kobles derfor enten via en manuell invitasjon
+    eller en handoff-lenke fra en alt koblet enhet (auth.py), aldri via selvbetjent snarvei.
     """
     krev_invitert(request)
     org = krev_invite_org(request)
@@ -50,8 +51,9 @@ def request_systembruker(request: Request) -> dict:
         if request.session.get("via_selvbetjening"):
             raise HTTPException(
                 status_code=409,
-                detail="Dette selskapet er allerede satt opp i Wenche. Av sikkerhetsgrunner "
-                "kobles slike bare via en invitasjon. Ta kontakt: " + settings().kontakt_tekst + ".",
+                detail="Dette selskapet er alt satt opp i Wenche. Har du alt koblet det på en "
+                "annen enhet, åpne Wenche der og velg «Fortsett på en annen enhet» for å koble "
+                "denne. Ellers, ta kontakt for en invitasjon: " + settings().kontakt_tekst + ".",
             )
         request.session["kunde_org"] = org
         request.session.pop("pending_org", None)

--- a/hosted/web/package.json
+++ b/hosted/web/package.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "@wenche/ui": "*",
+    "qrcode": "^1.5.4",
     "react": "^18.3.1",
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
+    "@types/qrcode": "^1.5.5",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type FormEvent } from "react";
+import QRCode from "qrcode";
 import { api } from "./api";
 import { sporSidevisning, sporHendelse } from "./sporing";
 import {
@@ -286,6 +287,89 @@ function Onboarding({ org, onApproved }: { org?: string | null; onApproved: () =
   );
 }
 
+// Fortsett på en annen enhet: en koblet økt lager en kortvarig overføringslenke (QR + lenke)
+// som en ny enhet løser inn for å arve samme binding, uten ny BankID. Løser at sesjonen ellers
+// lever per nettleser (signert cookie, ingen DB), så et andre apparat står uten tilkobling.
+function FortsettAnnenEnhet() {
+  const [aapen, setAapen] = useState(false);
+  const [lenke, setLenke] = useState<string | null>(null);
+  const [qr, setQr] = useState<string | null>(null);
+  const [gyldigMin, setGyldigMin] = useState<number | null>(null);
+  const [lager, setLager] = useState(false);
+  const [kopiert, setKopiert] = useState(false);
+  const [feil, setFeil] = useState<string | null>(null);
+
+  const lag = async () => {
+    setFeil(null);
+    setKopiert(false);
+    setLager(true);
+    try {
+      const r = await api.handoffCreate();
+      setLenke(r.lenke);
+      setGyldigMin(r.gyldig_sekunder ? Math.round(r.gyldig_sekunder / 60) : null);
+      // QR genereres i nettleseren; lenken (med tokenet) forlater aldri enheten her.
+      setQr(await QRCode.toDataURL(r.lenke, { margin: 1, width: 320 }));
+      setAapen(true);
+      sporHendelse("handoff-laget");
+    } catch (e) {
+      setFeil((e as Error).message);
+    } finally {
+      setLager(false);
+    }
+  };
+
+  const kopier = async () => {
+    if (!lenke) return;
+    try {
+      await navigator.clipboard.writeText(lenke);
+      setKopiert(true);
+    } catch {
+      /* clipboard blokkert (f.eks. ikke-https): lenken vises uansett for manuell kopiering */
+    }
+  };
+
+  if (!aapen) {
+    return (
+      <button className={btnOutline} onClick={lag} disabled={lager}>
+        {lager ? "Lager lenke…" : "Fortsett på en annen enhet"}
+      </button>
+    );
+  }
+
+  return (
+    <div className="rounded-sm border border-border bg-background p-4">
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        Skann QR-koden med den andre enheten, eller åpne lenken der. Da kobles den til samme
+        selskap uten ny BankID-godkjenning. Lenken er ferskvare
+        {gyldigMin ? ` (gyldig i ${gyldigMin} minutter)` : ""} og bør bare deles med deg selv.
+      </p>
+      {qr && (
+        <img
+          src={qr}
+          alt="QR-kode for å fortsette på en annen enhet"
+          className="mt-4 rounded bg-white p-2"
+          width={180}
+          height={180}
+        />
+      )}
+      {lenke && (
+        <div className="mt-4">
+          <a className="block break-all text-sm text-spruce underline-offset-2 hover:underline" href={lenke}>
+            {lenke}
+          </a>
+          <div className="mt-3 flex items-center gap-3">
+            <button className={btnOutline} onClick={kopier}>
+              Kopier lenke
+            </button>
+            {kopiert && <span className="text-xs text-spruce">✓ Kopiert</span>}
+          </div>
+        </div>
+      )}
+      {feil && <p className="mt-3 text-sm text-red-700">{feil}</p>}
+    </div>
+  );
+}
+
 // Hjem: tilkoblingsstatus. Koblet → bekreftelse + «sjekk tilkobling». Ikke koblet → onboarding.
 function HjemFane({ me, onChange }: { me: Me; onChange: () => void }) {
   const [sjekker, setSjekker] = useState(false);
@@ -353,6 +437,16 @@ function HjemFane({ me, onChange }: { me: Me; onChange: () => void }) {
             {sjekker ? "Sjekker…" : "Sjekk tilkobling"}
           </button>
           {melding && <span className="text-sm text-muted-foreground">{melding}</span>}
+        </div>
+      </Kort>
+      <Kort>
+        <p className={monoLabel}>Flere enheter</p>
+        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+          Vil du fortsette på telefonen eller en annen maskin? Lag en lenke her, så slipper du
+          å koble selskapet på nytt der.
+        </p>
+        <div className="mt-4">
+          <FortsettAnnenEnhet />
         </div>
       </Kort>
     </div>
@@ -482,10 +576,17 @@ export default function App() {
 
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
-    const token = params.get("invite");
-    if (token) {
-      api
-        .invite(token)
+    const invite = params.get("invite");
+    const handoff = params.get("handoff");
+    // En invite-lenke åpner porten; en handoff-lenke (fra en alt koblet enhet) arver bindingen
+    // direkte. Begge løses inn FØR URL-en ryddes og analytics kjører, så tokenet aldri lekker.
+    const losInn = invite
+      ? api.invite(invite)
+      : handoff
+        ? api.handoffUse(handoff)
+        : null;
+    if (losInn) {
+      losInn
         .catch(() => {})
         .finally(() => {
           window.history.replaceState({}, "", window.location.pathname);

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -339,32 +339,50 @@ function FortsettAnnenEnhet() {
   return (
     <div className="rounded-sm border border-border bg-background p-4">
       <p className="text-sm leading-relaxed text-muted-foreground">
-        Skann QR-koden med den andre enheten, eller åpne lenken der. Da kobles den til samme
-        selskap uten ny BankID-godkjenning. Lenken er ferskvare
-        {gyldigMin ? ` (gyldig i ${gyldigMin} minutter)` : ""} og bør bare deles med deg selv.
+        Det er to måter å koble den nye enheten på. Lenken gir tilgang uten ny
+        BankID-godkjenning, er ferskvare{gyldigMin ? ` (gyldig i ${gyldigMin} minutter)` : ""}, og
+        bør bare deles med deg selv.
       </p>
-      {qr && (
-        <img
-          src={qr}
-          alt="QR-kode for å fortsette på en annen enhet"
-          className="mt-4 rounded bg-white p-2"
-          width={180}
-          height={180}
-        />
-      )}
-      {lenke && (
-        <div className="mt-4">
-          <a className="block break-all text-sm text-spruce underline-offset-2 hover:underline" href={lenke}>
-            {lenke}
-          </a>
-          <div className="mt-3 flex items-center gap-3">
-            <button className={btnOutline} onClick={kopier}>
-              Kopier lenke
-            </button>
-            {kopiert && <span className="text-xs text-spruce">✓ Kopiert</span>}
-          </div>
-        </div>
-      )}
+
+      <div className="mt-5">
+        <p className="text-sm font-medium text-foreground">1. Skann QR-koden</p>
+        <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+          Bruk kameraet på telefonen eller nettbrettet du vil koble til.
+        </p>
+        {qr && (
+          <img
+            src={qr}
+            alt="QR-kode for å fortsette på en annen enhet"
+            className="mt-3 rounded bg-white p-2"
+            width={180}
+            height={180}
+          />
+        )}
+      </div>
+
+      <div className="mt-5">
+        <p className="text-sm font-medium text-foreground">2. Eller bruk lenken</p>
+        <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+          Åpne den på den andre enheten, eller send den til deg selv, for eksempel på e-post.
+        </p>
+        {lenke && (
+          <>
+            <a
+              className="mt-3 block break-all text-sm text-spruce underline-offset-2 hover:underline"
+              href={lenke}
+            >
+              {lenke}
+            </a>
+            <div className="mt-3 flex items-center gap-3">
+              <button className={btnOutline} onClick={kopier}>
+                Kopier lenke
+              </button>
+              {kopiert && <span className="text-xs text-spruce">✓ Kopiert</span>}
+            </div>
+          </>
+        )}
+      </div>
+
       {feil && <p className="mt-3 text-sm text-red-700">{feil}</p>}
     </div>
   );
@@ -442,8 +460,14 @@ function HjemFane({ me, onChange }: { me: Me; onChange: () => void }) {
       <Kort>
         <p className={monoLabel}>Flere enheter</p>
         <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-          Vil du fortsette på telefonen eller en annen maskin? Lag en lenke her, så slipper du
-          å koble selskapet på nytt der.
+          Tilkoblingen gjelder denne nettleseren.
+        </p>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          Vil du bruke Wenche på telefonen eller en annen maskin, lag en lenke her og åpne den
+          der, så kobles den enheten til i tillegg, uten ny godkjenning. Begge forblir koblet.
+        </p>
+        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+          En enhet du ikke vil bruke lenger, logger du ut med «Logg ut».
         </p>
         <div className="mt-4">
           <FortsettAnnenEnhet />

--- a/hosted/web/src/api.ts
+++ b/hosted/web/src/api.ts
@@ -9,6 +9,11 @@ export const api = {
   // Selvbetjent tilgang: navn + orgnr verifiseres mot Enhetsregisteret. Navnet lagres ikke.
   beOmTilgang: (navn: string, org: string) =>
     req("/api/auth/be-om-tilgang", { method: "POST", body: JSON.stringify({ navn, org }) }),
+  // Fortsett på en annen enhet: en koblet økt lager en kortvarig overføringslenke (QR),
+  // den nye enheten løser den inn og arver bindingen.
+  handoffCreate: () => req("/api/auth/handoff/create", { method: "POST" }),
+  handoffUse: (token: string) =>
+    req("/api/auth/handoff/use", { method: "POST", body: JSON.stringify({ token }) }),
   logout: () => req("/api/auth/logout", { method: "POST" }),
   systembrukerRequest: () => req("/api/systembruker/request", { method: "POST" }),
   systembrukerStatus: () => req("/api/systembruker/status", { method: "POST" }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,11 +18,13 @@
       "version": "0.0.0",
       "dependencies": {
         "@wenche/ui": "*",
+        "qrcode": "^1.5.4",
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
+        "@types/qrcode": "^1.5.5",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1494,12 +1496,32 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.9.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": ">=7.24.0 <7.24.7"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/qrcode": {
+      "version": "1.5.6",
+      "resolved": "https://registry.npmjs.org/@types/qrcode/-/qrcode-1.5.6.tgz",
+      "integrity": "sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/react": {
       "version": "18.3.30",
@@ -1547,6 +1569,30 @@
     "node_modules/@wenche/ui": {
       "resolved": "packages/ui",
       "link": true
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
     },
     "node_modules/argparse": {
       "version": "2.0.1",
@@ -1602,6 +1648,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001793",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
@@ -1622,6 +1677,35 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cliui": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
+      "integrity": "sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^6.2.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -1655,6 +1739,15 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -1665,12 +1758,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/dijkstrajs": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/dijkstrajs/-/dijkstrajs-1.0.3.tgz",
+      "integrity": "sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.364",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.364.tgz",
       "integrity": "sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
     },
     "node_modules/enhanced-resolve": {
       "version": "5.22.1",
@@ -1756,6 +1861,19 @@
         }
       }
     },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1781,12 +1899,30 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jiti": {
       "version": "2.7.0",
@@ -2113,6 +2249,18 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -2181,6 +2329,51 @@
         "node": ">=18"
       }
     },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -2200,6 +2393,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-5.0.0.tgz",
+      "integrity": "sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/postcss": {
@@ -2229,6 +2431,23 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/qrcode": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/qrcode/-/qrcode-1.5.4.tgz",
+      "integrity": "sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "dijkstrajs": "^1.0.1",
+        "pngjs": "^5.0.0",
+        "yargs": "^15.3.1"
+      },
+      "bin": {
+        "qrcode": "bin/qrcode"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/react": {
@@ -2267,6 +2486,21 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-main-filename": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
+      "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
+      "license": "ISC"
     },
     "node_modules/rollup": {
       "version": "4.61.0",
@@ -2332,6 +2566,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==",
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -2340,6 +2580,32 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/tailwindcss": {
@@ -2393,6 +2659,13 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.24.6",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -2509,12 +2782,73 @@
       "resolved": "wenche/web/frontend",
       "link": true
     },
+    "node_modules/which-module": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.1.tgz",
+      "integrity": "sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==",
+      "license": "ISC"
+    },
+    "node_modules/wrap-ansi": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
+      "license": "ISC"
+    },
     "node_modules/yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-15.4.1.tgz",
+      "integrity": "sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^6.0.0",
+        "decamelize": "^1.2.0",
+        "find-up": "^4.1.0",
+        "get-caller-file": "^2.0.1",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^2.0.0",
+        "set-blocking": "^2.0.0",
+        "string-width": "^4.2.0",
+        "which-module": "^2.0.0",
+        "y18n": "^4.0.0",
+        "yargs-parser": "^18.1.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "18.1.3",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.3.tgz",
+      "integrity": "sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==",
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.0.0",
+        "decamelize": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "packages/ui": {
       "name": "@wenche/ui",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.31.2"
+version = "0.32.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_hosted_handoff.py
+++ b/tests/test_hosted_handoff.py
@@ -1,0 +1,105 @@
+"""
+«Fortsett på en annen enhet»-flyten (handoff) for hostet Wenche.
+
+Beviser egenskapene:
+- Bare en alt koblet økt (bundet kunde_org) kan lage en overføringslenke.
+- En fersk enhet (eget app-objekt, ingen cookie) løser inn lenken og arver bindingen,
+  uten ny BankID og uten å treffe Altinn, så cross-device-fortsettelse virker.
+- Ugyldige og utløpte tokens avvises.
+- Lenken er forankret i sesjonens kunde_org, ikke i brukerinput.
+
+Altinn-kallene (wenche.systembruker) mockes; testen treffer verken nett eller tt02.
+"""
+import importlib
+from types import SimpleNamespace
+
+import pytest
+from fastapi.testclient import TestClient
+
+import hosted.api.systembruker as sb
+from hosted.api.auth import lag_invite_token
+
+
+@pytest.fixture
+def klient(monkeypatch):
+    """TestClient med test-miljø og egne (ikke-default) hemmeligheter; isolert per test."""
+    monkeypatch.setenv("WENCHE_ENV", "test")
+    monkeypatch.setenv("HOSTED_SESSION_SECRET", "test-session-secret")
+    monkeypatch.setenv("HOSTED_INVITE_SECRET", "test-invite-secret")
+    monkeypatch.setenv("HOSTED_PUBLIC_URL", "https://app.example.cloud")
+    from hosted.api import config
+
+    config.settings.cache_clear()
+    from hosted.api import main as main_mod
+
+    importlib.reload(main_mod)
+    with TestClient(main_mod.app) as klient:
+        yield klient
+    config.settings.cache_clear()
+
+
+def _koble(klient, monkeypatch, org="314273818"):
+    """Bind kunde_org på klienten via invite + AlreadyApproved (som en fullført device 1)."""
+    creds = SimpleNamespace(client_id="fake-client-id")
+    monkeypatch.setattr(sb, "krev_vendor", lambda: (creds, "999999999"))
+    monkeypatch.setattr(sb, "admin_token", lambda creds: "fake-token")
+    monkeypatch.setattr(sb.wsb, "hent_systembrukere", lambda tok, vendor: [{"reporteeOrgNo": org}])
+    klient.post("/api/auth/invite", json={"token": lag_invite_token(org)})
+    klient.post("/api/systembruker/request")
+    assert klient.get("/api/auth/me").json()["kunde_org"] == org
+
+
+def test_create_krever_kobling(klient):
+    """Uten bundet kunde_org finnes det ingenting å overføre → 409."""
+    r = klient.post("/api/auth/handoff/create")
+    assert r.status_code == 409
+
+
+def test_handoff_til_ny_enhet_arver_binding(klient, monkeypatch):
+    """
+    Device 1 kobler selskapet og lager en overføringslenke; en fersk enhet (eget app-objekt,
+    ingen cookie) løser den inn og er straks koblet, uten ny BankID og uten Altinn-kall.
+    """
+    _koble(klient, monkeypatch, org="314273818")
+
+    r = klient.post("/api/auth/handoff/create").json()
+    assert r["lenke"].startswith("https://app.example.cloud/?handoff=")
+    assert r["gyldig_sekunder"] == 300
+    token = r["lenke"].split("handoff=", 1)[1]
+
+    # Fersk enhet: nytt app-objekt, ingen delt cookie. Ingen vendor-stub her med vilje, så
+    # testen viser at innløsningen ikke rører Altinn.
+    from hosted.api import main as main_mod
+
+    importlib.reload(main_mod)
+    with TestClient(main_mod.app) as enhet2:
+        assert enhet2.get("/api/auth/me").json()["invited"] is False
+        svar = enhet2.post("/api/auth/handoff/use", json={"token": token}).json()
+        assert svar == {"invited": True, "invite_org": "314273818", "kunde_org": "314273818"}
+        me = enhet2.get("/api/auth/me").json()
+        assert me["invited"] is True and me["kunde_org"] == "314273818"
+
+
+def test_ugyldig_token_avvises(klient):
+    r = klient.post("/api/auth/handoff/use", json={"token": "soppel"}).json()
+    assert r["invited"] is False and "Ugyldig" in r["feil"]
+
+
+def test_utloept_token_avvises(klient, monkeypatch):
+    """Et token eldre enn maks-alderen skal nektes (ferskvare)."""
+    _koble(klient, monkeypatch, org="314273818")
+    token = klient.post("/api/auth/handoff/create").json()["lenke"].split("handoff=", 1)[1]
+
+    import hosted.api.auth as auth_mod
+
+    # Krymp gyldigheten til null: et alt utstedt token er da utløpt ved innløsing.
+    monkeypatch.setattr(auth_mod, "_HANDOFF_MAKS_ALDER", -1)
+    r = klient.post("/api/auth/handoff/use", json={"token": token}).json()
+    assert r["invited"] is False and "utløpt" in r["feil"].lower()
+
+
+def test_handoff_token_signeres_med_egen_salt(klient, monkeypatch):
+    """Et invite-token (annen salt/secret) skal ikke kunne brukes som overføringslenke."""
+    _koble(klient, monkeypatch, org="314273818")
+    r = klient.post("/api/auth/handoff/use", json={"token": lag_invite_token("314273818")}).json()
+    assert r["invited"] is False


### PR DESCRIPTION
Closes #128

## Bakgrunn

En bruker meldte at man kobler selskapet på én enhet, men står uten åpenbar vei videre på en annen. Sesjonsbindingen lever per nettleser (signert cookie, ingen DB), så et andre apparat har ingen binding, og selvbetjeningsbrukere havner i en 409-blindvei fordi selvbetjent tilkobling nektes for et alt-onboardet selskap.

## Spike-funn

Verifisert mot tt02: «rute selvbetjent reentry gjennom en frisk BankID-godkjenning» er umulig. Altinn nekter ny systembruker-forespørsel for et alt-onboardet selskap (`400 AUTH-00004`). Systembrukeren bindes på org-nivå, ikke per enhet. Derfor er løsningen handoff fra en alt koblet enhet, med invite-lenke som recovery når device 1 mangler.

## Endringer

- Nytt `POST /api/auth/handoff/create`: en alt koblet økt (bundet `kunde_org`) lager en kortvarig (5 min), signert overføringslenke. Krever fullført økt, ellers 409.
- Nytt `POST /api/auth/handoff/use`: en ny enhet løser inn lenken og arver bindingen direkte, uten ny BankID og uten å treffe Altinn.
- SPA: «Fortsett på en annen enhet» på Hjem, med to tydelige alternativer (skann QR / bruk lenke). `?handoff=`-token håndteres som `?invite=` og ryddes fra URL-en før analytics.
- Tydeligere tekst: «Flere enheter»-kortet sier at tilkoblingen gjelder per nettleser og kopieres additivt (begge enheter forblir koblet); 409-meldingen peker mot handoff eller invitasjon i stedet for å ende blindt.
- Doc: `hosted/README.md` beskriver handoff og at tilkoblingen kopieres, ikke flyttes.

## Modell og begrensninger

- Tilkobling er per nettleser; handoff **kopierer** bindingen (flytter den ikke), så flere enheter kan være koblet samtidig. Hver enhet logges ut for seg.
- Lenken er ferskvare (5 min) kun for innløsing; den nye økten lever normal lengde (14 dager, glidende) etterpå.
- Helt selvbetjent recovery uten device 1 (ID-porten + reportee-sjekk) er utenfor scope.

## Sikkerhet

- Forankret i en alt verifisert økt (`kunde_org`), ikke i offentlig registerkunnskap, så handoff omgår ikke selvbetjeningssperren. Egen salt på sesjons-secret-en skiller tokenet fra invite-tokens og cookien.

## Test plan

- [x] `pytest` (353 passerer, inkl. ny `tests/test_hosted_handoff.py`)
- [x] `npm run build --workspace hosted/web`
- [x] Manuelt: koble device 1, åpne handoff-lenke i eget vindu, bekreft tilkoblet uten BankID
- [ ] Manuelt: bekreft at utløpt lenke (> 5 min) avvises pent
