### PR TITLE
feat(hosted): forhåndsfyll selskapsopplysninger fra Enhetsregisteret

### DIFF
--- a/hosted/api/auth.py
+++ b/hosted/api/auth.py
@@ -34,6 +34,8 @@ from fastapi import APIRouter, HTTPException, Request
 from itsdangerous import BadSignature, SignatureExpired, URLSafeSerializer, URLSafeTimedSerializer
 from pydantic import BaseModel
 
+from wenche import brreg
+
 from .config import settings
 
 router = APIRouter(prefix="/api/auth", tags=["auth"])
@@ -113,7 +115,12 @@ def _navn_matcher(innsendt: str, kandidater: list[str]) -> bool:
 
 
 def _hent_rolleinnehavere(orgnr: str) -> list[str]:
-    """Navn på aktive daglig leder/styre fra Enhetsregisteret. Tom liste om selskapet/rollen mangler."""
+    """
+    Navn på aktive daglig leder/styre fra Enhetsregisteret, til navnematch i selvbetjeningen.
+    Beholder en streng feilkontrakt med vilje: 404 gir tom liste, men nettverks- og serverfeil
+    propageres (raise_for_status), så be-om-tilgang kan skille «fant ikke navnet» fra «fikk ikke
+    kontakt med registeret». Selve parsingen deles med wenche.brreg (forhåndsfyll-stien).
+    """
     resp = httpx.get(
         _BRREG_ROLLER_URL.format(org=orgnr),
         headers={"Accept": "application/json"},
@@ -122,19 +129,7 @@ def _hent_rolleinnehavere(orgnr: str) -> list[str]:
     if resp.status_code == 404:
         return []
     resp.raise_for_status()
-    navn: list[str] = []
-    for gruppe in resp.json().get("rollegrupper", []):
-        for rolle in gruppe.get("roller", []):
-            if rolle.get("fratraadt") or rolle.get("avregistrert"):
-                continue
-            person = rolle.get("person") or {}
-            if person.get("erDoed"):
-                continue
-            n = person.get("navn") or {}
-            fullt = " ".join(d for d in (n.get("fornavn"), n.get("mellomnavn"), n.get("etternavn")) if d)
-            if fullt:
-                navn.append(fullt)
-    return navn
+    return brreg.parse_roller(resp.json())["alle"]
 
 
 def _rate_ok(nokkel: str) -> bool:

--- a/hosted/api/main.py
+++ b/hosted/api/main.py
@@ -22,6 +22,7 @@ from .config import settings
 from .dokumenter import router as dokumenter_router
 from .innsending import router as innsending_router
 from .saft import router as saft_router
+from .selskap import router as selskap_router
 from .systembruker import router as systembruker_router
 
 s = settings()
@@ -50,6 +51,7 @@ app.include_router(systembruker_router)
 app.include_router(innsending_router)
 app.include_router(dokumenter_router)
 app.include_router(saft_router)
+app.include_router(selskap_router)
 
 
 @app.get("/api/health")

--- a/hosted/api/saft.py
+++ b/hosted/api/saft.py
@@ -5,7 +5,7 @@ Tar imot en opplastet SAF-T XML som rå request-body, parser den i minnet (wench
 returnerer en config-dict som klienten forhåndsfyller skjemaet med. Krever gyldig invite, ikke
 vendor/kunde-org, siden ingenting sendes inn. Personvern: bytene leses inn i minnet, parses og
 forkastes. Ingenting skrives til disk eller lagres (sesjonen er fasit). Behandlingen skjer i
-EØS (Fly arn/Stockholm). Org-låsen i klienten gjør at SAF-T-ens org ikke endrer kundeidentitet.
+EØS. Org-låsen i klienten gjør at SAF-T-ens org ikke endrer kundeidentitet.
 """
 from fastapi import APIRouter, HTTPException, Query, Request
 

--- a/hosted/api/selskap.py
+++ b/hosted/api/selskap.py
@@ -26,9 +26,12 @@ def hent_selskap(request: Request) -> dict:
         raise HTTPException(status_code=409, detail="Ingen koblet org å hente opplysninger for.")
     org = str(org).strip()
     roller = brreg.hent_roller(org)
+    enhet = brreg.hent_enhet(org)
     return {
         "org_nummer": org,
+        "navn": enhet["navn"],
+        "forretningsadresse": enhet["forretningsadresse"],
         "daglig_leder": roller["daglig_leder"],
         "styreleder": roller["styreleder"],
-        "stiftelsesaar": brreg.hent_stiftelsesaar(org),
+        "stiftelsesaar": enhet["stiftelsesaar"],
     }

--- a/hosted/api/selskap.py
+++ b/hosted/api/selskap.py
@@ -1,0 +1,34 @@
+"""
+Forhåndsfyll-endepunkt for den hostede tjenesten.
+
+Henter selskapsopplysninger Enhetsregisteret kjenner (daglig leder, styreleder, stiftelsesår)
+for den koblede orgen, slik at klienten kan forhåndsfylle skjemaet. SAF-T bærer ikke disse
+feltene, så uten dette må brukeren skrive dem manuelt etter import (se issue #130).
+
+Nøkles på den signerte øktbindingen (kunde_org, ev. invite_org), aldri brukerinput, så oppslaget
+ikke kan misbrukes til å enumerere registeret. Kun offentlige data, ingenting lagres. Fail-soft:
+er registeret nede, returneres tomme felter og skjemaet forblir tomt (samme oppførsel som før).
+"""
+from fastapi import APIRouter, HTTPException, Request
+
+from wenche import brreg
+
+from .deps import krev_invitert
+
+router = APIRouter(prefix="/api/selskap", tags=["selskap"])
+
+
+@router.get("")
+def hent_selskap(request: Request) -> dict:
+    krev_invitert(request)
+    org = request.session.get("kunde_org") or request.session.get("invite_org")
+    if not org:
+        raise HTTPException(status_code=409, detail="Ingen koblet org å hente opplysninger for.")
+    org = str(org).strip()
+    roller = brreg.hent_roller(org)
+    return {
+        "org_nummer": org,
+        "daglig_leder": roller["daglig_leder"],
+        "styreleder": roller["styreleder"],
+        "stiftelsesaar": brreg.hent_stiftelsesaar(org),
+    }

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -516,6 +516,7 @@ function TallFane({
           initial={config ?? undefined}
           laastOrg={org ?? undefined}
           importerSaft={api.importerSaft}
+          prefillSelskap={api.selskap}
           saftMerknad="SAF-T-filen behandles i minnet i EØS og lagres ikke."
           ekstraSeksjon={<NoterSeksjon noter={noter} setNoter={setNoter} />}
         />

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -725,7 +725,7 @@ export default function App() {
               aktiv={fane}
               onNaviger={naviger}
               disabled={fane === "tall" && !harMinimumsdata(config)}
-              disabledHint="Fyll inn selskapsnavn, daglig leder og styreleder, og trykk «Lagre data»."
+              disabledHint="Fyll inn selskapsnavn og minst daglig leder eller styreleder, og trykk «Lagre data»."
             />
           </>
         )}

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -725,7 +725,7 @@ export default function App() {
               aktiv={fane}
               onNaviger={naviger}
               disabled={fane === "tall" && !harMinimumsdata(config)}
-              disabledHint="Fyll inn selskapsnavn og minst daglig leder eller styreleder, og trykk «Lagre data»."
+              disabledHint="Trykk «Lagre data» for å gå videre. (Krever selskapsnavn og minst daglig leder eller styreleder.)"
             />
           </>
         )}

--- a/hosted/web/src/api.ts
+++ b/hosted/web/src/api.ts
@@ -17,6 +17,10 @@ export const api = {
   logout: () => req("/api/auth/logout", { method: "POST" }),
   systembrukerRequest: () => req("/api/systembruker/request", { method: "POST" }),
   systembrukerStatus: () => req("/api/systembruker/status", { method: "POST" }),
+  // Forhåndsfyll: daglig leder, styreleder og stiftelsesår fra Enhetsregisteret for den koblede
+  // orgen (offentlige data, lagres ikke). SAF-T bærer ikke disse feltene, så uten dette må de
+  // skrives manuelt etter import.
+  selskap: () => req("/api/selskap"),
   // Config sendes i body (klienten er fasit), så en sovende/restartende server ikke kan
   // miste utfyllingen. Ingen server-side datalagring mellom kall.
   innsending: (type: string, dryRun: boolean, config: unknown) =>

--- a/packages/ui/src/skjema.tsx
+++ b/packages/ui/src/skjema.tsx
@@ -411,6 +411,9 @@ export function DataSkjema({
             ...c,
             selskap: {
               ...s,
+              navn: String(s.navn ?? "").trim() || d.navn || "",
+              forretningsadresse:
+                String(s.forretningsadresse ?? "").trim() || d.forretningsadresse || "",
               daglig_leder: String(s.daglig_leder ?? "").trim() || d.daglig_leder || "",
               styreleder: String(s.styreleder ?? "").trim() || d.styreleder || "",
               stiftelsesaar: Number(s.stiftelsesaar) || d.stiftelsesaar || 0,

--- a/packages/ui/src/skjema.tsx
+++ b/packages/ui/src/skjema.tsx
@@ -264,9 +264,10 @@ export function oppsummer(config: any) {
 export function harMinimumsdata(config: any): boolean {
   if (!config) return false;
   const s = config.selskap ?? {};
-  return ["navn", "org_nummer", "daglig_leder", "styreleder"].every(
-    (k) => String(s[k] ?? "").trim() !== "",
-  );
+  const utfylt = (k: string) => String(s[k] ?? "").trim() !== "";
+  // Navn + org alltid; daglig leder ELLER styreleder. Passive holdingselskaper har ofte ingen
+  // daglig leder, og da står styrelederen som bekreftende representant i årsregnskapet.
+  return utfylt("navn") && utfylt("org_nummer") && (utfylt("daglig_leder") || utfylt("styreleder"));
 }
 
 function Feltrutenett({

--- a/packages/ui/src/skjema.tsx
+++ b/packages/ui/src/skjema.tsx
@@ -328,6 +328,7 @@ export function DataSkjema({
   laastOrg,
   importerSaft,
   saftMerknad,
+  prefillSelskap,
 }: {
   onLagre: (config: unknown) => Promise<void>;
   visEksempel?: boolean;
@@ -348,6 +349,10 @@ export function DataSkjema({
   importerSaft?: (file: File, foregaaende: boolean) => Promise<any>;
   // Valgfri merknad i SAF-T-modalen (hostet bruker den til personvern-info om EØS/ingen lagring).
   saftMerknad?: React.ReactNode;
+  // Valgfri forhåndsfylling av styringsdata SAF-T ikke bærer (daglig leder, styreleder,
+  // stiftelsesår) fra Enhetsregisteret. Hostet injiserer henteren; self-hosted lar den være.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  prefillSelskap?: () => Promise<any>;
 }) {
   const laasteFelter = laastOrg ? ["selskap.org_nummer"] : [];
   // Tving org til det låste selskapet (brukes ved start, Bodil-import og eksempeldata).
@@ -386,6 +391,40 @@ export function DataSkjema({
     };
     window.addEventListener("beforeunload", handler);
     return () => window.removeEventListener("beforeunload", handler);
+  }, []);
+
+  // Forhåndsfyll styringsdata SAF-T ikke bærer (daglig leder, styreleder, stiftelsesår) fra
+  // Enhetsregisteret ved kobling, kun der feltet står tomt, så det ikke overskriver noe brukeren
+  // (eller en importert config) alt har fylt. Fail-soft: feiler oppslaget, forblir skjemaet tomt.
+  // Forhåndsfyll teller ikke som ulagret endring (oppdaterer pristine), men må fortsatt lagres.
+  useEffect(() => {
+    if (!prefillSelskap) return;
+    let avbrutt = false;
+    prefillSelskap()
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      .then((d: any) => {
+        if (avbrutt || !d) return;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        setConfig((c: any) => {
+          const s = c.selskap ?? {};
+          const oppdatert = {
+            ...c,
+            selskap: {
+              ...s,
+              daglig_leder: String(s.daglig_leder ?? "").trim() || d.daglig_leder || "",
+              styreleder: String(s.styreleder ?? "").trim() || d.styreleder || "",
+              stiftelsesaar: Number(s.stiftelsesaar) || d.stiftelsesaar || 0,
+            },
+          };
+          pristine.current = JSON.stringify(oppdatert);
+          return oppdatert;
+        });
+      })
+      .catch(() => {});
+    return () => {
+      avbrutt = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/ui/src/stegnav.tsx
+++ b/packages/ui/src/stegnav.tsx
@@ -75,7 +75,10 @@ export function GaaVidere({
   return (
     <div className="mt-12 flex flex-wrap items-center justify-end gap-x-4 gap-y-2 border-t border-border pt-6">
       {disabled && disabledHint && (
-        <span className="text-xs text-muted-foreground">{disabledHint}</span>
+        <span className="mr-auto flex items-center gap-1.5 text-sm font-medium text-amber-700">
+          <span aria-hidden>⚠</span>
+          {disabledHint}
+        </span>
       )}
       <button
         className={btnPrimar}

--- a/packages/ui/src/stegnav.tsx
+++ b/packages/ui/src/stegnav.tsx
@@ -75,10 +75,7 @@ export function GaaVidere({
   return (
     <div className="mt-12 flex flex-wrap items-center justify-end gap-x-4 gap-y-2 border-t border-border pt-6">
       {disabled && disabledHint && (
-        <span className="mr-auto flex items-center gap-1.5 text-sm font-medium text-amber-700">
-          <span aria-hidden>⚠</span>
-          {disabledHint}
-        </span>
+        <span className="mr-auto text-sm font-medium text-foreground">{disabledHint}</span>
       )}
       <button
         className={btnPrimar}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.32.1"
+version = "0.33.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_brg_xml_fixes.py
+++ b/tests/test_brg_xml_fixes.py
@@ -4,6 +4,7 @@ and base64 decoding of forhåndsutfylt skattemelding.
 """
 
 import base64
+import dataclasses
 import xml.etree.ElementTree as ET
 
 import pytest
@@ -288,6 +289,28 @@ def test_note_maskinell_behandling_is_10(regnskap_med_alle_poster):
     note = root.find(f".//{{{NS_H}}}noteMaskinellBehandling")
     assert note is not None
     assert note.text == "10"
+
+
+def _bekreftende(root: ET.Element) -> str | None:
+    el = root.find(f".//{{{NS_H}}}bekreftendeSelskapsrepresentant")
+    return el.text if el is not None else None
+
+
+def test_signatar_bruker_daglig_leder_naar_satt(regnskap_med_alle_poster):
+    selskap = dataclasses.replace(
+        regnskap_med_alle_poster.selskap, daglig_leder="Per Daglig", styreleder="Kari Styreleder"
+    )
+    regnskap = dataclasses.replace(regnskap_med_alle_poster, selskap=selskap, signatar=None)
+    assert _bekreftende(_parse(generer_hovedskjema(regnskap))) == "Per Daglig"
+
+
+def test_signatar_faller_tilbake_paa_styreleder_uten_daglig_leder(regnskap_med_alle_poster):
+    # Passivt holding uten daglig leder: styrelederen skal stå som bekreftende representant.
+    selskap = dataclasses.replace(
+        regnskap_med_alle_poster.selskap, daglig_leder="", styreleder="Kari Styreleder"
+    )
+    regnskap = dataclasses.replace(regnskap_med_alle_poster, selskap=selskap, signatar=None)
+    assert _bekreftende(_parse(generer_hovedskjema(regnskap))) == "Kari Styreleder"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_brreg.py
+++ b/tests/test_brreg.py
@@ -66,6 +66,26 @@ def test_parse_stiftelsesaar():
     assert brreg.parse_stiftelsesaar({"stiftelsesdato": "xx"}) == 0
 
 
+def test_parse_enhet_navn_adresse_og_stiftelsesaar():
+    data = {
+        "navn": "OFL HOLDING AS",
+        "stiftelsesdato": "2018-12-11",
+        "forretningsadresse": {
+            "adresse": ["c/o Ole Fredrik Lie", "Kong Carls gate 29"],
+            "postnummer": "4010",
+            "poststed": "STAVANGER",
+        },
+    }
+    e = brreg.parse_enhet(data)
+    assert e["navn"] == "OFL HOLDING AS"
+    assert e["forretningsadresse"] == "c/o Ole Fredrik Lie, Kong Carls gate 29, 4010 STAVANGER"
+    assert e["stiftelsesaar"] == 2018
+
+
+def test_parse_enhet_tomt_svar():
+    assert brreg.parse_enhet({}) == {"navn": "", "forretningsadresse": "", "stiftelsesaar": 0}
+
+
 def _resp(status_code: int = 200, json_data: dict | None = None):
     resp = MagicMock(spec=httpx.Response)
     resp.status_code = status_code
@@ -95,12 +115,14 @@ def test_hent_roller_nettverksfeil_failsoft(mock_get):
 
 
 @patch("wenche.brreg.httpx.get")
-def test_hent_stiftelsesaar_ok(mock_get):
-    mock_get.return_value = _resp(json_data={"stiftelsesdato": "2020-01-02"})
-    assert brreg.hent_stiftelsesaar("999999999") == 2020
+def test_hent_enhet_ok(mock_get):
+    mock_get.return_value = _resp(json_data={"navn": "TEST AS", "stiftelsesdato": "2020-01-02"})
+    e = brreg.hent_enhet("999999999")
+    assert e["navn"] == "TEST AS"
+    assert e["stiftelsesaar"] == 2020
 
 
 @patch("wenche.brreg.httpx.get")
-def test_hent_stiftelsesaar_5xx_failsoft(mock_get):
+def test_hent_enhet_5xx_failsoft(mock_get):
     mock_get.return_value = _resp(status_code=503)
-    assert brreg.hent_stiftelsesaar("999999999") == 0
+    assert brreg.hent_enhet("999999999") == {"navn": "", "forretningsadresse": "", "stiftelsesaar": 0}

--- a/tests/test_brreg.py
+++ b/tests/test_brreg.py
@@ -1,0 +1,106 @@
+"""
+Enhetsregister-oppslag for forhåndsfylling (wenche.brreg).
+
+Parsingen dekkes direkte; fetch-funksjonene mockes på httpx-nivå og må være fail-soft: ukjent
+org, manglende felt og transient nettverksfeil skal aldri kaste, bare gi tomme verdier (0/"").
+"""
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from wenche import brreg
+
+_ROLLER = {
+    "rollegrupper": [
+        {
+            "type": {"kode": "DAGL"},
+            "roller": [
+                {"type": {"kode": "DAGL"}, "person": {"navn": {"fornavn": "Kari", "etternavn": "Nordmann"}}},
+            ],
+        },
+        {
+            "type": {"kode": "STYR"},
+            "roller": [
+                {"type": {"kode": "LEDE"}, "person": {"navn": {"fornavn": "Ola", "mellomnavn": "F", "etternavn": "Lie"}}},
+                {"type": {"kode": "MEDL"}, "person": {"navn": {"fornavn": "Per", "etternavn": "Hansen"}}},
+            ],
+        },
+    ]
+}
+
+
+def test_parse_roller_plukker_daglig_leder_og_styreleder():
+    r = brreg.parse_roller(_ROLLER)
+    assert r["daglig_leder"] == "Kari Nordmann"
+    assert r["styreleder"] == "Ola F Lie"  # styreleder er rolletype LEDE i STYR-gruppen, ikke MEDL
+    assert r["alle"] == ["Kari Nordmann", "Ola F Lie", "Per Hansen"]
+
+
+def test_parse_roller_hopper_over_fratraadt_og_doed():
+    data = {
+        "rollegrupper": [
+            {"type": {"kode": "DAGL"}, "roller": [
+                {"type": {"kode": "DAGL"}, "fratraadt": True,
+                 "person": {"navn": {"fornavn": "Gammel", "etternavn": "Leder"}}},
+            ]},
+            {"type": {"kode": "STYR"}, "roller": [
+                {"type": {"kode": "LEDE"},
+                 "person": {"erDoed": True, "navn": {"fornavn": "Avdod", "etternavn": "Leder"}}},
+            ]},
+        ]
+    }
+    r = brreg.parse_roller(data)
+    assert r["daglig_leder"] == ""
+    assert r["styreleder"] == ""
+    assert r["alle"] == []
+
+
+def test_parse_roller_tomt_svar():
+    assert brreg.parse_roller({}) == {"daglig_leder": "", "styreleder": "", "alle": []}
+
+
+def test_parse_stiftelsesaar():
+    assert brreg.parse_stiftelsesaar({"stiftelsesdato": "2018-06-15"}) == 2018
+    assert brreg.parse_stiftelsesaar({"stiftelsesdato": ""}) == 0
+    assert brreg.parse_stiftelsesaar({}) == 0
+    assert brreg.parse_stiftelsesaar({"stiftelsesdato": "xx"}) == 0
+
+
+def _resp(status_code: int = 200, json_data: dict | None = None):
+    resp = MagicMock(spec=httpx.Response)
+    resp.status_code = status_code
+    resp.is_success = 200 <= status_code < 300
+    resp.json.return_value = json_data or {}
+    return resp
+
+
+@patch("wenche.brreg.httpx.get")
+def test_hent_roller_ok(mock_get):
+    mock_get.return_value = _resp(json_data=_ROLLER)
+    r = brreg.hent_roller("999999999")
+    assert r["daglig_leder"] == "Kari Nordmann"
+    assert r["styreleder"] == "Ola F Lie"
+
+
+@patch("wenche.brreg.httpx.get")
+def test_hent_roller_404_failsoft(mock_get):
+    mock_get.return_value = _resp(status_code=404)
+    assert brreg.hent_roller("999999999") == {"daglig_leder": "", "styreleder": "", "alle": []}
+
+
+@patch("wenche.brreg.httpx.get")
+def test_hent_roller_nettverksfeil_failsoft(mock_get):
+    mock_get.side_effect = httpx.ConnectError("nede")
+    assert brreg.hent_roller("999999999")["alle"] == []
+
+
+@patch("wenche.brreg.httpx.get")
+def test_hent_stiftelsesaar_ok(mock_get):
+    mock_get.return_value = _resp(json_data={"stiftelsesdato": "2020-01-02"})
+    assert brreg.hent_stiftelsesaar("999999999") == 2020
+
+
+@patch("wenche.brreg.httpx.get")
+def test_hent_stiftelsesaar_5xx_failsoft(mock_get):
+    mock_get.return_value = _resp(status_code=503)
+    assert brreg.hent_stiftelsesaar("999999999") == 0

--- a/tests/test_hosted_selskap.py
+++ b/tests/test_hosted_selskap.py
@@ -1,0 +1,54 @@
+"""
+Forhåndsfyll-endepunktet /api/selskap (hostet).
+
+Krever invite (som alt annet), nøkler på den signerte øktbindingen (ikke brukerinput), og
+returnerer styringsdata fra Enhetsregisteret som SAF-T ikke bærer. Brreg-oppslaget mockes.
+"""
+import importlib
+
+import pytest
+from fastapi.testclient import TestClient
+
+from hosted.api.auth import lag_invite_token
+
+_INVITE_SECRET = "test-invite-secret"
+
+
+@pytest.fixture
+def klient(monkeypatch):
+    monkeypatch.setenv("WENCHE_ENV", "test")
+    monkeypatch.setenv("HOSTED_SESSION_SECRET", "test-session-secret")
+    monkeypatch.setenv("HOSTED_INVITE_SECRET", _INVITE_SECRET)
+    from hosted.api import config
+
+    config.settings.cache_clear()
+    from hosted.api import main as main_mod
+
+    importlib.reload(main_mod)
+    with TestClient(main_mod.app) as klient:
+        yield klient
+    config.settings.cache_clear()
+
+
+def test_selskap_krever_invite(klient):
+    assert klient.get("/api/selskap").status_code == 401
+
+
+def test_selskap_forhandsfyller_fra_brreg(klient, monkeypatch):
+    from wenche import brreg
+
+    monkeypatch.setattr(
+        brreg, "hent_roller",
+        lambda org, **k: {"daglig_leder": "Kari Nordmann", "styreleder": "Ola Lie", "alle": []},
+    )
+    monkeypatch.setattr(brreg, "hent_stiftelsesaar", lambda org, **k: 2018)
+
+    token = lag_invite_token("314273818")
+    assert klient.post("/api/auth/invite", json={"token": token}).json()["invited"] is True
+
+    data = klient.get("/api/selskap").json()
+    # Org kommer fra den signerte invite-bindingen, ikke fra brukerinput.
+    assert data["org_nummer"] == "314273818"
+    assert data["daglig_leder"] == "Kari Nordmann"
+    assert data["styreleder"] == "Ola Lie"
+    assert data["stiftelsesaar"] == 2018

--- a/tests/test_hosted_selskap.py
+++ b/tests/test_hosted_selskap.py
@@ -41,7 +41,11 @@ def test_selskap_forhandsfyller_fra_brreg(klient, monkeypatch):
         brreg, "hent_roller",
         lambda org, **k: {"daglig_leder": "Kari Nordmann", "styreleder": "Ola Lie", "alle": []},
     )
-    monkeypatch.setattr(brreg, "hent_stiftelsesaar", lambda org, **k: 2018)
+    monkeypatch.setattr(
+        brreg, "hent_enhet",
+        lambda org, **k: {"navn": "Test AS", "forretningsadresse": "Vei 1, 0001 OSLO",
+                          "stiftelsesaar": 2018},
+    )
 
     token = lag_invite_token("314273818")
     assert klient.post("/api/auth/invite", json={"token": token}).json()["invited"] is True
@@ -49,6 +53,8 @@ def test_selskap_forhandsfyller_fra_brreg(klient, monkeypatch):
     data = klient.get("/api/selskap").json()
     # Org kommer fra den signerte invite-bindingen, ikke fra brukerinput.
     assert data["org_nummer"] == "314273818"
+    assert data["navn"] == "Test AS"
+    assert data["forretningsadresse"] == "Vei 1, 0001 OSLO"
     assert data["daglig_leder"] == "Kari Nordmann"
     assert data["styreleder"] == "Ola Lie"
     assert data["stiftelsesaar"] == 2018

--- a/wenche/brg_xml.py
+++ b/wenche/brg_xml.py
@@ -99,7 +99,10 @@ def generer_hovedskjema(regnskap: Aarsregnskap) -> bytes:
     s = regnskap.selskap
     aar = regnskap.regnskapsaar
     fastsettelsesdato = regnskap.fastsettelsesdato or date.today()
-    signatar = regnskap.signatar or s.daglig_leder
+    # Bekreftende selskapsrepresentant som fastsetter regnskapet: daglig leder om den finnes,
+    # ellers styrelederen. Passive holdingselskaper har ofte ingen daglig leder (aksjeloven
+    # krever det ikke for små AS), og da er det styret som fastsetter.
+    signatar = regnskap.signatar or s.daglig_leder or s.styreleder
     revideres = "nei" if not regnskap.revideres else "ja"
     ikke_revideres = "ja" if not regnskap.revideres else "nei"
     morselskap = "ja" if regnskap.balanse.eiendeler.anleggsmidler.aksjer_i_datterselskap > 0 else "nei"

--- a/wenche/brreg.py
+++ b/wenche/brreg.py
@@ -1,0 +1,87 @@
+"""
+Oppslag mot Brønnøysundregistrenes åpne Enhetsregister-API (gratis, ingen auth).
+
+Brukes til å forhåndsfylle selskapsopplysninger SAF-T ikke bærer: daglig leder, styreleder og
+stiftelsesår. Alt er offentlige registerdata, og ingenting lagres. Oppslagene er fail-soft: ved
+ukjent org, manglende felt eller transient nettverksfeil returneres tomme verdier, aldri et unntak
+som blokkerer flyten. Parsingen er skilt ut som rene funksjoner så den kan gjenbrukes av hostet
+sin selvbetjenings-navnematch, som beholder en strengere feilkontrakt (se hosted/api/auth.py).
+"""
+from __future__ import annotations
+
+import httpx
+
+_BASE = "https://data.brreg.no/enhetsregisteret/api/enheter"
+
+
+def _fullt_navn(person: dict) -> str:
+    n = person.get("navn") or {}
+    return " ".join(d for d in (n.get("fornavn"), n.get("mellomnavn"), n.get("etternavn")) if d)
+
+
+def _rolle_aktiv(rolle: dict) -> bool:
+    """En rolle teller bare når personen sitter aktivt (ikke fratrådt, avregistrert eller død)."""
+    if rolle.get("fratraadt") or rolle.get("avregistrert"):
+        return False
+    return not (rolle.get("person") or {}).get("erDoed")
+
+
+def parse_roller(data: dict) -> dict:
+    """
+    Plukk aktiv daglig leder og styreleder ut av et /roller-svar, pluss en flat liste med navn på
+    alle aktive rolleinnehavere (til navnematch). Tomme verdier der rollen mangler.
+    """
+    daglig_leder = ""
+    styreleder = ""
+    alle: list[str] = []
+    for gruppe in data.get("rollegrupper", []):
+        gruppetype = (gruppe.get("type") or {}).get("kode")
+        for rolle in gruppe.get("roller", []):
+            if not _rolle_aktiv(rolle):
+                continue
+            navn = _fullt_navn(rolle.get("person") or {})
+            if not navn:
+                continue
+            alle.append(navn)
+            rolletype = (rolle.get("type") or {}).get("kode")
+            if gruppetype == "DAGL" and not daglig_leder:
+                daglig_leder = navn
+            elif gruppetype == "STYR" and rolletype == "LEDE" and not styreleder:
+                styreleder = navn
+    return {"daglig_leder": daglig_leder, "styreleder": styreleder, "alle": alle}
+
+
+def parse_stiftelsesaar(data: dict) -> int:
+    """Årstallet fra `stiftelsesdato` (YYYY-MM-DD) i et enhets-svar. 0 om ukjent eller ugyldig."""
+    stiftelsesdato = data.get("stiftelsesdato")
+    if not stiftelsesdato or len(stiftelsesdato) < 4:
+        return 0
+    try:
+        return int(stiftelsesdato[:4])
+    except ValueError:
+        return 0
+
+
+def _hent_json(url: str, timeout: float) -> dict | None:
+    try:
+        resp = httpx.get(url, headers={"Accept": "application/json"}, timeout=timeout)
+    except httpx.HTTPError:
+        return None
+    if not resp.is_success:
+        return None
+    try:
+        return resp.json()
+    except ValueError:
+        return None
+
+
+def hent_roller(orgnr: str, *, timeout: float = 5.0) -> dict:
+    """Aktiv daglig leder og styreleder for orgnr fra Enhetsregisteret. Fail-soft (tomt ved feil)."""
+    data = _hent_json(f"{_BASE}/{orgnr}/roller", timeout)
+    return parse_roller(data) if data else {"daglig_leder": "", "styreleder": "", "alle": []}
+
+
+def hent_stiftelsesaar(orgnr: str, *, timeout: float = 5.0) -> int:
+    """Stiftelsesår for orgnr fra Enhetsregisteret. Fail-soft (0 ved feil eller ukjent org)."""
+    data = _hent_json(f"{_BASE}/{orgnr}", timeout)
+    return parse_stiftelsesaar(data) if data else 0

--- a/wenche/brreg.py
+++ b/wenche/brreg.py
@@ -62,6 +62,25 @@ def parse_stiftelsesaar(data: dict) -> int:
         return 0
 
 
+def _format_adresse(adr: dict) -> str:
+    """Sett sammen brregs strukturerte forretningsadresse til én linje, f.eks.
+    «Kong Carls gate 29, 4010 STAVANGER». Tom streng om adressen mangler."""
+    if not adr:
+        return ""
+    gate = ", ".join(linje for linje in (adr.get("adresse") or []) if linje)
+    poststed = " ".join(d for d in (adr.get("postnummer"), adr.get("poststed")) if d)
+    return ", ".join(d for d in (gate, poststed) if d)
+
+
+def parse_enhet(data: dict) -> dict:
+    """Navn, forretningsadresse og stiftelsesår fra et enhets-svar. Tomme verdier der noe mangler."""
+    return {
+        "navn": data.get("navn") or "",
+        "forretningsadresse": _format_adresse(data.get("forretningsadresse") or {}),
+        "stiftelsesaar": parse_stiftelsesaar(data),
+    }
+
+
 def _hent_json(url: str, timeout: float) -> dict | None:
     try:
         resp = httpx.get(url, headers={"Accept": "application/json"}, timeout=timeout)
@@ -81,7 +100,7 @@ def hent_roller(orgnr: str, *, timeout: float = 5.0) -> dict:
     return parse_roller(data) if data else {"daglig_leder": "", "styreleder": "", "alle": []}
 
 
-def hent_stiftelsesaar(orgnr: str, *, timeout: float = 5.0) -> int:
-    """Stiftelsesår for orgnr fra Enhetsregisteret. Fail-soft (0 ved feil eller ukjent org)."""
+def hent_enhet(orgnr: str, *, timeout: float = 5.0) -> dict:
+    """Navn, forretningsadresse og stiftelsesår for orgnr fra Enhetsregisteret. Fail-soft (tomt ved feil)."""
     data = _hent_json(f"{_BASE}/{orgnr}", timeout)
-    return parse_stiftelsesaar(data) if data else 0
+    return parse_enhet(data) if data else {"navn": "", "forretningsadresse": "", "stiftelsesaar": 0}

--- a/wenche/web/frontend/src/App.tsx
+++ b/wenche/web/frontend/src/App.tsx
@@ -90,7 +90,7 @@ export default function App() {
           aktiv={fane}
           onNaviger={naviger}
           disabled={fane === "tall" && !harMinimumsdata(config)}
-          disabledHint="Fyll inn selskapsnavn, org.nr., daglig leder og styreleder, og trykk «Lagre data»."
+          disabledHint="Fyll inn selskapsnavn, org.nr. og minst daglig leder eller styreleder, og trykk «Lagre data»."
         />
       </main>
     </div>

--- a/wenche/web/frontend/src/App.tsx
+++ b/wenche/web/frontend/src/App.tsx
@@ -90,7 +90,7 @@ export default function App() {
           aktiv={fane}
           onNaviger={naviger}
           disabled={fane === "tall" && !harMinimumsdata(config)}
-          disabledHint="Fyll inn selskapsnavn, org.nr. og minst daglig leder eller styreleder, og trykk «Lagre data»."
+          disabledHint="Trykk «Lagre data» for å gå videre. (Krever selskapsnavn, org.nr. og minst daglig leder eller styreleder.)"
         />
       </main>
     </div>


### PR DESCRIPTION
## Bakgrunn

Etter kobling av foretak og import av SAF-T (fra Fiken) ga skjemaet valideringsfeil på manglende **daglig leder**, **styreleder** og **stiftelsesår** (rapportert i #130 av @janode). Årsaken er at SAF-T Financial ikke bærer disse feltene. Alt finnes som offentlige data i Brønnøysunds Enhetsregister, og hentes nå derfra ved kobling, slik at skjemaet er forhåndsfylt og SAF-T bare fyller tallene.

## Endring

- **Ny kjerne-hjelper `wenche/brreg.py`** med rene parse-funksjoner og fail-soft oppslag mot Enhetsregisteret:
  - roller splittet på type (daglig leder fra `DAGL`, styreleder fra `STYR`/`LEDE`)
  - enhet: **navn**, **forretningsadresse** (satt sammen til én linje) og **stiftelsesår** (fra `stiftelsesdato`)
  - Lagt generelt så self-hosted og CLI kan kobles på senere; foreløpig brukt av hostet.
- **`_hent_rolleinnehavere`** (auth.py) gjenbruker nå `brreg.parse_roller`, men beholder sin strengere feilkontrakt med vilje: nettverks-/serverfeil propageres, så selvbetjeningen fortsatt kan skille «fant ikke navnet» fra «fikk ikke kontakt med registeret».
- **Nytt endepunkt `GET /api/selskap`**, nøklet på den signerte øktbindingen (`kunde_org`/`invite_org`, aldri brukerinput), som returnerer forhåndsfyll-feltene for den koblede orgen.
- **`DataSkjema` (delt UI):** valgfri `prefillSelskap`-prop som fyller kun tomme felter ved mount, fail-soft, og som ikke teller som en ulagret endring. Hostet injiserer henteren; self-hosted lar den være.
- **Passive holdingselskaper uten daglig leder kommer nå videre.** Aksjeloven krever ikke daglig leder for små AS, men minimumskravet krevde begge. Avdekket i testing (OFL Holding mangler daglig leder i registeret):
  - `brg_xml`: bekreftende selskapsrepresentant (fastsetter årsregnskapet) faller tilbake `daglig_leder` → `styreleder`, så feltet aldri blir tomt.
  - `harMinimumsdata`: krever navn + org og **minst én** av daglig leder/styreleder, ikke begge.
  - Trygt: rollene brukes ellers ikke i noen innsendings-XML (aksjonærregister/skattemelding rører dem ikke, kun lesbar XBRL-visning), og ingen backend-validering krever dem.
- **«Gå videre»-veiledningen** er gjort tydeligere og mindre alarmerende: «mangler»-hinten gikk fra liten grå `text-xs` (lett å overse, #130) til synlig, men nøytral veiledningstekst som leder med handlingen («Trykk «Lagre data» for å gå videre»), med kravene som parentes. Ingen rød/⚠-alarm, ingen popup. Treffer begge SPA-ene via delt UI.
- **Opprydding:** rettet en utdatert «Fly arn/Stockholm»-rest i `saft.py`-docstringen (følger PR #132).

## Personvern / rekkverk

Kun offentlige registerdata, ingenting lagres (samme linje som dagens rolle-oppslag). Forhåndsfyll-only: overskriver aldri noe brukeren eller en importert config alt har fylt, og er redigerbart. Fail-soft: er registeret nede, forblir skjemaet tomt som før, aldri en blokkering.

## Verifisert manuelt

Testet lokalt mot ekte org (922020523): navn, forretningsadresse, styreleder og stiftelsesår forhåndsfylles fra brreg. Daglig leder står tomt fordi selskapet ikke har en registrert daglig leder, og skjemaet lar deg komme videre på styreleder alene (etter «Lagre data»).

## Test

`pytest` (372 grønne, inkl. nye `test_brreg.py`, `test_hosted_selskap.py` og signatar-fallback i `test_brg_xml_fixes.py`). Begge SPA-ene bygger med `tsc && vite build`. Versjon bumpet 0.32.1 → 0.33.0.

## Merk

Adresserer #130. Jeg har bevisst utelatt auto-close-nøkkelord, så issuet forblir åpent til rapportøren har fått svar.