### PR TITLE
fix(skattemelding): dropp erOverstyrt på avledede underskuddssummer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.33.2"
+version = "0.33.3"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_skattemelding_xml.py
+++ b/tests/test_skattemelding_xml.py
@@ -108,11 +108,13 @@ class TestAaretsUnderskudd:
         )
         assert ifu is not None and ifu.text == "-5000"
 
-        # samletUnderskudd (overstyrt) = årets underskudd
-        sum_u = iou.find(
-            f"{{{_NS}}}samletUnderskudd/{{{_NS}}}beloep/{{{_NS}}}beloepSomHeltall"
-        )
+        # samletUnderskudd = årets underskudd. Emitteres UTEN erOverstyrt:
+        # feltet er erAvledet, og når påstanden er lik SKDs utkast er
+        # overstyring et falskt signal til interessentoppfølgingen (SSV-5187).
+        sum_u_el = iou.find(f"{{{_NS}}}samletUnderskudd")
+        sum_u = sum_u_el.find(f"{{{_NS}}}beloep/{{{_NS}}}beloepSomHeltall")
         assert sum_u is not None and sum_u.text == "5000"
+        assert sum_u_el.find(f"{{{_NS}}}erOverstyrt") is None
 
     def test_fremfoerbart_er_summen_av_aarets_og_fremfoert(self):
         # Fremført fra tidligere år 1500 + årets underskudd 5000 = 6500
@@ -129,10 +131,13 @@ class TestAaretsUnderskudd:
         )
         assert fra_tidligere is not None and fra_tidligere.text == "1500"
 
-        fremfoerbart = utf.find(
-            f"{{{_NS}}}fremfoerbartUnderskuddIInntekt/{{{_NS}}}beloep/{{{_NS}}}beloepSomHeltall"
+        fremfoerbart_el = utf.find(f"{{{_NS}}}fremfoerbartUnderskuddIInntekt")
+        fremfoerbart = fremfoerbart_el.find(
+            f"{{{_NS}}}beloep/{{{_NS}}}beloepSomHeltall"
         )
         assert fremfoerbart is not None and fremfoerbart.text == "6500"
+        # UTEN erOverstyrt, jf. SSV-5187.
+        assert fremfoerbart_el.find(f"{{{_NS}}}erOverstyrt") is None
 
     def test_aarets_underskudd_uten_fremfoert_genererer_underskuddTilFremfoering(self):
         root = _parse(generer_skattemelding_upersonlig(

--- a/wenche/skattemelding_xml.py
+++ b/wenche/skattemelding_xml.py
@@ -114,7 +114,12 @@ def generer_skattemelding_upersonlig(
         if aarets_underskudd > 0:
             # fremfoerbartUnderskuddIInntekt = årets + fremført fra tidligere år.
             # Står sist i UnderskuddTilFremfoering-sekvensen.
-            _overstyrt_heltall(
+            # Emitteres UTEN erOverstyrt: feltet er erAvledet, og når påstanden
+            # er lik SKDs utkast er overstyring et falskt signal til
+            # interessentoppfølgingen (jf. SSV-5187). Å echo-e selve summen
+            # (uten flagget) holder avviks-detektoren ren, samme grep som
+            # samletVerdiBakAksjeneISelskapet nedenfor.
+            _heltall_med_beloep(
                 utf,
                 "fremfoerbartUnderskuddIInntekt",
                 aarets_underskudd + fremfoert_underskudd,
@@ -131,7 +136,8 @@ def generer_skattemelding_upersonlig(
                 "inntektFoerFradragForEventueltAvgittKonsernbidrag",
                 -aarets_underskudd,
             )
-            _overstyrt_heltall(iou, "samletUnderskudd", aarets_underskudd)
+            # UTEN erOverstyrt, samme begrunnelse som fremfoerbartUnderskuddIInntekt.
+            _heltall_med_beloep(iou, "samletUnderskudd", aarets_underskudd)
 
     # formueOgGjeld: formuesgrunnlaget bak aksjene. Skatteetaten utleder
     # samletVerdiBakAksjeneISelskapet = samletVerdiFoerVerdsettingsrabatt -


### PR DESCRIPTION
## Bakgrunn

Skatteetatens interessentoppfølging (sak SSV-5187) meldte at innsendinger fra Wenche markerte «Ja» til overstyring av fremførbart og samlet underskudd, selv når innlevert påstand var lik forhåndsutfylt utkast. Overstyring signaliserer
at man bevisst overstyrer SKDs beregning, og er misvisende når verdiene er like.

## Endringer

- `samletUnderskudd` og `fremfoerbartUnderskuddIInntekt` (begge `erAvledet`) emitteres nå uten `erOverstyrt`. Summen echo-es fortsatt, så SKDs etterBeregning forblir ren (ingen `manglerSkattemelding`-avvik). Samme grep som allerede er prod-verifisert for `samletVerdiBakAksjeneISelskapet`.
- Test dekker at `erOverstyrt` er borte fra begge feltene.
- Versjonsbump til 0.33.3 (wheel-relevant fiks i kjernen).

## Test plan

- [x] 459 enhetstester grønne
- [x] Verifisert XML lokalt: begge felt uten `erOverstyrt`, summer echo-et
- [x] tt02 ende-til-ende: innsending med reelt underskudd via demoen akseptert rent, ingen blokkerende avvik
