### PR TITLE
fix(hosted): flytt Fly-region fra arn til ams og gjør EØS-tekst region-uavhengig

### DIFF
--- a/docs/hostet.md
+++ b/docs/hostet.md
@@ -24,7 +24,7 @@ signering og arkivering hos selskapet.
 
 Under **Tall** kan du fylle inn manuelt, hente tallene fra [Bodil](https://github.com/olefredrik/Bodil),
 eller **importere fra SAF-T**. Laster du opp en SAF-T-fil, behandles den i minnet i EØS
-(Stockholm) for å fylle inn skjemaet, og forkastes umiddelbart, den lagres ikke.
+for å fylle inn skjemaet, og forkastes umiddelbart, den lagres ikke.
 
 !!! note "For operatører"
     Drifts- og deploy-dokumentasjon (Docker, Fly.io, secrets) ligger i `hosted/README.md`

--- a/fly.demo.toml
+++ b/fly.demo.toml
@@ -6,7 +6,7 @@
 # `flyctl secrets set -a wenche-demo ...`, ALDRI her (denne fila er åpen kildekode).
 
 app = "wenche-demo"
-primary_region = "arn"         # Stockholm, EØS (samme som prod).
+primary_region = "ams"         # Amsterdam, EØS (samme som prod). Flyttet fra "arn" 2026-06-08 (arn-kapasitet).
 
 [build]
   dockerfile = "Dockerfile"

--- a/fly.toml
+++ b/fly.toml
@@ -3,7 +3,7 @@
 # Hemmeligheter settes med `flyctl secrets set ...`, ALDRI her (denne fila er åpen kildekode).
 
 app = "wenche-hosted"          # bytt til ditt faktiske Fly-appnavn (settes av `flyctl launch`)
-primary_region = "arn"         # Stockholm, EØS. Alternativ: "ams" (Amsterdam).
+primary_region = "ams"         # Amsterdam, EØS. Flyttet fra "arn" (Stockholm) 2026-06-08 da arn manglet vert-kapasitet.
 
 [build]
   dockerfile = "Dockerfile"

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -516,7 +516,7 @@ function TallFane({
           initial={config ?? undefined}
           laastOrg={org ?? undefined}
           importerSaft={api.importerSaft}
-          saftMerknad="SAF-T-filen behandles i minnet i EØS (Stockholm) og lagres ikke."
+          saftMerknad="SAF-T-filen behandles i minnet i EØS og lagres ikke."
           ekstraSeksjon={<NoterSeksjon noter={noter} setNoter={setNoter} />}
         />
       </Kort>


### PR DESCRIPTION
## Bakgrunn

arn (Stockholm) manglet vert-kapasitet og klarte ikke å vekke scale-to-zero-maskinene (`machine can't start at the moment` / `PR01 no known healthy instances`), så både prod (app.wenche.cloud) og demo (demo.wenche.cloud) lå nede med 503.

## Endring

- **Region flyttet arn → ams** (Amsterdam, fortsatt EØS) i `fly.toml` og `fly.demo.toml`. Maskinene er allerede reskedulert til ams og kjører (1/1, HTTP 200); dette oppdaterer config så en fremtidig `fly deploy` ikke havner i arn igjen.
- **EØS-tekst gjort region-uavhengig:** dropper `(Stockholm)` fra den brukervendte SAF-T-merknaden i hostet SPA (`hosted/web/src/App.tsx`) og fra `docs/hostet.md`. Den bindende fakta etter GDPR er at data behandles innenfor EØS, ikke i hvilken by, så teksten tåler nå et regionbytte uten redigering. Samme mønster som vilkår/personvern allerede bruker på wenche-web («Fly.io i en EØS-region»).

## Merk

- Berører kun den hostede tjenesten og dokumentasjon, ikke den publiserte `wenche`-wheelen, så ingen versjonsbump.
- Begge regioner (arn og ams) er EØS, så data-residens og DPA-formuleringene er uendret og fortsatt korrekte.