### PR TITLE
fix(skattemelding): gjør tomt selskapsfelt til rettbart avvik, ikke naken 500

### DIFF
--- a/hosted/api/dokumenter.py
+++ b/hosted/api/dokumenter.py
@@ -48,6 +48,9 @@ def _bygg_noter(config: dict) -> Noter:
 @router.post("/skattemelding")
 def dok_skattemelding(request: Request, config: dict[str, Any] = Body(...)) -> dict:
     krev_invitert(request)
+    feil = sm.valider_selskap(config)
+    if feil:
+        raise HTTPException(status_code=422, detail={"feil": feil})
     regnskap, konfig = sm.les_config(config)
     tekst = sm.generer(regnskap, konfig)
     navn = f"skattemelding_{regnskap.regnskapsaar}_{regnskap.selskap.org_nummer}.txt"

--- a/hosted/api/innsending.py
+++ b/hosted/api/innsending.py
@@ -132,7 +132,7 @@ def innsending_aarsregnskap(
 ) -> dict:
     krev_invitert(request)
     if dry_run:
-        return {"dry_run": True, **tjeneste.valider_aarsregnskap(config)}
+        return _utfor(lambda: {"dry_run": True, **tjeneste.valider_aarsregnskap(config)})
     creds, _ = krev_vendor()
     org = krev_kunde_org(request)
     _sjekk_org(config, org)
@@ -152,7 +152,7 @@ def innsending_aksjonaer(
 ) -> dict:
     krev_invitert(request)
     if dry_run:
-        return {"dry_run": True, **tjeneste.valider_aksjonaer(config)}
+        return _utfor(lambda: {"dry_run": True, **tjeneste.valider_aksjonaer(config)})
     creds, _ = krev_vendor()
     org = krev_kunde_org(request)
     _sjekk_org(config, org)
@@ -172,7 +172,7 @@ def innsending_skattemelding(
 ) -> dict:
     krev_invitert(request)
     if dry_run:
-        return {"dry_run": True, **tjeneste.valider_skattemelding(config)}
+        return _utfor(lambda: {"dry_run": True, **tjeneste.valider_skattemelding(config)})
     creds, _ = krev_vendor()
     org = krev_kunde_org(request)
     _sjekk_org(config, org)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.33.0"
+version = "0.33.1"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_hosted_dokumenter.py
+++ b/tests/test_hosted_dokumenter.py
@@ -90,3 +90,16 @@ def test_aarsregnskap_uten_balanse_gir_422(klient):
     r = klient.post("/api/dokumenter/aarsregnskap", json=cfg)
     assert r.status_code == 422
     assert "feil" in r.json()["detail"]
+
+
+@pytest.mark.parametrize("verdi", ["", None])
+def test_skattemelding_tomt_stiftelsesaar_gir_422_ikke_500(klient, verdi):
+    # Regresjon: en tom stiftelsesår/aksjekapital (typisk etter SAF-T-import, issue #130) ble
+    # før en naken int('')/float('')-500. Nå er det et rettbart avvik med lesbar melding.
+    _inviter(klient)
+    cfg = _gyldig_config()
+    cfg["selskap"]["stiftelsesaar"] = verdi
+    r = klient.post("/api/dokumenter/skattemelding", json=cfg)
+    assert r.status_code == 422, r.text
+    feil = r.json()["detail"]["feil"]
+    assert any("Stiftelsesår" in f for f in feil)

--- a/tests/test_skattemelding_selskap_validering.py
+++ b/tests/test_skattemelding_selskap_validering.py
@@ -1,0 +1,76 @@
+"""
+Skattemeldingen krever stiftelsesår og aksjekapital som tall, i motsetning til årsregnskapet
+som tåler tomme verdier. En SAF-T-import bærer ikke disse feltene (issue #130), så en tom verdi
+er et reelt og vanlig tilfelle. Før ble det en naken int('')/float('')-500 i de lokale
+byggestiene (dry-run og dokumenter). Nå skal det bli et rettbart avvik med lesbar melding.
+"""
+import pytest
+
+from wenche import aarsregnskap as ar
+from wenche import skattemelding as sm
+from wenche.innsending import valider_skattemelding
+
+
+def _config(stiftelsesaar=2018, aksjekapital=30000, dropp=None):
+    selskap = {
+        "navn": "Galatea Invest AS", "org_nummer": "922236771",
+        "daglig_leder": "D L", "styreleder": "S L",
+        "forretningsadresse": "Vei 1, 0001 OSLO",
+        "stiftelsesaar": stiftelsesaar, "aksjekapital": aksjekapital,
+    }
+    if dropp:
+        del selskap[dropp]
+    return {"selskap": selskap, "regnskapsaar": 2025,
+            "resultatregnskap": {"driftsinntekter": {}, "driftskostnader": {}, "finansposter": {}},
+            "balanse": {"eiendeler": {"anleggsmidler": {}, "omloepmidler": {}},
+                        "egenkapital_og_gjeld": {"egenkapital": {}, "langsiktig_gjeld": {},
+                                                 "kortsiktig_gjeld": {}}}}
+
+
+@pytest.mark.parametrize("verdi", ["", None])
+def test_tom_stiftelsesaar_gir_lesbart_avvik_ikke_crash(verdi):
+    feil = sm.valider_selskap(_config(stiftelsesaar=verdi))
+    assert any("Stiftelsesår" in f for f in feil)
+
+
+@pytest.mark.parametrize("verdi", ["", None])
+def test_tom_aksjekapital_gir_lesbart_avvik(verdi):
+    feil = sm.valider_selskap(_config(aksjekapital=verdi))
+    assert any("Aksjekapital" in f for f in feil)
+
+
+def test_manglende_felt_fanges():
+    feil = sm.valider_selskap(_config(dropp="stiftelsesaar"))
+    assert any("Stiftelsesår" in f for f in feil)
+
+
+def test_komplett_selskap_gir_ingen_avvik():
+    assert sm.valider_selskap(_config()) == []
+
+
+def test_les_config_tom_verdi_gir_lesbar_valueerror_ikke_rå_int():
+    # Defense-in-depth for direkte/CLI-kallere: en tom verdi skal gi en forklarende melding,
+    # ikke "invalid literal for int() with base 10: ''".
+    with pytest.raises(ValueError, match="Stiftelsesår"):
+        sm.les_config(_config(stiftelsesaar=""))
+
+
+def test_aarsregnskap_tåler_samme_tomme_verdi():
+    # Bekrefter divergensen som forklarer hvorfor bare skattemelding feilet for brukeren:
+    # årsregnskapet leser de samme feltene uten konvertering og krasjer ikke.
+    ar.les_config(_config(stiftelsesaar=""))  # skal ikke kaste
+
+
+def test_valider_skattemelding_returnerer_feil_liste():
+    # Samme kontrakt som valider_aarsregnskap: dry-run-svaret bærer en feil-liste som
+    # bekreft-modalen viser som rettbare punkter (ok=False), ikke en kastet 500.
+    svar = valider_skattemelding(_config(stiftelsesaar=""))
+    assert svar["ok"] is False
+    assert any("Stiftelsesår" in f for f in svar["feil"])
+
+
+def test_valider_skattemelding_ok_for_komplett_config():
+    svar = valider_skattemelding(_config())
+    assert svar["ok"] is True
+    assert svar["feil"] == []
+    assert svar["regnskapsaar"] == 2025

--- a/wenche/innsending.py
+++ b/wenche/innsending.py
@@ -49,8 +49,13 @@ def valider_aksjonaer(config: Config) -> dict:
 
 def valider_skattemelding(config: Config) -> dict:
     # Lokal bygging uten nettverk/partsnummer. SKD-validering skjer ved ekte innsending.
+    # Sjekk de påkrevde selskapsfeltene først: et ufullstendig selskap (typisk etter SAF-T-import)
+    # skal bli et rettbart avvik i bekreft-modalen, ikke en naken int('')/float('')-500.
+    feil = _sm.valider_selskap(config)
+    if feil:
+        return {"ok": False, "feil": feil}
     regnskap, _konfig = _sm.les_config(config)
-    return {"ok": True, "regnskapsaar": regnskap.regnskapsaar}
+    return {"ok": True, "feil": [], "regnskapsaar": regnskap.regnskapsaar}
 
 
 # ---------------------------------------------------------------------------

--- a/wenche/skattemelding.py
+++ b/wenche/skattemelding.py
@@ -34,13 +34,69 @@ from wenche.models import (
 SKATTESATS = 0.22  # 22 % selskapsskatt
 
 
+# Selskapsfelt skattemeldingen krever (org-nr utledes på annet vis ved innsending). I motsetning
+# til årsregnskapet konverterer skattemeldingen stiftelsesår og aksjekapital til tall, så en tom
+# verdi måtte før bli en naken int('')/float('')-500. En SAF-T-import bærer ikke disse feltene
+# (issue #130), derfor er en tom verdi et reelt og vanlig tilfelle, ikke en kantsak.
+PAAKREVDE_SELSKAPSFELT: list[tuple[str, str]] = [
+    ("navn", "Selskapsnavn"),
+    ("org_nummer", "Organisasjonsnummer"),
+    ("daglig_leder", "Daglig leder"),
+    ("styreleder", "Styreleder"),
+    ("forretningsadresse", "Forretningsadresse"),
+    ("stiftelsesaar", "Stiftelsesår"),
+    ("aksjekapital", "Aksjekapital"),
+]
+_NUMERISKE_SELSKAPSFELT = {"stiftelsesaar", "aksjekapital"}
+
+
+def _raw(config_fil: str | dict) -> dict:
+    """Leser config som dict (allerede parset) eller fra YAML-fil."""
+    if isinstance(config_fil, dict):
+        return config_fil
+    with open(config_fil, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _er_tom(verdi) -> bool:
+    return verdi is None or (isinstance(verdi, str) and not verdi.strip())
+
+
+def _tall(verdi, etikett: str, konverter):
+    """Konverterer et påkrevd tallfelt med lesbar feil, aldri en rå int('')/float('')-ValueError."""
+    if _er_tom(verdi):
+        raise ValueError(f"{etikett} mangler i selskapsopplysningene.")
+    try:
+        return konverter(verdi)
+    except (TypeError, ValueError):
+        raise ValueError(f"{etikett} må være et tall (fikk {verdi!r}).")
+
+
+def valider_selskap(config_fil: str | dict) -> list[str]:
+    """
+    Returnerer lesbare meldinger for selskapsfelt skattemeldingen krever, men som mangler, er
+    tomme eller (for tallfeltene) ikke er tall. Tom liste betyr OK.
+
+    Kjøres lokalt før bygging, så et ufullstendig selskap (typisk rett etter en SAF-T-import som
+    ikke bærer disse feltene) blir et avvik brukeren kan rette, ikke en naken HTTP 500.
+    """
+    s = (_raw(config_fil).get("selskap")) or {}
+    feil: list[str] = []
+    for key, etikett in PAAKREVDE_SELSKAPSFELT:
+        verdi = s.get(key)
+        if _er_tom(verdi):
+            feil.append(f"{etikett} mangler. Fyll inn under selskapsopplysninger.")
+        elif key in _NUMERISKE_SELSKAPSFELT:
+            try:
+                float(verdi)
+            except (TypeError, ValueError):
+                feil.append(f"{etikett} må være et tall.")
+    return feil
+
+
 def les_config(config_fil: str | dict) -> tuple[Aarsregnskap, SkattemeldingKonfig]:
     """Leser config (filsti eller allerede parset dict) og returnerer (Aarsregnskap, SkattemeldingKonfig)."""
-    if isinstance(config_fil, dict):
-        raw = config_fil
-    else:
-        with open(config_fil, encoding="utf-8") as f:
-            raw = yaml.safe_load(f)
+    raw = _raw(config_fil)
 
     s = raw["selskap"]
     selskap = Selskap(
@@ -49,8 +105,8 @@ def les_config(config_fil: str | dict) -> tuple[Aarsregnskap, SkattemeldingKonfi
         daglig_leder=s["daglig_leder"],
         styreleder=s["styreleder"],
         forretningsadresse=s["forretningsadresse"],
-        stiftelsesaar=int(s["stiftelsesaar"]),
-        aksjekapital=float(s["aksjekapital"]),
+        stiftelsesaar=_tall(s.get("stiftelsesaar"), "Stiftelsesår", int),
+        aksjekapital=_tall(s.get("aksjekapital"), "Aksjekapital", float),
     )
 
     resultatregnskap = _les_resultat(raw["resultatregnskap"])

--- a/wenche/web/backend/ruter_dokumenter.py
+++ b/wenche/web/backend/ruter_dokumenter.py
@@ -48,6 +48,9 @@ def _bygg_noter(config: dict) -> Noter:
 @router.post("/skattemelding")
 def dok_skattemelding(config: dict[str, Any] = Body(...)) -> dict:
     config = miljo.med_test_org(config)
+    feil = sm.valider_selskap(config)
+    if feil:
+        raise HTTPException(status_code=422, detail={"feil": feil})
     regnskap, konfig = sm.les_config(config)
     tekst = sm.generer(regnskap, konfig)
     navn = f"skattemelding_{regnskap.regnskapsaar}_{regnskap.selskap.org_nummer}.txt"


### PR DESCRIPTION
## Bakgrunn

En testbruker fikk «Feil (HTTP 500)» ved skattemelding-innsending. Det avgjørende sporet: `?dry_run=true` (som gjør null nettverkskall) ga også 500. Det falsifiserte nettverks-hypotesen fra #131 og pekte på lokal bygging.

Rotårsak: skattemeldingen konverterer `stiftelsesaar`/`aksjekapital` til tall, mens årsregnskapet leser de samme feltene uten konvertering. En tom verdi (typisk etter en SAF-T-import, som ikke bærer disse feltene, jf. #130) ble dermed en naken `int('')`/`float('')`-500 i de lokale byggestiene.

## Hvorfor #131 ikke fanget dette

#131 hardnet bare ekte-innsending-stien (`_utfor`) mot nettverksfeil. Feilen her skjer før noe nettverkskall, på to flater #131 ikke rørte: `dry_run`-grenen går utenom `_utfor`, og dokumenter-endepunktet ligger i egen fil uten feilhåndtering.

## Endringer

- Ny `valider_selskap()` lister manglende/tomme selskapsfelt med lesbar melding.
- `valider_skattemelding` returnerer `{ok, feil}` som `valider_aarsregnskap`, så bekreft-modalen viser rettbare avvik i stedet for å kaste.
- `les_config` hardnet med `_tall()`-helper (lesbar feil også for CLI-kallere).
- Dokumenter-endepunktene (hostet + self-hosted) og alle tre `dry_run`-grener (hostet) gir nå 422/lesbart svar, aldri naken 500.
- Versjonsbump til 0.33.1.

## Test plan

- [x] `pytest` grønn (384 passerte), inkl. ny regresjonstest for tomt stiftelsesår → 422
- [x] Ny test bekrefter divergensen: årsregnskap tåler tom verdi, skattemelding gjør det ikke
- [ ] Deploy hostet + self-hosted, og verifiser at tomt felt nå gir rettbart avvik i bekreft-modalen