### PR TITLE
fix(hosted): gjør innsendingsfeil til lesbare svar, aldri naken 500

### DIFF
--- a/hosted/api/innsending.py
+++ b/hosted/api/innsending.py
@@ -98,7 +98,10 @@ def _utfor(fn, kunde_org: str | None = None):
         # Tidsavbrudd/tilkoblingsfeil (ikke et HTTP-svar). Søsken av HTTPStatusError, så den
         # må fanges eksplisitt — ellers blir den en naken 500. Skattemelding gjør flere
         # oppstrøms-kall enn aksjonær og er derfor mer utsatt for et forbigående avbrudd.
-        url = e.request.url if e.request else "?"
+        try:
+            url = str(e.request.url)  # httpx' .request kaster RuntimeError hvis den ikke er satt
+        except RuntimeError:
+            url = "ukjent URL"
         logger.warning("Innsending feilet for org %s: nettverksfeil mot %s: %s", kunde_org, url, e)
         raise HTTPException(
             status_code=502,

--- a/hosted/api/innsending.py
+++ b/hosted/api/innsending.py
@@ -69,12 +69,18 @@ def _tolk_http_feil(e: httpx.HTTPStatusError) -> HTTPException:
     return HTTPException(status_code=502, detail=melding)
 
 
-def _utfor(fn):
+def _utfor(fn, kunde_org: str | None = None):
     """
     Kjør en innsending og gjør alle feil om til lesbare HTTP-svar, aldri en rå 500.
 
+    `fn` må omslutte HELE innsendingen, inkludert token-hentingen: et avslag fra
+    Maskinporten (f.eks. systembruker mangler en rettighet) eller en feilet Altinn-veksling
+    kaster ellers utenfor denne fellen og blir en naken 500 hos brukeren.
+
     Domeneklientene melder feil på to måter: rå `httpx.HTTPStatusError` (Altinn) og
-    `RuntimeError` med ferdig melding (SKD-klienten). Valideringsfeil gir 422; alt annet 502.
+    `RuntimeError` med ferdig melding (SKD-klienten / token-henting). Valideringsfeil gir
+    422; alt annet 502. `kunde_org` logges (ikke kundedata) så en operatør kan knytte en
+    feil til riktig org i loggene uten å vente på at brukeren melder fra.
     """
     try:
         return fn()
@@ -83,9 +89,38 @@ def _utfor(fn):
     except SkattemeldingValideringsfeil as e:  # subklasse av RuntimeError — fanges først
         raise HTTPException(status_code=422, detail={"validering": str(e)})
     except httpx.HTTPStatusError as e:
+        logger.warning(
+            "Innsending feilet for org %s: HTTP %s fra %s",
+            kunde_org, e.response.status_code, e.request.url,
+        )
         raise _tolk_http_feil(e)
+    except httpx.RequestError as e:
+        # Tidsavbrudd/tilkoblingsfeil (ikke et HTTP-svar). Søsken av HTTPStatusError, så den
+        # må fanges eksplisitt — ellers blir den en naken 500. Skattemelding gjør flere
+        # oppstrøms-kall enn aksjonær og er derfor mer utsatt for et forbigående avbrudd.
+        url = e.request.url if e.request else "?"
+        logger.warning("Innsending feilet for org %s: nettverksfeil mot %s: %s", kunde_org, url, e)
+        raise HTTPException(
+            status_code=502,
+            detail=(
+                "Fikk ikke fullført forespørselen mot Altinn/Skatteetaten (nettverksfeil eller "
+                "tidsavbrudd). Det er som regel midlertidig. Sjekk Altinn-innboksen din før du "
+                "prøver på nytt, i tilfelle forespørselen likevel gikk gjennom."
+            ),
+        )
     except RuntimeError as e:
+        logger.warning("Innsending feilet for org %s: %s", kunde_org, e)
         raise HTTPException(status_code=502, detail=str(e))
+    except HTTPException:
+        raise  # alt bevisst reist (f.eks. _sjekk_org 409) skal slippe gjennom uendret
+    except Exception:
+        # Siste skanse: en uventet feiltype skal aldri bli en naken stacktrace-500 hos
+        # brukeren. Logg med traceback + org så den blir attribuerbar, og gi et rent svar.
+        logger.exception("Uventet feil under innsending for org %s", kunde_org)
+        raise HTTPException(
+            status_code=500,
+            detail="Uventet feil under innsending. Feilen er logget. Prøv igjen, eller ta kontakt.",
+        )
 
 
 @router.post("/innsending/aarsregnskap")
@@ -99,13 +134,13 @@ def innsending_aarsregnskap(
     org = krev_kunde_org(request)
     _sjekk_org(config, org)
     s = settings()
-    altinn_token = wauth.hent_tokens_for(creds, org, SCOPES, veksle_altinn=True)["altinn_token"]
 
     def _send():
+        altinn_token = wauth.hent_tokens_for(creds, org, SCOPES, veksle_altinn=True)["altinn_token"]
         with AltinnClient(altinn_token, env=s.env) as klient:
             return tjeneste.send_aarsregnskap(config, klient)
 
-    return _utfor(_send)
+    return _utfor(_send, org)
 
 
 @router.post("/innsending/aksjonaer")
@@ -119,13 +154,13 @@ def innsending_aksjonaer(
     org = krev_kunde_org(request)
     _sjekk_org(config, org)
     s = settings()
-    token = wauth.hent_tokens_for(creds, org, SKD_AKSJONAER_SCOPE)["maskinporten_token"]
 
     def _send():
+        token = wauth.hent_tokens_for(creds, org, SKD_AKSJONAER_SCOPE)["maskinporten_token"]
         with SkdAksjonaerClient(token, env=s.env) as klient:
             return tjeneste.send_aksjonaer(config, klient)
 
-    return _utfor(_send)
+    return _utfor(_send, org)
 
 
 @router.post("/innsending/skattemelding")
@@ -139,10 +174,10 @@ def innsending_skattemelding(
     org = krev_kunde_org(request)
     _sjekk_org(config, org)
     s = settings()
-    tokens = wauth.hent_tokens_for(creds, org, SKD_SKATTEMELDING_SCOPE, veksle_altinn=True)
 
     def _send():
+        tokens = wauth.hent_tokens_for(creds, org, SKD_SKATTEMELDING_SCOPE, veksle_altinn=True)
         with SkdSkattemeldingClient(tokens["maskinporten_token"], env=s.env) as skd:
             return tjeneste.send_skattemelding(config, skd, tokens["altinn_token"], orgnr=org)
 
-    return _utfor(_send)
+    return _utfor(_send, org)

--- a/hosted/api/innsending.py
+++ b/hosted/api/innsending.py
@@ -107,8 +107,8 @@ def _utfor(fn, kunde_org: str | None = None):
             status_code=502,
             detail=(
                 "Fikk ikke fullført forespørselen mot Altinn/Skatteetaten (nettverksfeil eller "
-                "tidsavbrudd). Det er som regel midlertidig. Sjekk Altinn-innboksen din før du "
-                "prøver på nytt, i tilfelle forespørselen likevel gikk gjennom."
+                "tidsavbrudd). Det er som regel midlertidig. Sjekk i Altinn eller hos Skatteetaten "
+                "før du prøver på nytt, i tilfelle forespørselen likevel gikk gjennom."
             ),
         )
     except RuntimeError as e:

--- a/hosted/list_systembrukere.py
+++ b/hosted/list_systembrukere.py
@@ -1,0 +1,101 @@
+"""
+List alle systembrukere som er koblet til den hostede Wenche-deployen, og sjekk hvilke
+rettigheter hver av dem faktisk kan bruke. Operatør-verktøy: kjøres lokalt med de samme
+HOSTED_VENDOR_*-creds som prod-appen, så svaret er autoritativt for den kjørende tjenesten
+(ikke din personlige self-hosted .env).
+
+Bakgrunn: en systembrukers rettigheter fryses ved kundens samtykke. Utvider du
+rettighetspakken senere (f.eks. da skattemelding ble lagt til 2026-03-27), får kunder som
+allerede har koblet seg på den IKKE automatisk. De feiler da på nettopp det skjemaet, mens
+de skjemaene de samtykket til virker. Dette skriptet finner dem uten å vente på at de melder
+fra: for hver tilkoblede org prøver det å hente token for hvert skjema, akkurat slik
+innsendingsruten gjør. Feiler token-hentingen, ville innsendingen gitt samme feil.
+
+  WENCHE_ENV=prod \
+  HOSTED_VENDOR_ORGNR=... HOSTED_VENDOR_CLIENT_ID=... HOSTED_VENDOR_KID=... \
+  HOSTED_VENDOR_KEY_PEM="$(cat vendor.pem)" \
+      ./.venv/bin/python hosted/list_systembrukere.py
+
+Read-only: henter kun tokens og lister systembrukere, sender ingenting inn og endrer
+ingen rettigheter. Fiks for berørte: systembruker.opprett_endringsforespørsel(...) med
+[systembruker._SKATTEMELDING_RETT], som kunden så godkjenner i Altinn.
+"""
+import os
+from pathlib import Path
+
+from wenche import auth as wauth
+from wenche import systembruker as sb
+from wenche.auth import (
+    ADMIN_SCOPES,
+    SCOPES,
+    SKD_AKSJONAER_SCOPE,
+    SKD_SKATTEMELDING_SCOPE,
+    VendorCredentials,
+)
+
+# Skjemaene en tilkoblet org kan sende inn, med scopene innsendingsruten faktisk ber om.
+SKJEMAER = [
+    ("aarsregnskap", SCOPES, True),
+    ("aksjonaer", SKD_AKSJONAER_SCOPE, False),
+    ("skattemelding", SKD_SKATTEMELDING_SCOPE, True),
+]
+
+
+def _org_av(systembruker: dict) -> str | None:
+    for nokkel in ("reporteeOrgNo", "partyOrgNo", "orgNo", "partyId"):
+        if systembruker.get(nokkel):
+            return str(systembruker[nokkel])
+    return None
+
+
+def _creds_fra_env() -> tuple[VendorCredentials, str]:
+    """Bygg vendor-creds rett fra HOSTED_VENDOR_*-env, uten å dra inn app-konfig.
+
+    Diagnostikk trenger bare vendor-nøkkelen, ikke session-/invite-hemmelighetene som
+    api.config fail-closer på i prod.
+    """
+    orgnr = os.getenv("HOSTED_VENDOR_ORGNR")
+    client_id = os.getenv("HOSTED_VENDOR_CLIENT_ID")
+    kid = os.getenv("HOSTED_VENDOR_KID")
+    pem = os.getenv("HOSTED_VENDOR_KEY_PEM")
+    pem_path = os.getenv("HOSTED_VENDOR_KEY_PATH")
+    if not (orgnr and client_id and kid and (pem or pem_path)):
+        raise SystemExit(
+            "Mangler vendor-creds. Sett HOSTED_VENDOR_ORGNR/CLIENT_ID/KID og "
+            "HOSTED_VENDOR_KEY_PEM (eller _PATH), og WENCHE_ENV."
+        )
+    pem_bytes = pem.encode() if pem else Path(pem_path).read_bytes()
+    return VendorCredentials(client_id=client_id, kid=kid, private_key_pem=pem_bytes), orgnr
+
+
+def main() -> None:
+    creds, vendor_orgnr = _creds_fra_env()
+    env = os.getenv("WENCHE_ENV", "prod")
+
+    print(f"Miljø: {env}   vendor: {vendor_orgnr}   system: {sb.system_id(vendor_orgnr)}\n")
+
+    admin_token = wauth.hent_tokens_for(creds, scopes=ADMIN_SCOPES)["maskinporten_token"]
+    brukere = sb.hent_systembrukere(admin_token, vendor_orgnr)
+    if not brukere:
+        print("Ingen systembrukere koblet til.")
+        return
+
+    print(f"{len(brukere)} tilkoblede systembrukere:\n")
+    for b in brukere:
+        org = _org_av(b)
+        if not org:
+            print(f"  ? ukjent org i objekt: {b}")
+            continue
+        status = []
+        for navn, scope, veksle in SKJEMAER:
+            try:
+                wauth.hent_tokens_for(creds, org, scope, veksle_altinn=veksle)
+                status.append(f"{navn}=OK")
+            except Exception as e:  # noqa: BLE001 - vil se hvilket skjema som feiler og hvorfor
+                kort = str(e).splitlines()[0][:80]
+                status.append(f"{navn}=FEIL ({kort})")
+        print(f"  {org}: " + "  ".join(status))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.32.0"
+version = "0.32.1"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_hosted_innsending_feil.py
+++ b/tests/test_hosted_innsending_feil.py
@@ -1,8 +1,10 @@
 """
 Feilhåndtering i hostet innsending: Altinn/SKD-feil skal aldri bli en rå 500 til brukeren.
 
-`_utfor` pakker innsendingen og gjør de tre feilklassene domeneklientene melder om til lesbare
-HTTP-svar: valideringsfeil → 422, rå httpx-feil (Altinn) og RuntimeError (SKD-klienten) → 502.
+`_utfor` pakker innsendingen og gjør feilene domeneklientene melder om til lesbare HTTP-svar:
+valideringsfeil → 422; HTTP-feil (Altinn), nettverksfeil/tidsavbrudd (httpx.RequestError) og
+RuntimeError (SKD-klienten / token-henting) → 502; bevisst reist HTTPException slipper gjennom
+uendret; alt annet → kontrollert 500 med melding (aldri en naken stacktrace).
 """
 import httpx
 import pytest
@@ -57,3 +59,38 @@ def test_skattemelding_valideringsfeil_blir_422():
         _utfor(_hev(SkattemeldingValideringsfeil(resultat)))
     assert ei.value.status_code == 422
     assert "validering" in ei.value.detail
+
+
+def test_nettverksfeil_timeout_blir_502_ikke_500():
+    # httpx.RequestError (tidsavbrudd) er søsken av HTTPStatusError, ikke en undertype, og
+    # ble tidligere en naken 500. Den ledende forklaringen på skattemelding-500-en.
+    req = httpx.Request("POST", "https://skatt.skatteetaten.no/api/skattemelding/v2/valider")
+    feil = httpx.ConnectTimeout("timed out", request=req)
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(feil))
+    assert ei.value.status_code == 502
+    assert "tidsavbrudd" in str(ei.value.detail).lower()
+
+
+def test_nettverksfeil_uten_request_kaster_ikke_i_handteringen():
+    # httpx' .request kaster RuntimeError hvis den ikke er satt — håndteringen må ikke selv
+    # kaste når den logger URL-en.
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(httpx.ConnectError("ingen request satt")))
+    assert ei.value.status_code == 502
+
+
+def test_uventet_feiltype_blir_kontrollert_500():
+    # Siste skanse: en uventet feiltype skal bli en ren 500 med melding, ikke en stacktrace.
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(ValueError("noe uventet")))
+    assert ei.value.status_code == 500
+    assert "uventet" in str(ei.value.detail).lower()
+
+
+def test_bevisst_httpexception_slipper_gjennom_uendret():
+    # F.eks. _sjekk_org sin 409 skal ikke pakkes om til 502/500.
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(HTTPException(status_code=409, detail="org matcher ikke")))
+    assert ei.value.status_code == 409
+    assert ei.value.detail == "org matcher ikke"


### PR DESCRIPTION
## Bakgrunn

En bruker fikk «Feil (HTTP 500)» ved «Bekreft innsending» av skattemelding i prod, mens aksjonærregisteroppgaven gikk gjennom. Feilsøkingen avkreftet de to nærliggende årsakene for den konkrete orgen: systembrukeren har skattemelding-rettigheten (token=OK), og perioden er åpen og ikke levert (frist blokkerer ikke). Det som sto igjen var hull i feilhåndteringen som lot enkelte feil boble ut som en naken stacktrace-500 i stedet for en forklarende melding.

## Endringer

- **Token-henting flyttet inn i `_utfor`** i alle tre innsendingsrutene. Et Maskinporten-avslag eller en feilet Altinn-veksling lå tidligere utenfor feilhåndteringen og ble en naken 500.
- **`httpx.RequestError` fanges nå** (tidsavbrudd/tilkoblingsfeil, søsken av `HTTPStatusError`) som en lesbar 502. Skattemelding gjør flere oppstrøms-kall enn aksjonær og er mer utsatt for et forbigående avbrudd, den ledende forklaringen på 500-en.
- **Catch-all som siste skanse**: uventede feiltyper logges med traceback i stedet for å bli en stacktrace-500. Bevisst reiste `HTTPException` slipper gjennom uendret.
- **`kunde_org` logges ved feil**, så en operatør kan knytte en feil til riktig org via `fly logs` uten å vente på at brukeren melder fra.
- **Nytt operatør-verktøy** `hosted/list_systembrukere.py`: lister tilkoblede systembrukere og verifiserer per skjema hvilke rettigheter hver org faktisk kan bruke. Plassert under `hosted/` (som `mint_invite.py`), så det havner i image men ikke i PyPI-wheelen.
- Versjonsbump til 0.32.1.

## Vurdert og avslått

- **Gjenopptakbar/idempotent innsending** for å unngå duplikat-instans ved retry etter tidsavbrudd: en reell forbedring, men en større endring (klientkontrakt + duplikat-håndtering) som fortjener egen PR.
- **Liste-kommando i `wenche/cli.py`**: avslått, en self-hosted ett-org-bruker har bare én systembruker, så det ville vært støy i den publiserte CLI-en.

## Test plan

- [x] `pytest` grønn (353 passerte)
- [x] `hosted/list_systembrukere.py` kjørt mot prod: 11 systembrukere, alle `skattemelding=OK`
- [x] Read-only statussjekk bekreftet at perioden er åpen og ikke innsendt for den berørte orgen
- [ ] Deploy, og be brukeren prøve innsending på nytt: enten går det gjennom, eller feilen kommer nå som lesbar melding + attribuerbar logglinje