### PR TITLE
fix: lesbare feil i stedet for stille svikt og 500 i hostet innsendings- og dokumentflyt

### DIFF
--- a/docs/bruk.md
+++ b/docs/bruk.md
@@ -41,6 +41,9 @@ Under **Oppsett** finner du:
 
 Wenche fyller ut næringsspesifikasjonen og skattemeldingen og sender dem digitalt til Skatteetaten via Altinn. Du fullfører ved å signere med BankID i Altinn.
 
+!!! note "Inntektsår og skjemaversjon"
+    Wenche leverer skattemelding etter Skatteetatens gjeldende skjema (for tiden v5) og støtter inneværende og nylige inntektsår. Eldre år som Skatteetaten kun tar imot i et tidligere skjema (for eksempel inntektsår 2024 i v4), kan ikke sendes via Wenche. Årsregnskap og aksjonærregisteroppgave er ikke berørt av dette.
+
 Gå til fanen **Send** og klikk **Fortsett til innsending** ved siden av **Skattemelding**.
 
 Wenche validerer først skattemeldingen mot Skatteetaten og viser en oppsummering. Er noe feil, stopper Wenche uten å sende noe og viser hva som må rettes. Når valideringen er OK, bekrefter du og skattemeldingen lastes opp. Wenche viser en lenke til Altinn-innboksen. Åpne lenken og signer med BankID for å fullføre innsendingen.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -9,7 +9,7 @@ Denne veiledningen tar deg gjennom en komplett innsending fra start til slutt. V
 
 ## Selskapet vi bruker som eksempel
 
-**Eksempel Holding AS** er et enkelt holdingselskap med følgende situasjon for regnskapsåret 2024:
+**Eksempel Holding AS** er et enkelt holdingselskap med følgende situasjon for regnskapsåret 2025:
 
 - Eier 100 % av Fjordheim Teknologi AS
 - Mottok **250 000 kr** i utbytte fra datterselskapet
@@ -46,7 +46,7 @@ Gå til fanen **Tall**. Her fyller du ut alt på én side: selskapsopplysninger,
 - **Forretningsadresse:** Eksempelveien 1, 0001 Oslo
 - **Stiftelsesår:** 2020
 - **Aksjekapital:** 30 000
-- **Regnskapsår:** 2024
+- **Regnskapsår:** 2025
 
 **Resultatregnskap:**
 

--- a/hosted/api/dokumenter.py
+++ b/hosted/api/dokumenter.py
@@ -28,6 +28,42 @@ def _fil(filnavn: str, innhold: bytes, mime: str) -> dict:
     return {"filnavn": filnavn, "mime": mime, "base64": base64.b64encode(innhold).decode("ascii")}
 
 
+# Lesbare navn på config-seksjonene les_config slår opp direkte. Et ufullstendig Tall-steg
+# (typisk tomt resultatregnskap eller balanse) får les_config til å kaste KeyError på det
+# manglende nøkkeloppslaget; uten _les_eller_422 ble det en naken HTTP 500. Aksjonærregisteret
+# rører ikke resultatregnskap/balanse, så det er det eneste dokumentet som lar seg generere før
+# tallene er fylt inn, derav den forvirrende delvise feilen.
+_SEKSJON_TEKST = {
+    "resultatregnskap": "Resultatregnskapet",
+    "balanse": "Balansen",
+    "regnskapsaar": "Regnskapsåret",
+    "selskap": "Selskapsopplysningene",
+    "aksjonaerer": "Aksjonærene",
+}
+
+
+def _les_eller_422(les, config: dict):
+    """Kjør en les_config og gjør en manglende config-seksjon om til en forklarende 422.
+
+    Samme ånd som skattemelding.valider_selskap: en påregnelig, ufullstendig brukertilstand skal
+    bli et avvik brukeren kan rette, ikke en uhåndtert serverfeil.
+    """
+    try:
+        return les(config)
+    except KeyError as e:
+        felt = str(e.args[0]) if e.args else ""
+        navn = _SEKSJON_TEKST.get(felt, f"Feltet «{felt}»" if felt else "Et påkrevd felt")
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "feil": [
+                    f"{navn} mangler. Fyll inn opplysningene i Tall-steget før du genererer "
+                    "dette dokumentet."
+                ]
+            },
+        ) from e
+
+
 def _bygg_noter(config: dict) -> Noter:
     noter_cfg = config.get("noter") or {}
     return Noter(
@@ -51,7 +87,7 @@ def dok_skattemelding(request: Request, config: dict[str, Any] = Body(...)) -> d
     feil = sm.valider_selskap(config)
     if feil:
         raise HTTPException(status_code=422, detail={"feil": feil})
-    regnskap, konfig = sm.les_config(config)
+    regnskap, konfig = _les_eller_422(sm.les_config, config)
     tekst = sm.generer(regnskap, konfig)
     navn = f"skattemelding_{regnskap.regnskapsaar}_{regnskap.selskap.org_nummer}.txt"
     return {"filer": [_fil(navn, tekst.encode("utf-8"), "text/plain; charset=utf-8")]}
@@ -60,7 +96,7 @@ def dok_skattemelding(request: Request, config: dict[str, Any] = Body(...)) -> d
 @router.post("/aarsregnskap")
 def dok_aarsregnskap(request: Request, config: dict[str, Any] = Body(...)) -> dict:
     krev_invitert(request)
-    regnskap = ar.les_config(config)
+    regnskap = _les_eller_422(ar.les_config, config)
     feil = ar.valider(regnskap)
     if feil:
         raise HTTPException(status_code=422, detail={"feil": feil})
@@ -76,7 +112,7 @@ def dok_aarsregnskap(request: Request, config: dict[str, Any] = Body(...)) -> di
 @router.post("/aksjonaer")
 def dok_aksjonaer(request: Request, config: dict[str, Any] = Body(...)) -> dict:
     krev_invitert(request)
-    oppgave = akr.les_config(config)
+    oppgave = _les_eller_422(akr.les_config, config)
     feil = akr.valider(oppgave)
     if feil:
         raise HTTPException(status_code=422, detail={"feil": feil})
@@ -96,7 +132,7 @@ def dok_aksjonaer(request: Request, config: dict[str, Any] = Body(...)) -> dict:
 @router.post("/noter")
 def dok_noter(request: Request, config: dict[str, Any] = Body(...)) -> dict:
     krev_invitert(request)
-    regnskap = ar.les_config(config)
+    regnskap = _les_eller_422(ar.les_config, config)
     tekst = noter_modul.generer(regnskap, _bygg_noter(config))
     navn = f"noter_{regnskap.regnskapsaar}_{regnskap.selskap.org_nummer}.txt"
     return {"filer": [_fil(navn, tekst.encode("utf-8"), "text/plain; charset=utf-8")]}

--- a/hosted/diagnose_forhandsutfylt.py
+++ b/hosted/diagnose_forhandsutfylt.py
@@ -1,5 +1,5 @@
 """
-Lese-only diagnose: hent SKDs forhåndsutfylte skattemelding for ett orgnr/år og rapporter hva
+Skrivebeskyttet diagnose: hent SKDs forhåndsutfylte skattemelding for ett orgnr/år og rapporter hva
 visnings-API-et faktisk gir tilbake. Operatør-verktøy, kjøres lokalt med de samme
 HOSTED_VENDOR_*-creds som prod-appen (samme som list_systembrukere.py), så svaret er
 autoritativt for den kjørende tjenesten.
@@ -14,7 +14,7 @@ det (utkast/fastsatt), eller er året ikke klargjort (403/404)?
   HOSTED_VENDOR_KEY_PEM="$(cat vendor.pem)" \
       ./.venv/bin/python hosted/diagnose_forhandsutfylt.py <orgnr> <aar> [--valider]
 
-Read-only: henter kun, sender ingenting inn. Skriver ikke ut tall-/persondata fra den
+Skrivebeskyttet: henter kun, sender ingenting inn. Skriver ikke ut tall-/persondata fra den
 forhåndsutfylte, kun struktur (tag-navn), partsnummer (SKDs interne id) og HTTP-status.
 
 --valider: i tillegg, bygg en MINIMAL, GENERISK (ikke kundens) v5-skattemelding for orgnr/året

--- a/hosted/diagnose_forhandsutfylt.py
+++ b/hosted/diagnose_forhandsutfylt.py
@@ -1,0 +1,94 @@
+"""
+Lese-only diagnose: hent SKDs forhåndsutfylte skattemelding for ett orgnr/år og rapporter hva
+visnings-API-et faktisk gir tilbake. Operatør-verktøy, kjøres lokalt med de samme
+HOSTED_VENDOR_*-creds som prod-appen (samme som list_systembrukere.py), så svaret er
+autoritativt for den kjørende tjenesten.
+
+Bakgrunn: skattemelding-innsending bygger på partsnummer hentet fra den forhåndsutfylte
+(GET /api/skattemelding/v2/{aar}/{orgnr}). Mangler partsnummer, feiler innsendingen. Dette
+skriptet svarer på HVORFOR: kom det et 2xx-svar? finnes <partsnummer>? hva slags dokument er
+det (utkast/fastsatt), eller er året ikke klargjort (403/404)?
+
+  WENCHE_ENV=prod \
+  HOSTED_VENDOR_ORGNR=... HOSTED_VENDOR_CLIENT_ID=... HOSTED_VENDOR_KID=... \
+  HOSTED_VENDOR_KEY_PEM="$(cat vendor.pem)" \
+      ./.venv/bin/python hosted/diagnose_forhandsutfylt.py <orgnr> <aar>
+
+Read-only: henter kun, sender ingenting inn. Skriver ikke ut tall-/persondata fra den
+forhåndsutfylte, kun struktur (tag-navn), partsnummer (SKDs interne id) og HTTP-status.
+"""
+import os
+import sys
+from pathlib import Path
+from xml.etree.ElementTree import fromstring
+
+from wenche import auth as wauth
+from wenche.auth import SKD_SKATTEMELDING_SCOPE, VendorCredentials
+from wenche.skattemelding_xml import hent_partsnummer
+from wenche.skd_skattemelding_client import SkdSkattemeldingClient
+
+
+def _creds_fra_env() -> VendorCredentials:
+    orgnr = os.getenv("HOSTED_VENDOR_ORGNR")
+    client_id = os.getenv("HOSTED_VENDOR_CLIENT_ID")
+    kid = os.getenv("HOSTED_VENDOR_KID")
+    pem = os.getenv("HOSTED_VENDOR_KEY_PEM")
+    pem_path = os.getenv("HOSTED_VENDOR_KEY_PATH")
+    if not (orgnr and client_id and kid and (pem or pem_path)):
+        raise SystemExit(
+            "Mangler vendor-creds. Sett HOSTED_VENDOR_ORGNR/CLIENT_ID/KID og "
+            "HOSTED_VENDOR_KEY_PEM (eller _PATH), og WENCHE_ENV."
+        )
+    pem_bytes = pem.encode() if pem else Path(pem_path).read_bytes()
+    return VendorCredentials(client_id=client_id, kid=kid, private_key_pem=pem_bytes)
+
+
+def _lokal(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1]
+
+
+def main() -> None:
+    if len(sys.argv) < 3:
+        raise SystemExit("Bruk: python hosted/diagnose_forhandsutfylt.py <orgnr> <aar>")
+    orgnr, aar = sys.argv[1].strip(), int(sys.argv[2])
+    env = os.getenv("WENCHE_ENV", "prod")
+    creds = _creds_fra_env()
+
+    print(f"Miljø: {env}   org: {orgnr}   inntektsår: {aar}\n")
+
+    # Systembruker-token for kunde-orgen, akkurat som innsendingsruten henter det.
+    token = wauth.hent_tokens_for(creds, orgnr, SKD_SKATTEMELDING_SCOPE)["maskinporten_token"]
+
+    with SkdSkattemeldingClient(token, env=env) as skd:
+        try:
+            forhandsutfylt, dok_id = skd.hent_forhåndsutfylt_med_id(aar, orgnr)
+        except RuntimeError as e:
+            # Ikke-2xx fra SKD (f.eks. 403/404 = ikke klargjort, eller en feilkode som SMEVB-005).
+            print("HENTING FEILET (ikke-2xx fra Skatteetaten):")
+            print("  " + str(e).strip()[:800])
+            return
+
+    print("Henting OK (HTTP 2xx).")
+    print(f"  dokument_id: {dok_id!r}")
+
+    try:
+        root = fromstring(forhandsutfylt)
+    except Exception as e:  # noqa: BLE001 - vil se at svaret ikke er gyldig XML
+        print(f"  Svaret er ikke gyldig XML: {e}")
+        print(f"  Første 300 tegn: {forhandsutfylt[:300]!r}")
+        return
+
+    print(f"  rot-tag: {_lokal(root.tag)}")
+    print(f"  namespace: {root.tag[1:root.tag.rindex('}')] if '}' in root.tag else '(ingen)'}")
+    print(f"  barn (struktur, uten verdier): {[_lokal(c.tag) for c in root][:25]}")
+
+    try:
+        pn = hent_partsnummer(forhandsutfylt)
+        print(f"\n  partsnummer: FUNNET = {pn}  -> innsending ville fått partsnummer")
+    except Exception as e:  # noqa: BLE001
+        print(f"\n  partsnummer: MANGLER -> {str(e).splitlines()[0]}")
+        print("  Dette er årsaken til at skattemelding-innsending feiler.")
+
+
+if __name__ == "__main__":
+    main()

--- a/hosted/diagnose_forhandsutfylt.py
+++ b/hosted/diagnose_forhandsutfylt.py
@@ -12,10 +12,15 @@ det (utkast/fastsatt), eller er året ikke klargjort (403/404)?
   WENCHE_ENV=prod \
   HOSTED_VENDOR_ORGNR=... HOSTED_VENDOR_CLIENT_ID=... HOSTED_VENDOR_KID=... \
   HOSTED_VENDOR_KEY_PEM="$(cat vendor.pem)" \
-      ./.venv/bin/python hosted/diagnose_forhandsutfylt.py <orgnr> <aar>
+      ./.venv/bin/python hosted/diagnose_forhandsutfylt.py <orgnr> <aar> [--valider]
 
 Read-only: henter kun, sender ingenting inn. Skriver ikke ut tall-/persondata fra den
 forhåndsutfylte, kun struktur (tag-navn), partsnummer (SKDs interne id) og HTTP-status.
+
+--valider: i tillegg, bygg en MINIMAL, GENERISK (ikke kundens) v5-skattemelding for orgnr/året
+med det ekte partsnummeret, pakk konvolutten som ved ekte innsending, og kjør Skatteetatens
+`valider`-tjeneste (IKKE-BINDENDE, sender ingenting inn). Svarer på om v5 godtas for året eller
+avvises på skjemaversjon. Generiske tall, så ingen persondata involveres.
 """
 import os
 import sys
@@ -23,9 +28,34 @@ from pathlib import Path
 from xml.etree.ElementTree import fromstring
 
 from wenche import auth as wauth
+from wenche import skattemelding as sm
 from wenche.auth import SKD_SKATTEMELDING_SCOPE, VendorCredentials
-from wenche.skattemelding_xml import hent_partsnummer
+from wenche.naeringsspesifikasjon_xml import generer_naeringsspesifikasjon
+from wenche.skattemelding_konvolutt import generer_konvolutt
+from wenche.skattemelding_xml import generer_skattemelding_fra_konfig, hent_partsnummer
 from wenche.skd_skattemelding_client import SkdSkattemeldingClient
+
+
+def _minimal_config(orgnr: str, aar: int) -> dict:
+    """Minimal, balansert, GENERISK config — kun for å teste skjemaversjon, ikke kundens tall."""
+    return {
+        "selskap": {"navn": "DIAGNOSE AS", "org_nummer": orgnr, "daglig_leder": "Test Person",
+                    "styreleder": "Test Person", "forretningsadresse": "Testveien 1, 0001 OSLO",
+                    "stiftelsesaar": 2018, "aksjekapital": 30000, "kontakt_epost": "test@example.no"},
+        "regnskapsaar": aar,
+        "resultatregnskap": {"driftsinntekter": {"salgsinntekter": 0, "andre_driftsinntekter": 0},
+            "driftskostnader": {"loennskostnader": 0, "avskrivninger": 0, "andre_driftskostnader": 0},
+            "finansposter": {"utbytte_fra_datterselskap": 0, "andre_finansinntekter": 0,
+                             "rentekostnader": 0, "andre_finanskostnader": 0}},
+        "balanse": {"eiendeler": {"anleggsmidler": {"aksjer_i_datterselskap": 0, "andre_aksjer": 0, "langsiktige_fordringer": 0},
+                        "omloepmidler": {"kortsiktige_fordringer": 0, "bankinnskudd": 30000}},
+            "egenkapital_og_gjeld": {"egenkapital": {"aksjekapital": 30000, "overkursfond": 0, "annen_egenkapital": 0},
+                "langsiktig_gjeld": {"laan_fra_aksjonaer": 0, "andre_langsiktige_laan": 0},
+                "kortsiktig_gjeld": {"leverandoergjeld": 0, "skyldige_offentlige_avgifter": 0, "annen_kortsiktig_gjeld": 0}}},
+        "skattemelding": {"anvend_fritaksmetoden": True, "boersnotert": False,
+                          "underskudd_til_fremfoering": 0, "formuesverdi_aksjer": 0},
+        "aksjonaerer": [],
+    }
 
 
 def _creds_fra_env() -> VendorCredentials:
@@ -49,8 +79,9 @@ def _lokal(tag: str) -> str:
 
 def main() -> None:
     if len(sys.argv) < 3:
-        raise SystemExit("Bruk: python hosted/diagnose_forhandsutfylt.py <orgnr> <aar>")
+        raise SystemExit("Bruk: python hosted/diagnose_forhandsutfylt.py <orgnr> <aar> [--valider]")
     orgnr, aar = sys.argv[1].strip(), int(sys.argv[2])
+    gjor_valider = "--valider" in sys.argv[3:]
     env = os.getenv("WENCHE_ENV", "prod")
     creds = _creds_fra_env()
 
@@ -68,26 +99,54 @@ def main() -> None:
             print("  " + str(e).strip()[:800])
             return
 
-    print("Henting OK (HTTP 2xx).")
-    print(f"  dokument_id: {dok_id!r}")
+        print("Henting OK (HTTP 2xx).")
+        print(f"  dokument_id: {dok_id!r}")
 
-    try:
-        root = fromstring(forhandsutfylt)
-    except Exception as e:  # noqa: BLE001 - vil se at svaret ikke er gyldig XML
-        print(f"  Svaret er ikke gyldig XML: {e}")
-        print(f"  Første 300 tegn: {forhandsutfylt[:300]!r}")
-        return
+        try:
+            root = fromstring(forhandsutfylt)
+            print(f"  rot-tag: {_lokal(root.tag)}")
+            print(f"  namespace: {root.tag[1:root.tag.rindex('}')] if '}' in root.tag else '(ingen)'}")
+            print(f"  barn (struktur, uten verdier): {[_lokal(c.tag) for c in root][:25]}")
+        except Exception as e:  # noqa: BLE001 - vil se at svaret ikke er gyldig XML
+            print(f"  Svaret er ikke gyldig XML: {e}")
+            print(f"  Første 300 tegn: {forhandsutfylt[:300]!r}")
+            return
 
-    print(f"  rot-tag: {_lokal(root.tag)}")
-    print(f"  namespace: {root.tag[1:root.tag.rindex('}')] if '}' in root.tag else '(ingen)'}")
-    print(f"  barn (struktur, uten verdier): {[_lokal(c.tag) for c in root][:25]}")
+        try:
+            pn = hent_partsnummer(forhandsutfylt)
+            print(f"\n  partsnummer: FUNNET = {pn}")
+        except Exception as e:  # noqa: BLE001
+            print(f"\n  partsnummer: MANGLER -> {str(e).splitlines()[0]}")
+            print("  Dette er årsaken til at skattemelding-innsending feiler.")
+            return
 
-    try:
-        pn = hent_partsnummer(forhandsutfylt)
-        print(f"\n  partsnummer: FUNNET = {pn}  -> innsending ville fått partsnummer")
-    except Exception as e:  # noqa: BLE001
-        print(f"\n  partsnummer: MANGLER -> {str(e).splitlines()[0]}")
-        print("  Dette er årsaken til at skattemelding-innsending feiler.")
+        if not gjor_valider:
+            print("\n(Kjør med --valider for ikke-bindende valideringssjekk av v5 mot dette året.)")
+            return
+
+        # Ikke-bindende: bygg en MINIMAL, GENERISK v5-skattemelding for året og valider.
+        print(f"\n--- Ikke-bindende valider (GENERISKE tall, sender ingenting inn) ---")
+        regnskap, konfig = sm.les_config(_minimal_config(orgnr, aar))
+        sm_xml = generer_skattemelding_fra_konfig(regnskap, konfig, pn)
+        naer_xml = generer_naeringsspesifikasjon(regnskap, pn)
+        konvolutt = generer_konvolutt(
+            skattemelding_xml=sm_xml, inntektsaar=aar, orgnr=orgnr,
+            naeringsspesifikasjon_xml=naer_xml, gjeldende_dokument_id=dok_id,
+        )
+        try:
+            res = skd.valider(aar, orgnr, konvolutt)
+        except RuntimeError as e:
+            print("  VALIDER FEILET (ikke-2xx) — peker ofte på skjema-/versjonsavvik:")
+            print("  " + str(e).strip()[:900])
+            return
+        print(f"  resultat: {res.get('resultat')}")
+        if res.get("aarsak"):
+            print(f"  aarsak: {res.get('aarsak')}")
+        for nokkel in ("avvik_ved_validering", "avvik_etter_beregning"):
+            avvik = res.get(nokkel) or []
+            print(f"  {nokkel}: {len(avvik)}")
+            for a in avvik[:8]:
+                print(f"     - {a.get('avvikstype') or a.get('kode') or a}")
 
 
 if __name__ == "__main__":

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -596,6 +596,9 @@ export default function App() {
   const [fane, setFane] = useState<FaneId>("hjem");
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const [config, setConfig] = useState<any | null>(null);
+  // Feil ved innløsning av en invite-/handoff-lenke. Vises som banner så en avvist lenke ikke
+  // svelges stille (se useEffect under).
+  const [lenkeFeil, setLenkeFeil] = useState<string | null>(null);
 
   const refresh = () => api.me().then(setMe).catch(() => setMe({ invited: false }));
 
@@ -612,7 +615,13 @@ export default function App() {
         : null;
     if (losInn) {
       losInn
-        .catch(() => {})
+        .then((r) => {
+          // En avvist eller utløpt lenke svarer 200 med {invited:false, feil}. Uten dette ville
+          // brukeren havnet stille på gateskjermen (eller en gammel økt fra et tidligere forsøk,
+          // som viser samme tilkoblingsskjerm) uten å skjønne at lenken var ugyldig. Vis feilen.
+          if (r && !r.invited) setLenkeFeil(r.feil ?? "Ugyldig invitasjonslenke.");
+        })
+        .catch(() => setLenkeFeil("Kunne ikke lese invitasjonslenken. Prøv igjen, eller be om en ny."))
         .finally(() => {
           window.history.replaceState({}, "", window.location.pathname);
           refresh();
@@ -695,6 +704,29 @@ export default function App() {
       </header>
 
       <main className="mx-auto max-w-2xl px-6 py-12">
+        {lenkeFeil && (
+          <div
+            role="alert"
+            className="mb-8 flex items-start justify-between gap-4 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm leading-relaxed text-red-700"
+          >
+            <span>
+              {lenkeFeil}
+              {me?.kontakt && (
+                <>
+                  {" "}
+                  Be om en ny lenke: <KontaktLenke kontakt={me.kontakt} />.
+                </>
+              )}
+            </span>
+            <button
+              className="shrink-0 text-red-700/70 transition hover:text-red-700"
+              onClick={() => setLenkeFeil(null)}
+              aria-label="Lukk"
+            >
+              ✕
+            </button>
+          </div>
+        )}
         {!me ? (
           <p className="text-sm text-muted-foreground">Laster…</p>
         ) : !me.invited ? (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.33.3"
+version = "0.33.4"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_hosted_dokumenter.py
+++ b/tests/test_hosted_dokumenter.py
@@ -103,3 +103,31 @@ def test_skattemelding_tomt_stiftelsesaar_gir_422_ikke_500(klient, verdi):
     assert r.status_code == 422, r.text
     feil = r.json()["detail"]["feil"]
     assert any("Stiftelsesår" in f for f in feil)
+
+
+@pytest.mark.parametrize("type_", ["skattemelding", "aarsregnskap", "noter"])
+@pytest.mark.parametrize("seksjon,navn", [("resultatregnskap", "Resultatregnskapet"), ("balanse", "Balansen")])
+def test_manglende_tall_gir_422_ikke_500(klient, type_, seksjon, navn):
+    # Regresjon: et ufullstendig Tall-steg (manglende resultatregnskap eller balanse) fikk
+    # les_config til å kaste KeyError -> naken HTTP 500. Nå er det et rettbart avvik som peker
+    # brukeren til Tall-steget.
+    _inviter(klient)
+    cfg = _gyldig_config()
+    del cfg[seksjon]
+    r = klient.post(f"/api/dokumenter/{type_}", json=cfg)
+    assert r.status_code == 422, r.text
+    feil = r.json()["detail"]["feil"]
+    assert any(navn in f and "Tall-steget" in f for f in feil), feil
+
+
+def test_aksjonaer_genereres_uten_tall(klient):
+    # Aksjonærregisteret leser ikke resultatregnskap/balanse, så det skal generere selv når
+    # tallene mangler. Dette er asymmetrien som gjorde at bare aksjonær virket før tallene var
+    # fylt inn.
+    _inviter(klient)
+    cfg = _gyldig_config()
+    del cfg["resultatregnskap"]
+    del cfg["balanse"]
+    r = klient.post("/api/dokumenter/aksjonaer", json=cfg)
+    assert r.status_code == 200, r.text
+    assert r.json()["filer"]

--- a/tests/test_innsending_skattemelding_partsnummer.py
+++ b/tests/test_innsending_skattemelding_partsnummer.py
@@ -1,0 +1,50 @@
+"""
+Regresjon: når SKDs visnings-API ikke gir et brukbart partsnummer i den forhåndsutfylte
+skattemeldingen, kastet `hent_partsnummer` en bar `ValueError`. I hostet `_utfor` er ikke
+ValueError i fangst-listen, så den ble en naken HTTP 500 («Uventet feil under innsending»).
+send_skattemelding gjør den nå om til en lesbar RuntimeError (-> 502), uten å sende noe inn.
+"""
+from unittest.mock import Mock
+
+import pytest
+
+from wenche import innsending as tjeneste
+
+_CONFIG = {
+    "selskap": {"navn": "Test AS", "org_nummer": "314273818", "daglig_leder": "Ola Nordmann",
+                "styreleder": "Ola Nordmann", "forretningsadresse": "Testveien 1, 0001 Oslo",
+                "stiftelsesaar": 2018, "aksjekapital": 30000, "kontakt_epost": "test@example.no"},
+    "regnskapsaar": 2024,
+    "resultatregnskap": {
+        "driftsinntekter": {"salgsinntekter": 0, "andre_driftsinntekter": 0},
+        "driftskostnader": {"loennskostnader": 0, "avskrivninger": 0, "andre_driftskostnader": 0},
+        "finansposter": {"utbytte_fra_datterselskap": 0, "andre_finansinntekter": 0,
+                         "rentekostnader": 0, "andre_finanskostnader": 0}},
+    "balanse": {
+        "eiendeler": {"anleggsmidler": {"aksjer_i_datterselskap": 0, "andre_aksjer": 0, "langsiktige_fordringer": 0},
+                      "omloepmidler": {"kortsiktige_fordringer": 0, "bankinnskudd": 30000}},
+        "egenkapital_og_gjeld": {
+            "egenkapital": {"aksjekapital": 30000, "overkursfond": 0, "annen_egenkapital": 0},
+            "langsiktig_gjeld": {"laan_fra_aksjonaer": 0, "andre_langsiktige_laan": 0},
+            "kortsiktig_gjeld": {"leverandoergjeld": 0, "skyldige_offentlige_avgifter": 0, "annen_kortsiktig_gjeld": 0}}},
+    "skattemelding": {"anvend_fritaksmetoden": False, "boersnotert": False,
+                      "underskudd_til_fremfoering": 0, "formuesverdi_aksjer": 0},
+    "aksjonaerer": [{"navn": "Kari", "fodselsnummer": "24847799354", "antall_aksjer": 300,
+                     "aksjeklasse": "ordinære", "utbytte_utbetalt": 0, "innbetalt_kapital_per_aksje": 100}],
+}
+
+# Forhåndsutfylt uten <partsnummer> (typisk hvis skattemeldingen for året ikke er klargjort).
+_UTEN_PARTSNUMMER = (
+    '<skattemelding xmlns="urn:no:skatteetaten:fastsetting:formueinntekt:'
+    'skattemelding:upersonlig:ekstern:v5"><inntektsaar>2024</inntektsaar></skattemelding>'
+).encode("utf-8")
+
+
+def test_manglende_partsnummer_gir_lesbar_runtimeerror_ikke_500():
+    skd = Mock()
+    skd.hent_forhåndsutfylt_med_id.return_value = (_UTEN_PARTSNUMMER, None)
+    with pytest.raises(RuntimeError) as ei:
+        tjeneste.send_skattemelding(_CONFIG, skd, "altinn-token", orgnr="314273818")
+    melding = str(ei.value)
+    assert "partsnummer" in melding and "Ingenting er" in melding
+    skd.send.assert_not_called()  # ingenting sendt inn

--- a/tests/test_les_config_dual.py
+++ b/tests/test_les_config_dual.py
@@ -4,6 +4,8 @@ Den delte grensen mellom standalone (CLI/NiceGUI) og den hostede appen:
 dict (hosted sender config i request-body), og gi IDENTISK resultat. Brekker noen denne
 ekvivalensen, brekker enten standalone eller webapp i stillhet, derav disse regresjonsvaktene.
 """
+import copy
+
 import yaml
 
 from wenche import aarsregnskap as ar
@@ -78,3 +80,37 @@ def test_skattemelding_dict_og_fil_gir_likt(tmp_path):
 
 def test_aksjonaer_dict_og_fil_gir_likt(tmp_path):
     assert akr.les_config(dict(_CFG)) == akr.les_config(_fil(tmp_path))
+
+
+def test_delvis_fjoraar_uten_underseksjoner_kraesjer_ikke():
+    # Regresjon: skjemaet utelater urørte (valgfrie) felt, så et delvis utfylt fjorår mangler
+    # hele underseksjoner (her driftsinntekter). Før kastet _les_resultat KeyError på det direkte
+    # oppslaget -> «Uventet feil under innsending» (HTTP 500). Nå leses de manglende som 0.
+    cfg = copy.deepcopy(_CFG)
+    cfg["foregaaende_aar"] = {
+        "resultatregnskap": {"driftskostnader": {"andre_driftskostnader": 5.5},
+                             "finansposter": {"rentekostnader": 70086}},
+        "balanse": {"eiendeler": {"anleggsmidler": {"andre_aksjer": 2271521.28}}},
+    }
+    regnskap = ar.les_config(cfg)
+    assert regnskap.foregaaende_aar_resultat.driftsinntekter.salgsinntekter == 0
+    assert regnskap.foregaaende_aar_resultat.driftskostnader.andre_driftskostnader == 5.5
+    assert regnskap.foregaaende_aar_balanse.eiendeler.anleggsmidler.andre_aksjer == 2271521.28
+    # skattemelding deler de samme leserne
+    sm.les_config(cfg)
+
+
+def test_tomme_strenger_i_tallfelt_tolkes_som_null():
+    # Regresjon: et blankt tallfelt sendes som "" fra skjemaet. Før ble float("")/int("") en
+    # naken 500; nå tolkes tomt som 0 (og tom eierandel som 100 %, tom samlet_verdi som None).
+    cfg = copy.deepcopy(_CFG)
+    cfg["balanse"]["eiendeler"]["omloepmidler"]["bankinnskudd"] = ""
+    cfg["skattemelding"]["underskudd_til_fremfoering"] = ""
+    cfg["skattemelding"]["eierandel_for_fritaksmetoden"] = ""
+    cfg["skattemelding"]["samlet_verdi_bak_aksjene"] = ""
+    regnskap = ar.les_config(cfg)
+    assert regnskap.balanse.eiendeler.omloepmidler.bankinnskudd == 0
+    _, konfig = sm.les_config(cfg)
+    assert konfig.underskudd_til_fremfoering == 0
+    assert konfig.eierandel_for_fritaksmetoden == 100
+    assert konfig.samlet_verdi_bak_aksjene is None

--- a/tests/test_skattemelding_xml.py
+++ b/tests/test_skattemelding_xml.py
@@ -12,7 +12,7 @@ from xml.etree.ElementTree import fromstring
 
 import pytest
 
-from wenche.skattemelding_xml import generer_skattemelding_upersonlig
+from wenche.skattemelding_xml import generer_skattemelding_upersonlig, hent_partsnummer
 
 _NS = (
     "urn:no:skatteetaten:fastsetting:formueinntekt:"
@@ -205,3 +205,37 @@ class TestVerdsettingAvAksje:
         # Ingen formue-input → ingen verdsettingAvAksje-blokk
         root = _parse(generer_skattemelding_upersonlig(12345678, 2024))
         assert root.find(f"{{{_NS}}}verdsettingAvAksje") is None
+
+
+class TestHentPartsnummer:
+    """Partsnummer hentes uavhengig av skjemaversjon på den forhåndsutfylte.
+
+    Skatteetaten serverer forhåndsutfylt i versjonen som gjelder for inntektsåret: 2024 kom
+    i v4-namespacet, 2025 i v5. hent_partsnummer låste før til v5 og kastet en feilaktig
+    «mangler partsnummer» for v4 (WiNo / inntektsår 2024), som ble en naken 500 ved innsending.
+    """
+
+    def _forhandsutfylt(self, ekstern_versjon: str) -> bytes:
+        ns = (
+            "urn:no:skatteetaten:fastsetting:formueinntekt:"
+            f"skattemelding:upersonlig:ekstern:{ekstern_versjon}"
+        )
+        return (
+            f'<skattemelding xmlns="{ns}"><partsnummer>826662392</partsnummer>'
+            "<inntektsaar>2024</inntektsaar></skattemelding>"
+        ).encode("utf-8")
+
+    def test_v5(self):
+        assert hent_partsnummer(self._forhandsutfylt("v5")) == 826662392
+
+    def test_v4(self):
+        # Regresjon: 2024-forhåndsutfylt er v4.
+        assert hent_partsnummer(self._forhandsutfylt("v4")) == 826662392
+
+    def test_manglende_partsnummer_kaster(self):
+        uten = (
+            '<skattemelding xmlns="urn:no:skatteetaten:fastsetting:formueinntekt:'
+            'skattemelding:upersonlig:ekstern:v4"><inntektsaar>2024</inntektsaar></skattemelding>'
+        ).encode("utf-8")
+        with pytest.raises(ValueError):
+            hent_partsnummer(uten)

--- a/wenche/aarsregnskap.py
+++ b/wenche/aarsregnskap.py
@@ -24,53 +24,77 @@ from wenche.models import (
 from wenche.brg_xml import generer_aksjenote_vedlegg, generer_hovedskjema, generer_underskjema
 
 
+def _tall(verdi) -> float:
+    """Tolererer tomme og manglende tallfelt (None, "", whitespace) som 0.0, ellers float().
+
+    Skjemaet utelater urørte (valgfrie) felt og sender tom streng for blanke. Et passivt
+    holdingselskap har legitimt mange slike, særlig i fjorårstallene. Uten dette havnet en ""
+    eller None i modellen og fikk summeringen til å kaste TypeError -> naken HTTP 500.
+    """
+    if verdi is None or (isinstance(verdi, str) and not verdi.strip()):
+        return 0.0
+    return float(verdi)
+
+
 def _les_resultat(r: dict) -> Resultatregnskap:
+    # .get(..., {}) på hver underseksjon: et delvis utfylt år (typisk fjoråret) utelater hele
+    # seksjoner brukeren ikke rørte, så et direkte oppslag ville kastet KeyError -> 500.
+    di = r.get("driftsinntekter", {})
+    dk = r.get("driftskostnader", {})
+    fp = r.get("finansposter", {})
     return Resultatregnskap(
         driftsinntekter=Driftsinntekter(
-            salgsinntekter=r["driftsinntekter"].get("salgsinntekter", 0),
-            andre_driftsinntekter=r["driftsinntekter"].get("andre_driftsinntekter", 0),
+            salgsinntekter=_tall(di.get("salgsinntekter")),
+            andre_driftsinntekter=_tall(di.get("andre_driftsinntekter")),
         ),
         driftskostnader=Driftskostnader(
-            loennskostnader=r["driftskostnader"].get("loennskostnader", 0),
-            avskrivninger=r["driftskostnader"].get("avskrivninger", 0),
-            andre_driftskostnader=r["driftskostnader"].get("andre_driftskostnader", 0),
+            loennskostnader=_tall(dk.get("loennskostnader")),
+            avskrivninger=_tall(dk.get("avskrivninger")),
+            andre_driftskostnader=_tall(dk.get("andre_driftskostnader")),
         ),
         finansposter=Finansposter(
-            utbytte_fra_datterselskap=r["finansposter"].get("utbytte_fra_datterselskap", 0),
-            andre_finansinntekter=r["finansposter"].get("andre_finansinntekter", 0),
-            rentekostnader=r["finansposter"].get("rentekostnader", 0),
-            andre_finanskostnader=r["finansposter"].get("andre_finanskostnader", 0),
+            utbytte_fra_datterselskap=_tall(fp.get("utbytte_fra_datterselskap")),
+            andre_finansinntekter=_tall(fp.get("andre_finansinntekter")),
+            rentekostnader=_tall(fp.get("rentekostnader")),
+            andre_finanskostnader=_tall(fp.get("andre_finanskostnader")),
         ),
     )
 
 
 def _les_balanse(b: dict) -> Balanse:
+    eiendeler = b.get("eiendeler", {})
+    am = eiendeler.get("anleggsmidler", {})
+    om = eiendeler.get("omloepmidler", {})
+    ekg = b.get("egenkapital_og_gjeld", {})
+    ek = ekg.get("egenkapital", {})
+    lg = ekg.get("langsiktig_gjeld", {})
+    kg = ekg.get("kortsiktig_gjeld", {})
     return Balanse(
         eiendeler=Eiendeler(
             anleggsmidler=Anleggsmidler(
-                aksjer_i_datterselskap=b["eiendeler"]["anleggsmidler"].get("aksjer_i_datterselskap", 0),
-                andre_aksjer=b["eiendeler"]["anleggsmidler"].get("andre_aksjer", 0),
-                langsiktige_fordringer=b["eiendeler"]["anleggsmidler"].get("langsiktige_fordringer", 0),
+                aksjer_i_datterselskap=_tall(am.get("aksjer_i_datterselskap")),
+                andre_aksjer=_tall(am.get("andre_aksjer")),
+                langsiktige_fordringer=_tall(am.get("langsiktige_fordringer")),
             ),
             omloepmidler=Omloepmidler(
-                kortsiktige_fordringer=b["eiendeler"]["omloepmidler"].get("kortsiktige_fordringer", 0),
-                bankinnskudd=b["eiendeler"]["omloepmidler"].get("bankinnskudd", 0),
+                kortsiktige_fordringer=_tall(om.get("kortsiktige_fordringer")),
+                bankinnskudd=_tall(om.get("bankinnskudd")),
             ),
         ),
         egenkapital_og_gjeld=EgenkapitalOgGjeld(
             egenkapital=Egenkapital(
-                aksjekapital=b["egenkapital_og_gjeld"]["egenkapital"].get("aksjekapital", 0),
-                overkursfond=b["egenkapital_og_gjeld"]["egenkapital"].get("overkursfond", 0),
-                annen_egenkapital=b["egenkapital_og_gjeld"]["egenkapital"].get("annen_egenkapital", 0),
+                aksjekapital=_tall(ek.get("aksjekapital")),
+                overkursfond=_tall(ek.get("overkursfond")),
+                annen_egenkapital=_tall(ek.get("annen_egenkapital")),
             ),
             langsiktig_gjeld=LangsiktigGjeld(
-                laan_fra_aksjonaer=b["egenkapital_og_gjeld"]["langsiktig_gjeld"].get("laan_fra_aksjonaer", 0),
-                andre_langsiktige_laan=b["egenkapital_og_gjeld"]["langsiktig_gjeld"].get("andre_langsiktige_laan", 0),
+                laan_fra_aksjonaer=_tall(lg.get("laan_fra_aksjonaer")),
+                andre_langsiktige_laan=_tall(lg.get("andre_langsiktige_laan")),
             ),
             kortsiktig_gjeld=KortsiktigGjeld(
-                leverandoergjeld=b["egenkapital_og_gjeld"]["kortsiktig_gjeld"].get("leverandoergjeld", 0),
-                skyldige_offentlige_avgifter=b["egenkapital_og_gjeld"]["kortsiktig_gjeld"].get("skyldige_offentlige_avgifter", 0),
-                annen_kortsiktig_gjeld=b["egenkapital_og_gjeld"]["kortsiktig_gjeld"].get("annen_kortsiktig_gjeld", 0),
+                leverandoergjeld=_tall(kg.get("leverandoergjeld")),
+                skyldige_offentlige_avgifter=_tall(kg.get("skyldige_offentlige_avgifter")),
+                annen_kortsiktig_gjeld=_tall(kg.get("annen_kortsiktig_gjeld")),
             ),
         ),
     )

--- a/wenche/innsending.py
+++ b/wenche/innsending.py
@@ -106,7 +106,20 @@ def send_skattemelding(
         forhåndsutfylt, gjeldende_dokument_id = skd_klient.hent_forhåndsutfylt_med_id(
             regnskap.regnskapsaar, orgnr
         )
-        partsnummer = hent_partsnummer(forhåndsutfylt)
+        # hent_partsnummer kaster ValueError (eller en XML-parse-/decode-feil) hvis svaret fra
+        # SKDs visnings-API ikke bærer et partsnummer. Det er en upstream-/tilgjengelighets-
+        # tilstand (skattemeldingen for orgen/året er kanskje ikke klargjort hos Skatteetaten),
+        # ikke en feil i tallene. Gjør den om til en lesbar RuntimeError, ellers slipper en
+        # uventet exception-type forbi 502-fellen i hostet `_utfor` og blir en naken 500.
+        try:
+            partsnummer = hent_partsnummer(forhåndsutfylt)
+        except Exception as e:
+            raise RuntimeError(
+                f"Skatteetaten ga ikke en brukbar forhåndsutfylt skattemelding for {orgnr} "
+                f"(inntektsår {regnskap.regnskapsaar}); fant ikke partsnummer. Ingenting er "
+                "sendt inn. Skattemeldingen for dette året er kanskje ikke klargjort hos "
+                "Skatteetaten ennå. Prøv igjen senere, eller ta kontakt."
+            ) from e
     skattemelding_xml = generer_skattemelding_fra_konfig(regnskap, konfig, partsnummer)
     naeringsspesifikasjon_xml = generer_naeringsspesifikasjon(regnskap, partsnummer)
     instans_id = skd_klient.send(

--- a/wenche/skattemelding.py
+++ b/wenche/skattemelding.py
@@ -12,7 +12,7 @@ import math
 
 import yaml
 
-from wenche.aarsregnskap import _les_resultat, _les_balanse
+from wenche.aarsregnskap import _les_resultat, _les_balanse, _tall as _belop
 from wenche.models import (
     Aarsregnskap,
     Balanse,
@@ -130,17 +130,19 @@ def les_config(config_fil: str | dict) -> tuple[Aarsregnskap, SkattemeldingKonfi
         utbytte_utbetalt=utbytte_utbetalt,
     )
 
+    # Blanke tallfelt sendes som "" fra skjemaet, så vi tolererer dem (som leserne over) i
+    # stedet for å la float("")/int("") bli en naken 500. Tomt eierandel = 100 % (helt
+    # skattefritt), tom samlet_verdi = ingen overstyring.
     sm_raw = raw.get("skattemelding", {})
+    _eierandel = sm_raw.get("eierandel_for_fritaksmetoden")
     _verdi_override = sm_raw.get("samlet_verdi_bak_aksjene")
     konfig = SkattemeldingKonfig(
-        underskudd_til_fremfoering=float(sm_raw.get("underskudd_til_fremfoering", 0)),
+        underskudd_til_fremfoering=_belop(sm_raw.get("underskudd_til_fremfoering")),
         anvend_fritaksmetoden=bool(sm_raw.get("anvend_fritaksmetoden", True)),
-        eierandel_for_fritaksmetoden=int(sm_raw.get("eierandel_for_fritaksmetoden", 100)),
+        eierandel_for_fritaksmetoden=100 if _er_tom(_eierandel) else int(float(_eierandel)),
         boersnotert=bool(sm_raw.get("boersnotert", False)),
-        formuesverdi_aksjer=float(sm_raw.get("formuesverdi_aksjer", 0)),
-        samlet_verdi_bak_aksjene=(
-            float(_verdi_override) if _verdi_override is not None else None
-        ),
+        formuesverdi_aksjer=_belop(sm_raw.get("formuesverdi_aksjer")),
+        samlet_verdi_bak_aksjene=None if _er_tom(_verdi_override) else float(_verdi_override),
     )
 
     return regnskap, konfig

--- a/wenche/skattemelding_xml.py
+++ b/wenche/skattemelding_xml.py
@@ -267,10 +267,15 @@ def hent_partsnummer(skattemelding_xml: bytes) -> int:
         ValueError: hvis partsnummer ikke finnes i XML-en.
     """
     root = fromstring(skattemelding_xml.decode("utf-8"))
+    # Skatteetaten serverer forhåndsutfylt i skjemaversjonen som gjelder for inntektsåret
+    # (2024 = v4, 2025 = v5), mens denne modulen ellers genererer v5. Partsnummer er likt på
+    # tvers av versjonene, så finn det namespace-agnostisk i stedet for å låse til v5 (det ga
+    # en feilaktig «mangler partsnummer» når den forhåndsutfylte var v4).
     element = root.find(f"{{{_NS}}}partsnummer")
+    if element is None:
+        element = root.find(".//{*}partsnummer")
     if element is None or not element.text:
         raise ValueError(
-            "Fant ikke <partsnummer> i skattemelding-XML-en. "
-            "Kontroller at XML-en er en gyldig skattemeldingUpersonlig v5."
+            "Fant ikke <partsnummer> i forhåndsutfylt skattemelding fra Skatteetaten."
         )
     return int(element.text)


### PR DESCRIPTION
## Bakgrunn

En rekke påregnelige brukertilstander i den hostede tjenesten endte i stille svikt eller en naken HTTP 500, uten en melding brukeren kunne handle på. Alle dukket opp i reell bruk under et årsoppgjør.

## Endringer

### 1. Avvist invitasjons- eller overføringslenke (`App.tsx`)

En avvist eller utløpt invite-/handoff-lenke svarer HTTP 200 med `{invited: false, feil}`, men SPA-en svelget svaret stille (`.catch(() => {})`). Brukeren havnet uten tilbakemelding på gateskjermen, eller på en gammel økt fra et tidligere forsøk som viser samme tilkoblingsskjerm, og trodde lenken virket. Nå leses `feil`-feltet og vises som et lukkbart banner (`role="alert"`) uavhengig av øktstatus.

### 2. Manglende regnskapstall ved dokumentgenerering (`dokumenter.py`)

Et ufullstendig Tall-steg (tomt `resultatregnskap`/`balanse`) fikk `les_config` til å kaste `KeyError` -> HTTP 500 ved nedlasting av skattemelding, årsregnskap og noter. Aksjonærregisteret leser ikke disse seksjonene, så det var det eneste som lot seg generere (forvirrende delvis feil). Ny hjelper `_les_eller_422` gir et rettbart 422-avvik som peker til Tall-steget.

### 3. Tomme og manglende tallfelt ved innsending (`aarsregnskap.py`, `skattemelding.py`)

Et delvis utfylt år (typisk fjoråret i et passivt holdingselskap) utelater hele underseksjoner brukeren ikke rørte, fordi skjemaet bare bygger delobjekter langs rørte stier. `_les_resultat`/`_les_balanse` gjorde direkte oppslag på underseksjonene (kun bladene var `.get`-beskyttet), så en manglende seksjon kastet `KeyError`. Blanke tallfelt sendes dessuten som tom streng, som ga `float('')`/`int('')`-feil. Begge ble fanget av siste-skanse-handleren i innsending og vist som «Uventet feil under innsending» (HTTP 500), for både årsregnskap og skattemelding.

Leserne henter nå hver underseksjon med `.get(..., {})` og tolker tomme/manglende tallfelt (None, `''`, whitespace) som 0. Skattemelding-konfigen tolererer tilsvarende blanke felt. Deles av CLI, self-hosted og hostet.

### 4. Partsnummer leses uavhengig av skjemaversjon (`skattemelding_xml.py`)

Skatteetaten serverer forhåndsutfylt skattemelding i skjemaversjonen som gjelder for inntektsåret (eldre inntektsår i v4, nyere i v5). `hent_partsnummer` låste til v5-namespacet, så for et v4-svar fant den ikke `<partsnummer>` selv om det lå der, og kastet en feilaktig `ValueError` -> «Uventet feil under innsending» (HTTP 500). Partsnummer leses nå namespace-agnostisk (faller tilbake til `{*}` hvis v5 ikke matcher).

### 5. Lesbar feil når forhåndsutfylt mangler partsnummer (`innsending.py`)

`hent_partsnummer` kunne kaste `ValueError` (eller en XML-parse-/decode-feil), som ikke var i fangst-listen til hostet `_utfor` og dermed ble en naken 500. `send_skattemelding` wrapper det nå i en lesbar `RuntimeError` (-> 502): «Skatteetaten ga ikke en brukbar forhåndsutfylt skattemelding ... ingenting er sendt inn.»

### 6. Operatør-diagnose (`hosted/diagnose_forhandsutfylt.py`)

Skrivebeskyttet verktøy (samme creds-mønster som `list_systembrukere.py`) som henter forhåndsutfylt skattemelding for et orgnr/år og rapporterer HTTP-status, skjemaversjon (namespace), struktur og om `<partsnummer>` finnes. Med `--valider` bygger den en minimal, generisk skattemelding og kjører Skatteetatens ikke-bindende `valider` for å se om gjeldende skjemaversjon godtas for året. Sender ingenting inn, skriver ikke ut tall-/persondata.

## Kjent begrensning

Innsending genererer v5-skjemaet (verifisert for inneværende inntektsår). Eldre inntektsår som Skatteetaten kun tar imot i v4, avvises på skjemanivå (`xmlValideringsfeilPaaSkattemelding`) og støttes ikke. Fiksene over gjør at slike tilfeller nå feiler lesbart i stedet for med en naken 500.

## Tester

- `test_hosted_dokumenter.py`: manglende `resultatregnskap`/`balanse` gir 422 (ikke 500); aksjonær genereres fortsatt uten tallene.
- `test_les_config_dual.py`: delvis fjorår uten underseksjoner og tomme strenger i tallfelt leses uten å kaste, med fornuftige standardverdier.
- `test_skattemelding_xml.py`: `hent_partsnummer` finner partsnummer i både v4- og v5-namespace, og kaster lesbart når det faktisk mangler.
- `test_innsending_skattemelding_partsnummer.py`: manglende partsnummer gir lesbar `RuntimeError` (ikke 500), og ingenting sendes inn.
- Hele suiten grønn (472 passerer).

## Versjon og deploy

Punkt 3, 4 og 5 er wheel-relevante, så versjon bumpes til 0.33.4. Punkt 1, 2 og 6 er i `hosted/` (Docker-imaget på Fly). Rulles ut med Fly-deploy + ny wheel til PyPI når det er trygt (en deploy restarter maskinen og nullstiller pågående in-memory-økter).

