### PR TITLE
feat(hosted): ID-porten-innlogging med valg av selskap fra Altinn

### DIFF
--- a/docs/hostet.md
+++ b/docs/hostet.md
@@ -16,10 +16,11 @@ Den hostede tjenesten er for deg som heller vil slippe det tekniske oppsettet. D
 nøyaktig samme åpne kildekode under panseret, så du kan når som helst velge å kjøre
 self-hosted i stedet.
 
-Du logger inn med **ID-porten** (BankID). Etter innlogging henter jeg automatisk listen over
-selskaper du kan handle for i Altinn, og du velger fra listen. Fødselsnummeret ditt lagres ikke.
-(Er du i en situasjon der du ikke dukker opp i listen, for eksempel skjermet adresse eller selskap
-som mangler registrert rolleinnehaver, ta kontakt, så ordner jeg en invitasjonslenke manuelt.)
+Du logger inn med **ID-porten** (BankID) og oppgir organisasjonsnummeret til selskapet du vil
+sende inn for. Jeg bekrefter at du står registrert som daglig leder eller styreleder for selskapet
+i Enhetsregisteret før du kobles til. Fødselsnummeret ditt lagres ikke. (Står du ikke oppført slik,
+for eksempel ved skjermet adresse eller selskap uten registrert rolleinnehaver, ta kontakt, så
+ordner jeg en invitasjonslenke manuelt.)
 
 Deretter følger du en enkel stegvis flyt: koble selskapet til Altinn (én gang, med BankID), fylle inn
 tallene, eventuelt laste ned dokumentene (skattemelding, årsregnskap, aksjonæroppgave og noter)

--- a/docs/hostet.md
+++ b/docs/hostet.md
@@ -1,23 +1,27 @@
-# Hostet versjon (invite-only)
+# Hostet versjon
 
 Du kan kjøre Wenche selv (se [Installasjon](installasjon.md) og [Oppsett](oppsett.md)),
-eller bruke den hostede, invite-only versjonen på
-**[wenche.cloud](https://wenche.cloud)**.
+eller bruke den hostede versjonen på **[wenche.cloud](https://wenche.cloud)**.
 
 ## Forskjellen
 
 | | Self-hosted (resten av denne dokumentasjonen) | Hostet ([wenche.cloud](https://wenche.cloud)) |
 |---|---|---|
 | Oppsett | Du genererer RSA-nøkkel og registrerer en Maskinporten-klient | Gjort én gang av operatøren |
-| Innlogging | Kjører lokalt på din maskin | Invitasjonslenke + godkjenning i Altinn med BankID |
+| Innlogging | Kjører lokalt på din maskin | Logg inn med ID-porten (BankID), så godkjenning i Altinn |
 | Data | Blir på din maskin | Behandles kun i økten, ingenting lagres i database |
-| Tilgang | Åpen kildekode, gratis | Foreløpig kun for inviterte testere |
+| Tilgang | Åpen kildekode, gratis | Foreløpig en tidlig testfase |
 
 Den hostede tjenesten er for deg som heller vil slippe det tekniske oppsettet. Det er
 nøyaktig samme åpne kildekode under panseret, så du kan når som helst velge å kjøre
 self-hosted i stedet.
 
-Du følger en enkel stegvis flyt: koble selskapet til Altinn (én gang, med BankID), fylle inn
+Du logger inn med **ID-porten** (BankID). Etter innlogging henter jeg automatisk listen over
+selskaper du kan handle for i Altinn, og du velger fra listen. Fødselsnummeret ditt lagres ikke.
+(Er du i en situasjon der du ikke dukker opp i listen, for eksempel skjermet adresse eller selskap
+som mangler registrert rolleinnehaver, ta kontakt, så ordner jeg en invitasjonslenke manuelt.)
+
+Deretter følger du en enkel stegvis flyt: koble selskapet til Altinn (én gang, med BankID), fylle inn
 tallene, eventuelt laste ned dokumentene (skattemelding, årsregnskap, aksjonæroppgave og noter)
 for gjennomgang, og så sende inn. Noter sendes ikke inn digitalt, men kan lastes ned for
 signering og arkivering hos selskapet.

--- a/hosted/README.md
+++ b/hosted/README.md
@@ -61,6 +61,7 @@ Per-org invite-lenker lages med `./.venv/bin/python hosted/mint_invite.py <orgnr
 | `HOSTED_IDPORTEN_KEY_PEM` | (valgfri) PEM-innhold for ID-porten-klientens private nøkkel (egen, *ikke* vendor-nøkkelen). Foretrukket i prod (Fly-secret). |
 | `HOSTED_IDPORTEN_KEY_PATH` | (valgfri) Sti til ID-porten-privatnøkkelen (PEM). Brukes i dev; `_PEM` har forrang. |
 | `HOSTED_IDPORTEN_REDIRECT_URI` | (valgfri) Callback-URL registrert på klienten (HTTPS i prod, `http://127.0.0.1:5173/...` i dev). |
+| `HOSTED_IDPORTEN_REPORTEES` | (valgfri, `1`/`true`) Be om `altinn:reportees` og hent selskapslista fra Altinn autoriserte parter. Krever at scopet er tildelt klienten (se under). Av som standard: da logger man inn med kun `openid profile` og taster orgnr manuelt. Skru ALDRI på før scopet faktisk er tildelt, ellers avviser ID-porten innloggingen (`invalid_scope`). |
 | `HOSTED_VENDOR_ORGNR` | Operatørens organisasjonsnummer (vendor). |
 | `HOSTED_VENDOR_CLIENT_ID` | Operatørens Maskinporten-klient-ID. |
 | `HOSTED_VENDOR_KID` | Operatørens nøkkel-ID (KID). |
@@ -94,6 +95,53 @@ ID-porten-innlogging, gjør dette én gang per miljø (test og prod hver for seg
 
 Endepunkter og JWKS hentes fra ID-portens well-known-dokument ved kjøretid
 (`test.idporten.no` / `idporten.no` etter `WENCHE_ENV`), så ingen URL-er hardkodes.
+
+### Selskapsvalg fra Altinn (valgfritt, `altinn:reportees`)
+
+Med kun `openid profile` taster brukeren inn organisasjonsnummeret selv, og det bekreftes mot
+det åpne Enhetsregisteret (verifisert navn mot daglig leder/styreleder). Vil du i stedet vise en
+liste over selskapene brukeren kan representere, hentet fra **Altinn autoriserte parter**, kreves
+scopet **`altinn:reportees`**:
+
+1. Be Altinn/Digdir tildele org-en din tilgang til `altinn:reportees` (servicedesk@digdir.no), og
+   legg deretter scopet på ID-porten-klienten i Samarbeidsportalen. Scopet eies av Altinn, så det
+   dukker ikke opp i scope-velgeren før det er tildelt.
+2. Sett `HOSTED_IDPORTEN_REPORTEES=1`.
+
+Da veksles ID-porten-tokenet mot et Altinn-token (`exchange/id-porten`) og selskapslista hentes fra
+`accessmanagement/api/v1/authorizedparties`. Er scopet ikke tildelt, MÅ flagget være av, ellers
+avviser ID-porten hele innloggingen.
+
+### Kjøre lokalt mot prod (røyktest uten deploy)
+
+For å teste ID-porten-innloggingen mot ekte BankID og din egen org uten å deploye, kjør den hostede
+appen lokalt med prod-miljø og prod-creds. ID-porten-login + manuell orgnr-inntasting (brreg-match)
+kan testes slik; selskapslista krever at `altinn:reportees` er tildelt prod-klienten.
+
+Forutsetning: prod-ID-porten-klienten må ha `http://127.0.0.1:5173/api/auth/idporten/callback`
+registrert som redirect-URI (sjekk at prod-klienten godtar loopback-IP).
+
+```sh
+# Backend mot prod (egne prod-verdier; les fra ~/.wenche eller en prod-env-fil, aldri hardkod):
+WENCHE_ENV=prod \
+HOSTED_PUBLIC_URL=http://127.0.0.1:5173 \
+HOSTED_SESSION_SECRET=$(openssl rand -hex 32) \
+HOSTED_INVITE_SECRET=$(openssl rand -hex 32) \
+HOSTED_VENDOR_ORGNR=<operatørens orgnr> \
+HOSTED_VENDOR_CLIENT_ID=<maskinporten-klient-id, prod> \
+HOSTED_VENDOR_KID=<kid, prod> \
+HOSTED_VENDOR_KEY_PATH=<sti til prod-vendor.pem> \
+HOSTED_IDPORTEN_CLIENT_ID=<id-porten-klient-id, prod> \
+HOSTED_IDPORTEN_KID=<id-porten kid, prod> \
+HOSTED_IDPORTEN_KEY_PATH=<sti til idporten_prod_privat.pem> \
+HOSTED_IDPORTEN_REDIRECT_URI=http://127.0.0.1:5173/api/auth/idporten/callback \
+  ./.venv/bin/python -m uvicorn hosted.api.main:app --host 127.0.0.1 --port 8077
+
+# Frontend (egen terminal): cd hosted/web && npm run dev  -> åpne http://127.0.0.1:5173
+```
+
+Dette treffer ekte myndigheter (Altinn/Maskinporten prod). En systembruker-forespørsel i denne
+flyten er en reell handling mot Altinn, men ingenting sendes inn før du fullfører innsendingsstegene.
 
 ## Deploy (Fly.io)
 

--- a/hosted/README.md
+++ b/hosted/README.md
@@ -5,24 +5,28 @@ gjenbruker domene-, auth- og klientlaget. Self-hosted-appen (`wenche` / `wenche 
 er **upåvirket** av alt her, og denne mappen er ikke en del av `wenche`-wheelen som publiseres
 til PyPI.
 
-Status: **live på https://app.wenche.cloud** (invite-only). Onboarding: en **per-org
-invite-lenke** som invite-only-port, og Altinn systembruker-godkjenning (BankID) som selve
-autorisasjonen. Ingen e-post, passord eller database.
+Status: **live på https://app.wenche.cloud**. Onboarding har to porter, og Altinn
+systembruker-godkjenning (BankID) er uansett selve autorisasjonen til å sende inn. Ingen e-post,
+passord eller database.
 
-Valgfritt kan **selvbetjent tilgang** skrus på (`HOSTED_SELVBETJENING=1`): en bruker som står
-som aktiv daglig leder eller styremedlem i Enhetsregisteret for et orgnr får da tilgang med en
-gang, uten manuell invitasjon. Navnet brukes kun transient til ett oppslag mot åpne
-registerdata og lagres ikke. Det er proporsjonal støydemping, ikke identitetsbevis, så
-AlreadyApproved-snarveien (binding uten BankID) gjelder ikke for selvbetjente økter; et
-alt-onboardet selskap krever fortsatt manuell invitasjon. Av som standard.
+- **ID-porten-innlogging** (primær port i prod, se `api/idporten.py`): brukeren logger inn med
+  BankID, vi får et **verifisert** navn, og `velg_org` bekrefter at navnet står som aktiv daglig
+  leder/styreleder for det oppgitte orgnr i Enhetsregisteret før økten bindes. Fødselsnummeret
+  (`pid`) er transient og lagres aldri. Skrus på ved å sette `HOSTED_IDPORTEN_*` (se under); uten
+  dem er ID-porten av og invite er eneste port (slik demo kjører).
+- **Per-org invite-lenke** (operatør-fallback): en signert token som bærer ETT orgnr, delt ut
+  manuelt. Brukes når ID-porten-rollesjekken ikke kan treffe (skjermet person, selskap uten
+  registrert rolleinnehaver). Org er ikke brukerinput.
+
+Begge porter er sterke (invite er operatør-attestert, ID-porten er BankID-verifisert), så
+AlreadyApproved-snarveien (binding til en alt godkjent systembruker uten ny BankID) gjelder begge.
 
 **Fortsett på en annen enhet:** sesjonen lever per nettleser (signert cookie, ingen DB), så et
 andre apparat står i utgangspunktet uten tilkobling. En alt koblet økt kan derfor lage en
 kortvarig lenke (vist som QR + lenke på Hjem), som den nye enheten åpner for å arve samme
 binding, uten ny BankID. Tilkoblingen **kopieres** (den flyttes ikke): begge enheter forblir
 koblet, og hver enhet logges ut for seg. Lenken er forankret i en alt verifisert økt (bundet
-`kunde_org`), ikke i offentlig registerkunnskap, og er ferskvare (5 min), så den omgår ikke
-selvbetjeningssperren over.
+`kunde_org`) og er ferskvare (5 min).
 
 ## Komponenter
 - `api/` — FastAPI JSON-API (importerer `wenche`).
@@ -50,9 +54,13 @@ Per-org invite-lenker lages med `./.venv/bin/python hosted/mint_invite.py <orgnr
 | `HOSTED_SESSION_SECRET` | Nøkkel for signerte sesjonscookies. |
 | `HOSTED_INVITE_SECRET` | Signerer invite-lenken. Roter for å ugyldiggjøre utdelte lenker. |
 | `HOSTED_CORS_ORIGINS` | Tillatte frontend-origins (default `http://localhost:5173`). |
-| `HOSTED_PUBLIC_URL` | App-origin som invite-lenken peker på (default `http://localhost:5173`). |
-| `HOSTED_SELVBETJENING` | (valgfri) `1`/`true` skrur på selvbetjent tilgang (navn + orgnr verifiseres mot Enhetsregisteret). Av som standard. |
-| `HOSTED_KONTAKT` | (valgfri) Kontaktvei som vises når selvbetjent verifisering ikke gir treff. `mailto:`- eller https-URL (default `mailto:hello@olefredrik.com`). |
+| `HOSTED_PUBLIC_URL` | App-origin (invite-lenker + ID-porten-callbacken redirecter hit). Default `http://localhost:5173`. |
+| `HOSTED_KONTAKT` | (valgfri) Kontaktvei som vises når ID-porten-rollesjekken ikke gir treff (skjermet person o.l.). `mailto:`- eller https-URL (default `mailto:hello@olefredrik.com`). |
+| `HOSTED_IDPORTEN_CLIENT_ID` | (valgfri) ID-porten OIDC-klient-ID. Settes alle fire `HOSTED_IDPORTEN_*` skrus ID-porten-innlogging på; utelates de, er invite eneste port. |
+| `HOSTED_IDPORTEN_KID` | (valgfri) Nøkkel-ID for ID-porten-klientens registrerte offentlige nøkkel. |
+| `HOSTED_IDPORTEN_KEY_PEM` | (valgfri) PEM-innhold for ID-porten-klientens private nøkkel (egen, *ikke* vendor-nøkkelen). Foretrukket i prod (Fly-secret). |
+| `HOSTED_IDPORTEN_KEY_PATH` | (valgfri) Sti til ID-porten-privatnøkkelen (PEM). Brukes i dev; `_PEM` har forrang. |
+| `HOSTED_IDPORTEN_REDIRECT_URI` | (valgfri) Callback-URL registrert på klienten (HTTPS i prod, `http://127.0.0.1:5173/...` i dev). |
 | `HOSTED_VENDOR_ORGNR` | Operatørens organisasjonsnummer (vendor). |
 | `HOSTED_VENDOR_CLIENT_ID` | Operatørens Maskinporten-klient-ID. |
 | `HOSTED_VENDOR_KID` | Operatørens nøkkel-ID (KID). |
@@ -60,6 +68,32 @@ Per-org invite-lenker lages med `./.venv/bin/python hosted/mint_invite.py <orgnr
 | `HOSTED_VENDOR_KEY_PEM` | Selve PEM-innholdet til nøkkelen. Foretrukket i prod/container (holder nøkkelen unna disk); settes som Fly-secret. Har forrang over `_PATH`. |
 | `HOSTED_UMAMI_SRC` | (valgfri) URL til Umami-script. Injiseres i `index.html` ved servering. Tom = ingen analytics. (Self-host i EØS for region-garanti; cloud.umami.is sin region er ikke bekreftet.) |
 | `HOSTED_UMAMI_WEBSITE_ID` | (valgfri) Umami website-id. Sammen med `_SRC` skrur det på anonymisert sporing (auto-track av; SPA-en sporer manuelt etter at invite-tokenet er fjernet fra URL-en). |
+
+## ID-porten-innlogging (oppsett)
+
+ID-porten er primær onboarding-port i prod. Vil du kjøre din egen hostede Wenche med
+ID-porten-innlogging, gjør dette én gang per miljø (test og prod hver for seg):
+
+1. **Opprett en ID-porten-klient** i [Digdir Selvbetjening](https://docs.digdir.no) (tjeneste
+   «ID-porten & API-Klient»):
+   - Applikasjonstype **web**, autentiseringsmetode **private_key_jwt**.
+   - Grant **authorization_code** (ikke refresh), PKCE **S256**.
+   - Eksterne scope **Nei** (`openid` + `profile` holder; fødselsnummer kommer som `pid`-claim).
+   - **Redirect URI** = `https://<din-app>/api/auth/idporten/callback` (prod, HTTPS) eller
+     `http://127.0.0.1:5173/api/auth/idporten/callback` (dev; loopback-IP, ikke `localhost`).
+2. **Generer et eget RSA-nøkkelpar** (ikke gjenbruk vendor/Maskinporten-nøkkelen) og registrer
+   den **offentlige** nøkkelen på klienten (lim inn PEM under «Nøkler»):
+   ```sh
+   openssl genrsa -out idporten_prod_privat.pem 2048
+   openssl rsa -in idporten_prod_privat.pem -pubout -out idporten_prod_offentlig.pem
+   ```
+   Noter `kid`-en Digdir tildeler nøkkelen.
+3. **Sett miljøvariablene** (`HOSTED_IDPORTEN_CLIENT_ID/_KID/_KEY_PEM/_REDIRECT_URI`). Settes
+   alle fire, slås ID-porten på; utelates de (som på demo), kjører appen invite-only. Delvis
+   config i prod gir fail-closed ved oppstart (alt eller intet).
+
+Endepunkter og JWKS hentes fra ID-portens well-known-dokument ved kjøretid
+(`test.idporten.no` / `idporten.no` etter `WENCHE_ENV`), så ingen URL-er hardkodes.
 
 ## Deploy (Fly.io)
 
@@ -85,10 +119,16 @@ krever én prosess). `Dockerfile` og `fly.toml` ligger i repo-roten. Engangsopps
      HOSTED_VENDOR_ORGNR="<operatørens orgnr>" \
      HOSTED_VENDOR_CLIENT_ID="<maskinporten-klient-id, prod>" \
      HOSTED_VENDOR_KID="<kid, prod>" \
-     HOSTED_VENDOR_KEY_PEM="$(cat operatør_prod.pem)"
+     HOSTED_VENDOR_KEY_PEM="$(cat operatør_prod.pem)" \
+     HOSTED_IDPORTEN_CLIENT_ID="<id-porten-klient-id, prod>" \
+     HOSTED_IDPORTEN_KID="<id-porten kid, prod>" \
+     HOSTED_IDPORTEN_KEY_PEM="$(cat idporten_prod_privat.pem)" \
+     HOSTED_IDPORTEN_REDIRECT_URI="https://<din-app>/api/auth/idporten/callback"
    ```
-   Sett også `HOSTED_PUBLIC_URL` (app-URL-en, til invite-lenkene), enten som secret eller i
-   `fly.toml` `[env]`. Uten egne secrets nekter appen å starte i prod (fail-closed).
+   Sett også `HOSTED_PUBLIC_URL` (app-URL-en, til invite-lenker og ID-porten-callbacken), enten
+   som secret eller i `fly.toml` `[env]`. Uten egne secrets nekter appen å starte i prod
+   (fail-closed); delvis ID-porten-config gjør det samme. Vil du kjøre prod invite-only, utelat
+   alle `HOSTED_IDPORTEN_*`.
 
    > **NB om anførselstegn:** skriv inn de rene verdiene. Henter du `client_id`/`kid` fra en
    > `.env`-fil med shell, pass på at omsluttende `'`/`"` ikke blir med (de stripper ikke seg
@@ -125,7 +165,9 @@ Roter `HOSTED_INVITE_SECRET` for å ugyldiggjøre alle utdelte lenker på én ga
 
 En **helt separat** Fly-app som lar hvem som helst prøve tjenesten mot Altinns testmiljø (tt02)
 uten invitasjon, på syntetiske data. Den deler aldri prod-creds eller `env=prod`: egen app, egne
-**test**-vendor-creds, `WENCHE_ENV=test`. Konfig ligger i `fly.demo.toml`. Banneren i SPA-en
+**test**-vendor-creds, `WENCHE_ENV=test`. ID-porten holdes **av** på demo (ingen
+`HOSTED_IDPORTEN_*`), så demo kjører på invite-flyten uten BankID-dansen med syntetiske brukere.
+Konfig ligger i `fly.demo.toml`. Banneren i SPA-en
 styres av `HOSTED_DEMO_MODE=1` (rent informativt, endrer ikke funksjonalitet).
 
 Engangsoppsett:

--- a/hosted/README.md
+++ b/hosted/README.md
@@ -26,7 +26,9 @@ andre apparat står i utgangspunktet uten tilkobling. En alt koblet økt kan der
 kortvarig lenke (vist som QR + lenke på Hjem), som den nye enheten åpner for å arve samme
 binding, uten ny BankID. Tilkoblingen **kopieres** (den flyttes ikke): begge enheter forblir
 koblet, og hver enhet logges ut for seg. Lenken er forankret i en alt verifisert økt (bundet
-`kunde_org`) og er ferskvare (5 min).
+`kunde_org`) og er ferskvare (5 min). Vises kun for **invite-baserte økter** (demo + fallback);
+en ID-porten-bruker logger bare inn på nytt på den nye enheten (treffer AlreadyApproved), så
+handoff er overflødig for dem og skjules.
 
 ## Komponenter
 - `api/` — FastAPI JSON-API (importerer `wenche`).

--- a/hosted/api/auth.py
+++ b/hosted/api/auth.py
@@ -1,30 +1,28 @@
 """
-Invite-only-port + sesjonsstatus for hostet Wenche.
+Onboarding-porter + sesjonsstatus for hostet Wenche.
 
-Onboarding-modellen (besluttet): per-org invite-lenke + BankID.
-- Invite-lenke: en signert token som bærer ETT bestemt organisasjonsnummer, du deler den
-  ut manuelt til en kjent, verifisert person. Gyldig token setter 'invited' og binder
-  sesjonen til org-en i tokenet. Org er altså ikke fritt brukerinput. Roteres ved å bytte
-  HOSTED_INVITE_SECRET (ugyldiggjør alle utdelte lenker).
-- Selve autentiseringen/autorisasjonen er Altinn systembruker-godkjenning (BankID), se
-  systembruker.py. En lekket invite-lenke er avgrenset til det ene selskapet i tokenet
-  (og kan tilbakekalles ved rotasjon), ikke evnen til å sende inn for en vilkårlig org.
+To porter binder en økt til et selskap. Begge setter 'invited' (gate passert) og til slutt
+'invite_org' (org bundet til økten); navnene er historiske, men dekker nå begge portene:
 
-Selvbetjent tilgang (be_om_tilgang): når operatøren har skrudd på HOSTED_SELVBETJENING kan en
-som står som aktiv daglig leder eller styremedlem i Enhetsregisteret for et orgnr få tilgang
-med en gang, uten manuell utdeling. Verifiseringen er en proporsjonal støydempingssjekk, ikke
-en festning: den hindrer at noen trigger en Altinn-systembruker-forespørsel mot et vilkårlig
-selskap de ikke har noe med å gjøre, mens BankID-godkjenningen i Altinn forblir den reelle
-porten. Navnet brukes kun transient til matching mot åpne registerdata og lagres aldri.
+- ID-porten-innlogging (primær i prod, se idporten.py): brukeren logger inn med BankID, vi får
+  et VERIFISERT navn, og velg_org bekrefter at navnet står som aktiv daglig leder/styreleder for
+  det oppgitte orgnr i Enhetsregisteret før økten bindes. Det verifiserte navnet erstatter det
+  tidligere fritt innskrevne, så onboardingen ikke lenger hviler på et upåvist navn.
+- Invite-lenke (operatør-fallback): en signert token som bærer ETT orgnr, delt ut manuelt til en
+  kjent, verifisert person. Org er ikke brukerinput. Brukes når ID-porten-rollesjekken ikke kan
+  treffe (skjermet person, selskap uten registrert rolleinnehaver). Roteres via HOSTED_INVITE_SECRET.
+
+Den reelle fullmakten til å sende inn er uansett Altinn systembruker-godkjenning (BankID), se
+systembruker.py. Portene her er forporten som hindrer at noen trigger en systembruker-forespørsel
+mot et vilkårlig selskap; ID-porten gjør den forporten sterk (verifisert identitet).
 
 Fortsett på en annen enhet (handoff): sesjonen lever per nettleser (signert cookie, ingen DB),
-så en ny enhet har ingen binding. En alt fullført økt (bundet kunde_org, altså en enhet som
-har vært gjennom invite/BankID) kan lage en kortvarig, signert overføringslenke som den nye
-enheten åpner for å arve samme binding. Tilliten er forankret i en eksisterende, verifisert
-økt, ikke i offentlig registerkunnskap, så den er uavhengig av selvbetjeningssperren i
-systembruker.request_systembruker. Lenken er ferskvare (HANDOFF_MAKS_ALDER), ikke engangsbruk.
+så en ny enhet har ingen binding. En alt fullført økt (bundet kunde_org) kan lage en kortvarig,
+signert overføringslenke som den nye enheten åpner for å arve samme binding, uten ny BankID.
+Lenken er ferskvare (HANDOFF_MAKS_ALDER), ikke engangsbruk.
 
-Ingen e-post, ingen passord, ingen database.
+ID-porten gir oss et transient fødselsnummer (`pid`) ved innlogging; det lagres aldri. Ellers:
+ingen e-post, ingen passord, ingen database.
 """
 import time
 from collections import defaultdict, deque
@@ -47,12 +45,12 @@ _HANDOFF_SALT = "handoff"
 _HANDOFF_MAKS_ALDER = 300  # sekunder
 
 # Enhetsregisterets åpne rolle-endepunkt (gratis, ingen auth). Gir navn på daglig leder og
-# styre som offentlig data, slik at vi kan bekrefte at forespørgeren plausibelt hører til
-# orgnummeret uten å samle inn eller lagre noe.
+# styre som offentlig data, slik at vi kan bekrefte at den ID-porten-verifiserte personen
+# står som rolleinnehaver for orgnummeret uten å samle inn eller lagre noe.
 _BRREG_ROLLER_URL = "https://data.brreg.no/enhetsregisteret/api/enheter/{org}/roller"
 
 # Lett, in-memory rate-limit (én worker med vilje, så et dict holder). Demper enumerering av
-# registeret via tilgangsskjemaet; nullstilles ved restart, helt greit for formålet.
+# registeret via velg-org-steget; nullstilles ved restart, helt greit for formålet.
 _RATE: dict[str, deque] = defaultdict(deque)
 _RATE_VINDU = 600.0  # sekunder
 _RATE_MAKS = 20
@@ -116,9 +114,9 @@ def _navn_matcher(innsendt: str, kandidater: list[str]) -> bool:
 
 def _hent_rolleinnehavere(orgnr: str) -> list[str]:
     """
-    Navn på aktive daglig leder/styre fra Enhetsregisteret, til navnematch i selvbetjeningen.
+    Navn på aktive daglig leder/styre fra Enhetsregisteret, til navnematch i velg_org.
     Beholder en streng feilkontrakt med vilje: 404 gir tom liste, men nettverks- og serverfeil
-    propageres (raise_for_status), så be-om-tilgang kan skille «fant ikke navnet» fra «fikk ikke
+    propageres (raise_for_status), så velg_org kan skille «fant ikke navnet» fra «fikk ikke
     kontakt med registeret». Selve parsingen deles med wenche.brreg (forhåndsfyll-stien).
     """
     resp = httpx.get(
@@ -148,7 +146,6 @@ class InviteBody(BaseModel):
 
 
 class TilgangBody(BaseModel):
-    navn: str
     org: str
 
 
@@ -162,64 +159,56 @@ def bruk_invite(body: InviteBody, request: Request) -> dict:
     org = payload.get("org") if isinstance(payload, dict) else None
     if not org:
         return {"invited": False, "feil": "Ugyldig invite-lenke."}
-    _grant(request, str(org).strip(), via_selvbetjening=False)
+    _grant(request, str(org).strip())
     return {"invited": True, "invite_org": str(org).strip()}
 
 
-def _grant(request: Request, orgnr: str, *, via_selvbetjening: bool) -> None:
-    """
-    Bind sesjonen til orgnr, samme effekt som en innløst invite-lenke.
-
-    via_selvbetjening skiller tillitsanker: en operatør-myntet invite-lenke (False) er en
-    manuell, verifisert utdeling, mens selvbetjening (True) bare er et navneoppslag mot
-    offentlige data. Skillet brukes til å nekte AlreadyApproved-snarveien for selvbetjente
-    økter (se systembruker.request_systembruker), så BankID forblir reell port der.
-    """
+def _grant(request: Request, orgnr: str) -> None:
+    """Bind sesjonen til orgnr: marker gate passert ('invited') og sett bundet org ('invite_org')."""
     request.session["invited"] = True
     request.session["invite_org"] = orgnr
-    request.session["via_selvbetjening"] = via_selvbetjening
 
 
-@router.post("/be-om-tilgang")
-def be_om_tilgang(body: TilgangBody, request: Request) -> dict:
+@router.post("/velg-org")
+def velg_org(body: TilgangBody, request: Request) -> dict:
     """
-    Selvbetjent tilgang: bekreft at navnet står som aktiv daglig leder/styremedlem for orgnr
-    i Enhetsregisteret, og gi i så fall tilgang med en gang (ingen e-post, ingenting lagret).
-    Ved bom returneres en kontaktvei for manuelle tilfeller.
+    ID-porten-rollesjekk: bekreft at den innloggede personens VERIFISERTE navn (fra ID-porten,
+    i sesjonen) står som aktiv daglig leder/styremedlem for orgnr i Enhetsregisteret, og bind i
+    så fall økten. Navnet kommer fra innloggingen, ikke fra request-body, så det er bevist.
+    Ved bom returneres en kontaktvei for manuelle tilfeller (skjermet person, manglende rolle).
     """
     s = settings()
-    if not s.selvbetjening:
-        return {"invited": False, "feil": "Selvbetjent tilgang er ikke åpen ennå.", "kontakt": s.kontakt}
+    navn = request.session.get("idporten_navn")
+    if not request.session.get("via_idporten") or not navn:
+        raise HTTPException(status_code=401, detail="Logg inn med ID-porten først.")
 
     klient_ip = request.headers.get("fly-client-ip") or (request.client.host if request.client else "ukjent")
     if not _rate_ok(klient_ip):
-        return {"invited": False, "feil": "For mange forsøk. Vent litt og prøv igjen.", "kontakt": s.kontakt}
+        return {"ok": False, "feil": "For mange forsøk. Vent litt og prøv igjen.", "kontakt": s.kontakt}
 
     orgnr = _normaliser_orgnr(body.org)
     if not _gyldig_orgnr(orgnr):
-        return {"invited": False, "feil": "Ugyldig organisasjonsnummer.", "kontakt": s.kontakt}
-    if len(_tokens(body.navn)) < 2:
-        return {"invited": False, "feil": "Skriv inn fullt navn (fornavn og etternavn).", "kontakt": s.kontakt}
+        return {"ok": False, "feil": "Ugyldig organisasjonsnummer.", "kontakt": s.kontakt}
 
     try:
         rolleinnehavere = _hent_rolleinnehavere(orgnr)
     except httpx.HTTPError:
         return {
-            "invited": False,
+            "ok": False,
             "feil": "Fikk ikke kontakt med Enhetsregisteret. Prøv igjen om litt.",
             "kontakt": s.kontakt,
         }
 
-    if not _navn_matcher(body.navn, rolleinnehavere):
+    if not _navn_matcher(navn, rolleinnehavere):
         return {
-            "invited": False,
-            "feil": "Jeg fant ikke navnet ditt som registrert daglig leder eller styremedlem "
-            "for dette selskapet.",
+            "ok": False,
+            "feil": "Jeg fant deg ikke som registrert daglig leder eller styremedlem for dette "
+            "selskapet.",
             "kontakt": s.kontakt,
         }
 
-    _grant(request, orgnr, via_selvbetjening=True)
-    return {"invited": True, "invite_org": orgnr}
+    _grant(request, orgnr)
+    return {"ok": True, "invite_org": orgnr}
 
 
 class HandoffBody(BaseModel):
@@ -261,28 +250,29 @@ def bruk_handoff(body: HandoffBody, request: Request) -> dict:
     if not org:
         return {"invited": False, "feil": "Ugyldig overføringslenke."}
     org = str(org).strip()
-    # Forankret i en alt verifisert økt, så bindingen arves uten ny BankID. via_selvbetjening
-    # er irrelevant her (kunde_org er alt satt), men False markerer at dette ikke er en svak
-    # navneoppslag-økt.
-    _grant(request, org, via_selvbetjening=False)
+    # Forankret i en alt verifisert økt, så bindingen arves uten ny BankID.
+    _grant(request, org)
     request.session["kunde_org"] = org
     return {"invited": True, "invite_org": org, "kunde_org": org}
 
 
 @router.get("/me")
 def me(request: Request) -> dict:
-    """Sesjonsstatus: invitert?, hvilket selskap invitasjonen gjelder, og evt. bundet kunde-org."""
+    """Sesjonsstatus: gate passert?, bundet org, evt. kunde-org, og hvilken port som er åpen."""
     s = settings()
     if not request.session.get("invited"):
-        # Gatesiden trenger å vite om den skal vise selvbetjeningsskjemaet og hvor man ellers
-        # tar kontakt. Begge er ikke-sensitiv config.
-        return {"invited": False, "selvbetjening": s.selvbetjening, "kontakt": s.kontakt}
+        # Gatesiden trenger å vite om ID-porten-innlogging er tilgjengelig (prod) eller om den
+        # skal vise invite/kontakt-fallback (demo). Begge er ikke-sensitiv config.
+        return {"invited": False, "idporten": s.idporten_aktivert, "kontakt": s.kontakt}
     return {
         "invited": True,
+        "via_idporten": request.session.get("via_idporten", False),
+        "navn": request.session.get("idporten_navn"),
         "invite_org": request.session.get("invite_org"),
         "kunde_org": request.session.get("kunde_org"),
         "env": s.env,
         "demo": s.demo_mode,
+        "kontakt": s.kontakt,
     }
 
 

--- a/hosted/api/auth.py
+++ b/hosted/api/auth.py
@@ -202,8 +202,8 @@ def velg_org(body: TilgangBody, request: Request) -> dict:
     if not _navn_matcher(navn, rolleinnehavere):
         return {
             "ok": False,
-            "feil": "Jeg fant deg ikke som registrert daglig leder eller styremedlem for dette "
-            "selskapet.",
+            "feil": "Wenche kunne ikke finne deg som registrert daglig leder eller styreleder for "
+            "dette selskapet.",
             "kontakt": s.kontakt,
         }
 

--- a/hosted/api/auth.py
+++ b/hosted/api/auth.py
@@ -267,6 +267,9 @@ def me(request: Request) -> dict:
     return {
         "invited": True,
         "via_idporten": request.session.get("via_idporten", False),
+        # reportees styrer om SPA-en henter selskapslista fra Altinn (krever altinn:reportees-scopet)
+        # eller går rett til manuell orgnr-inntasting.
+        "reportees": s.idporten_reportees,
         "navn": request.session.get("idporten_navn"),
         "invite_org": request.session.get("invite_org"),
         "kunde_org": request.session.get("kunde_org"),

--- a/hosted/api/config.py
+++ b/hosted/api/config.py
@@ -57,6 +57,13 @@ class Settings:
         self._idporten_key_pem = os.getenv("HOSTED_IDPORTEN_KEY_PEM")
         self._idporten_key_path = os.getenv("HOSTED_IDPORTEN_KEY_PATH")
         self.idporten_redirect_uri = os.getenv("HOSTED_IDPORTEN_REDIRECT_URI")
+        # Be om Altinn-scopet altinn:reportees (for å hente selskapslista fra autoriserte parter)
+        # KUN når operatøren har fått scopet tildelt klienten i Samarbeidsportalen. Ber vi om et
+        # ikke-tildelt scope, avviser ID-porten hele innloggingen (invalid_scope). Av som standard:
+        # da logger man inn med bare openid+profile, og selskap velges ved manuell orgnr-inntasting.
+        self._idporten_reportees = os.getenv("HOSTED_IDPORTEN_REPORTEES", "").lower() in (
+            "1", "true", "yes",
+        )
         self._fail_closed_i_prod()
 
     @property
@@ -71,6 +78,16 @@ class Settings:
     @property
     def idporten_client_id(self) -> str | None:
         return self._idporten_client_id
+
+    @property
+    def idporten_reportees(self) -> bool:
+        """
+        Om vi skal be om altinn:reportees og tilby selskapsvalg fra Altinn autoriserte parter.
+
+        Krever at ID-porten er aktivert og at scopet faktisk er tildelt klienten (env-flagget
+        settes da av operatøren). Er det av, hoppes auto-lista over og brukeren taster orgnr selv.
+        """
+        return self.idporten_aktivert and self._idporten_reportees
 
     @property
     def idporten_aktivert(self) -> bool:

--- a/hosted/api/config.py
+++ b/hosted/api/config.py
@@ -37,14 +37,9 @@ class Settings:
         # Demo-modus: viser en «dette er en demo mot tt02»-banner i SPA-en. Rent informativt,
         # endrer ikke funksjonalitet. Settes kun på demo-appen (aldri i prod).
         self.demo_mode: bool = os.getenv("HOSTED_DEMO_MODE", "").lower() in ("1", "true", "yes")
-        # Selvbetjent tilgang: når på, kan en som står som aktiv daglig leder eller
-        # styremedlem i Enhetsregisteret for et orgnr få tilgang umiddelbart, uten manuell
-        # invitasjon. Verifiseringen skjer mot åpne data og lagrer ingenting; den er bare
-        # støydemping (BankID-godkjenningen i Altinn er den reelle porten). Av som standard,
-        # skru på når testbetaen skal åpnes, og av igjen for å stenge selvbetjeningen.
-        self.selvbetjening: bool = os.getenv("HOSTED_SELVBETJENING", "").lower() in ("1", "true", "yes")
-        # Kontaktvei som vises når selvbetjent verifisering ikke gir treff (skjermet person,
-        # navneavvik, selskap uten registrert rolleinnehaver). mailto:- eller https-URL.
+        # Kontaktvei som vises når ID-porten-rollesjekken ikke gir treff (skjermet person,
+        # navneavvik, selskap uten registrert rolleinnehaver) og som operatør-fallback.
+        # mailto:- eller https-URL.
         self.kontakt: str = os.getenv("HOSTED_KONTAKT", "mailto:hello@olefredrik.com")
         self.vendor_orgnr = os.getenv("HOSTED_VENDOR_ORGNR")
         self._vendor_client_id = os.getenv("HOSTED_VENDOR_CLIENT_ID")
@@ -53,6 +48,15 @@ class Settings:
         # container/Fly, holder nøkkelen unna disk), eller som sti til en PEM-fil (dev).
         self._vendor_key_pem = os.getenv("HOSTED_VENDOR_KEY_PEM")
         self._vendor_key_path = os.getenv("HOSTED_VENDOR_KEY_PATH")
+        # ID-porten-innlogging (OIDC). Primær onboarding-port i prod: brukeren logger inn med
+        # BankID, og vi får et verifisert navn (+ fødselsnummer som transient `pid`) som
+        # rollesjekken mot Enhetsregisteret bygger på. Utelates config (som på demo), er
+        # ID-porten av og invite-lenken er eneste port. Samme nøkkelmønster som vendor-creds.
+        self._idporten_client_id = os.getenv("HOSTED_IDPORTEN_CLIENT_ID")
+        self._idporten_kid = os.getenv("HOSTED_IDPORTEN_KID")
+        self._idporten_key_pem = os.getenv("HOSTED_IDPORTEN_KEY_PEM")
+        self._idporten_key_path = os.getenv("HOSTED_IDPORTEN_KEY_PATH")
+        self.idporten_redirect_uri = os.getenv("HOSTED_IDPORTEN_REDIRECT_URI")
         self._fail_closed_i_prod()
 
     @property
@@ -63,6 +67,37 @@ class Settings:
         if self.kontakt.startswith("mailto:"):
             return self.kontakt[len("mailto:") :]
         return self.kontakt.removeprefix("https://").removeprefix("http://")
+
+    @property
+    def idporten_client_id(self) -> str | None:
+        return self._idporten_client_id
+
+    @property
+    def idporten_aktivert(self) -> bool:
+        """
+        Om ID-porten-innlogging er konfigurert (og dermed primær port).
+
+        Krever client-ID, nøkkel-ID, en privat nøkkel (PEM eller filsti) og redirect-URI.
+        Mangler alt, er ID-porten av og invite-lenken er eneste port (slik demo kjører).
+        """
+        return bool(
+            self._idporten_client_id
+            and self._idporten_kid
+            and (self._idporten_key_pem or self._idporten_key_path)
+            and self.idporten_redirect_uri
+        )
+
+    @property
+    def idporten_kid(self) -> str | None:
+        return self._idporten_kid
+
+    def idporten_key(self) -> bytes | None:
+        """Privat ID-porten-nøkkel (client_assertion), fra PEM-env eller filsti. None om ukonfigurert."""
+        if self._idporten_key_pem:
+            return self._idporten_key_pem.encode()
+        if self._idporten_key_path:
+            return Path(self._idporten_key_path).read_bytes()
+        return None
 
     def _fail_closed_i_prod(self) -> None:
         """Nekt oppstart i prod hvis hemmelighetene ikke er overstyrt fra dev-standardene."""
@@ -83,6 +118,22 @@ class Settings:
                 + ". Sett dem fra secret manager/KMS før oppstart. Dev-standardene "
                 "ligger i åpen kildekode og ville latt hvem som helst lage gyldige "
                 "invite-lenker og forfalske sesjonscookies."
+            )
+        # Delvis ID-porten-config i prod er nesten alltid en feil (glemt secret), og en
+        # halvkonfigurert OIDC-klient feiler stille ved innlogging. Krev enten alt eller intet.
+        idp = {
+            "HOSTED_IDPORTEN_CLIENT_ID": self._idporten_client_id,
+            "HOSTED_IDPORTEN_KID": self._idporten_kid,
+            "HOSTED_IDPORTEN_KEY_PEM/_PATH": self._idporten_key_pem or self._idporten_key_path,
+            "HOSTED_IDPORTEN_REDIRECT_URI": self.idporten_redirect_uri,
+        }
+        satt = {k for k, v in idp.items() if v}
+        if satt and satt != set(idp):
+            mangler = ", ".join(sorted(set(idp) - satt))
+            raise RuntimeError(
+                "Hostet Wenche har delvis ID-porten-config i prod. Mangler: "
+                + mangler
+                + ". Sett alle eller ingen (uten = invite-only)."
             )
 
     def vendor_credentials(self) -> VendorCredentials | None:

--- a/hosted/api/idporten.py
+++ b/hosted/api/idporten.py
@@ -1,0 +1,384 @@
+"""
+ID-porten-innlogging (OIDC authorization_code + PKCE) for hostet Wenche.
+
+Primær onboarding-port i prod: brukeren logger inn med BankID via ID-porten, og vi får et
+verifisert navn (+ fødselsnummer som transient `pid`-claim). Det verifiserte navnet erstatter
+det tidligere fritt innskrevne navnet i rollesjekken mot Enhetsregisteret (se auth.velg_org),
+så onboardingen ikke lenger hviler på et upåvist navn. Fødselsnummeret lagres aldri; kun det
+verifiserte navnet legges i den signerte sesjonscookien.
+
+ID-porten gir identitet, ikke innsendingsrett. Den reelle fullmakten til å sende inn ligger
+fortsatt i Altinn systembruker-godkjenningen (systembruker.py). ID-porten er person-porten foran.
+
+Flyt:
+  GET /api/auth/idporten/login         -> bygg autorisasjons-URL (PKCE S256), redirect til ID-porten.
+  GET /api/auth/idporten/callback      -> valider state, veksle code mot tokens (private_key_jwt),
+                                          valider id_token, legg verifisert navn i sesjonen.
+  GET /api/auth/idporten/organisasjoner -> veksle access_token mot Altinn-token, hent autoriserte
+                                           parter (orger personen kan handle for).
+  POST /api/auth/idporten/velg-org     -> bind sesjonen til valgt org (Altinn-verifisert).
+
+Klient-assertion signeres med operatørens egne ID-porten-nøkkel (ikke Maskinporten-vendor-
+nøkkelen). Endepunkter og JWKS hentes fra ID-portens well-known-dokument (cachet i minnet, én
+worker), så vi slipper å hardkode stier som kan endres.
+"""
+import base64
+import hashlib
+import logging
+import secrets
+import time
+import uuid
+from urllib.parse import urlencode
+
+import httpx
+from authlib.jose import JsonWebKey, jwt
+from fastapi import APIRouter, HTTPException, Request
+from fastapi.responses import RedirectResponse
+from pydantic import BaseModel
+
+from .config import settings
+
+router = APIRouter(prefix="/api/auth/idporten", tags=["idporten"])
+_log = logging.getLogger("wenche.idporten")
+
+# Tillatt klokkeskjev ved id_token-validering.
+_LEEWAY = 60
+# `altinn:reportees` («se hvem du kan representere») kreves for å (a) la Altinn godta
+# token-vekslingen (exchange/id-porten avviser tokens uten en altinn:-scope, AUTH-koden
+# HasAltinnScope) og (b) hente autoriserte parter. Scopet må også være tildelt ID-porten-
+# klienten i Samarbeidsportalen, ellers nekter ID-porten å utstede tokenet.
+_SCOPE = "openid profile altinn:reportees"
+
+# Well-known-metadata og JWKS per miljø (test/prod), cachet i minnet.
+_metadata_cache: dict[str, dict] = {}
+_jwks_cache: dict[str, object] = {}
+
+
+def _issuer(env: str) -> str:
+    """ID-portens utsteder for miljøet. test ⇒ test.idporten.no, ellers prod."""
+    return "https://test.idporten.no" if env == "test" else "https://idporten.no"
+
+
+def _metadata(env: str) -> dict:
+    md = _metadata_cache.get(env)
+    if md is None:
+        resp = httpx.get(f"{_issuer(env)}/.well-known/openid-configuration", timeout=10)
+        resp.raise_for_status()
+        md = resp.json()
+        _metadata_cache[env] = md
+    return md
+
+
+def _jwks(env: str):
+    jwks = _jwks_cache.get(env)
+    if jwks is None:
+        resp = httpx.get(_metadata(env)["jwks_uri"], timeout=10)
+        resp.raise_for_status()
+        jwks = JsonWebKey.import_key_set(resp.json())
+        _jwks_cache[env] = jwks
+    return jwks
+
+
+def _b64url(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).rstrip(b"=").decode()
+
+
+def _client_assertion(audience: str) -> str:
+    """Signert private_key_jwt for token-endepunktet (iss=sub=client_id, aud=utsteder)."""
+    s = settings()
+    now = int(time.time())
+    claims = {
+        "iss": s.idporten_client_id,
+        "sub": s.idporten_client_id,
+        "aud": audience,
+        "iat": now,
+        "exp": now + 60,
+        "jti": str(uuid.uuid4()),
+    }
+    header = {"alg": "RS256", "kid": s.idporten_kid}
+    token = jwt.encode(header, claims, s.idporten_key())
+    return token.decode() if isinstance(token, bytes) else token
+
+
+def _navn_fra_claims(claims: dict) -> str:
+    """Verifisert navn: `name` om satt, ellers satt sammen av given_name/family_name."""
+    navn = (claims.get("name") or "").strip()
+    if navn:
+        return navn
+    deler = [claims.get("given_name"), claims.get("family_name")]
+    return " ".join(d for d in deler if d).strip()
+
+
+def _altinn_exchange_url(env: str) -> str:
+    return (
+        "https://platform.tt02.altinn.no/authentication/api/v1/exchange/id-porten"
+        if env == "test"
+        else "https://platform.altinn.no/authentication/api/v1/exchange/id-porten"
+    )
+
+
+def _altinn_parter_url(env: str) -> str:
+    # Endepunktet henter den autentiserte brukeren fra tokenet selv (ingen party-id i stien).
+    base = "https://platform.tt02.altinn.no" if env == "test" else "https://platform.altinn.no"
+    return f"{base}/accessmanagement/api/v1/authorizedparties?includeAltinn2=true"
+
+
+def _veksle_til_altinn_token(access_token: str, env: str) -> str:
+    """Veksle ID-porten access_token mot Altinn brukertoken."""
+    resp = httpx.get(
+        _altinn_exchange_url(env),
+        headers={"Authorization": f"Bearer {access_token}"},
+        timeout=10,
+    )
+    if resp.status_code != 200:
+        _log.warning("Altinn exchange/id-porten svarte %s: %s", resp.status_code, resp.text[:500])
+    resp.raise_for_status()
+    return resp.text.strip().strip('"')
+
+
+def _hent_altinn_parter(altinn_token: str, env: str) -> list:
+    """Hent autoriserte parter (orger) for brukeren fra Altinn Access Management."""
+    resp = httpx.get(
+        _altinn_parter_url(env),
+        headers={"Authorization": f"Bearer {altinn_token}", "Accept": "application/json"},
+        timeout=15,
+    )
+    if resp.status_code != 200:
+        _log.warning(
+            "Altinn authorizedparties svarte %s: %s", resp.status_code, resp.text[:500],
+        )
+    resp.raise_for_status()
+    return resp.json()
+
+
+def _orger_fra_parter(parter: list) -> list[dict]:
+    """
+    Filtrer Altinn autoriserte parter til organisasjoner brukeren har reell tilgang til.
+
+    Felt fra Altinns AuthorizedPartyExternal (camelCase): `type` (JsonStringEnum: Person/
+    Organization/SelfIdentified), `organizationNumber`, `name`, `isDeleted`,
+    `onlyHierarchyElementWithNoAccess` (hierarki-node uten faktisk tilgang).
+    """
+    return [
+        {"orgnr": p["organizationNumber"], "navn": p.get("name") or p["organizationNumber"]}
+        for p in parter
+        if (
+            p.get("type") == "Organization"
+            and p.get("organizationNumber")
+            and not p.get("isDeleted")
+            and not p.get("onlyHierarchyElementWithNoAccess")
+        )
+    ]
+
+
+def _krev_aktivert() -> None:
+    if not settings().idporten_aktivert:
+        raise HTTPException(status_code=404, detail="ID-porten-innlogging er ikke konfigurert.")
+
+
+@router.get("/login")
+def login(request: Request) -> RedirectResponse:
+    """Start ID-porten-innlogging: lagre state/nonce/PKCE i sesjonen og redirect til ID-porten."""
+    _krev_aktivert()
+    s = settings()
+    md = _metadata(s.env)
+
+    state = secrets.token_urlsafe(32)
+    nonce = secrets.token_urlsafe(32)
+    verifier = secrets.token_urlsafe(64)
+    challenge = _b64url(hashlib.sha256(verifier.encode()).digest())
+
+    request.session["idp_state"] = state
+    request.session["idp_nonce"] = nonce
+    request.session["idp_verifier"] = verifier
+
+    params = {
+        "response_type": "code",
+        "client_id": s.idporten_client_id,
+        "redirect_uri": s.idporten_redirect_uri,
+        "scope": _SCOPE,
+        "state": state,
+        "nonce": nonce,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    }
+    return RedirectResponse(md["authorization_endpoint"] + "?" + urlencode(params))
+
+
+def _tilbake(feil: str | None = None) -> RedirectResponse:
+    """Redirect tilbake til SPA-en, ev. med en lesbar feil SPA-en viser som banner."""
+    base = settings().public_url.rstrip("/") + "/"
+    if feil:
+        base += "?" + urlencode({"idp_feil": feil})
+    return RedirectResponse(base)
+
+
+@router.get("/callback")
+def callback(
+    request: Request,
+    code: str | None = None,
+    state: str | None = None,
+    error: str | None = None,
+    error_description: str | None = None,
+) -> RedirectResponse:
+    """Løs inn autorisasjonskoden, valider id_token, og bind den verifiserte identiteten til økten."""
+    _krev_aktivert()
+    s = settings()
+
+    forventet_state = request.session.pop("idp_state", None)
+    nonce = request.session.pop("idp_nonce", None)
+    verifier = request.session.pop("idp_verifier", None)
+
+    if error:
+        # Brukeren avbrøt eller ID-porten avviste. error_description er teknisk, vis en rolig tekst.
+        return _tilbake("Innloggingen ble avbrutt. Prøv igjen.")
+    if not code or not state or state != forventet_state or not verifier:
+        return _tilbake("Innloggingen kunne ikke fullføres. Prøv igjen.")
+
+    md = _metadata(s.env)
+    try:
+        token_resp = httpx.post(
+            md["token_endpoint"],
+            data={
+                "grant_type": "authorization_code",
+                "code": code,
+                "redirect_uri": s.idporten_redirect_uri,
+                "code_verifier": verifier,
+                "client_assertion_type": "urn:ietf:params:oauth:client-assertion-type:jwt-bearer",
+                "client_assertion": _client_assertion(md["issuer"]),
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=15,
+        )
+        token_resp.raise_for_status()
+        id_token = token_resp.json()["id_token"]
+        claims = _valider_id_token(id_token, md, nonce)
+    except (httpx.HTTPError, KeyError, ValueError):
+        return _tilbake("Innloggingen kunne ikke fullføres. Prøv igjen.")
+
+    navn = _navn_fra_claims(claims)
+    if not navn:
+        # Uten et verifisert navn kan vi ikke gjøre rollesjekken mot Enhetsregisteret.
+        return _tilbake("Fikk ikke navnet ditt fra ID-porten. Ta kontakt for manuell tilgang.")
+
+    # Bind den verifiserte identiteten til økten. Fødselsnummeret (`pid`) lagres aldri; kun
+    # navnet, som rollesjekken (velg_org) bruker. `via_idporten` skiller en ID-porten-økt fra
+    # en invite-innløst økt, så SPA-en vet at den skal vise velg-org-steget.
+    request.session["invited"] = True
+    request.session["via_idporten"] = True
+    request.session["idporten_navn"] = navn
+
+    # access_token lagres midlertidig for å hente Altinn-autoriserte parter i org-listen.
+    # Slettes etter at org er valgt (se velg_org nedenfor). Tokenet lever i den signerte
+    # sesjonscookien (ikke i databasen) og utløper med ID-portens token-levetid (~10-15 min).
+    access_token = token_resp.json().get("access_token", "")
+    if access_token:
+        request.session["idporten_access_token"] = access_token
+
+    return _tilbake()
+
+
+class VelgOrgBody(BaseModel):
+    org: str
+
+
+@router.get("/organisasjoner")
+def hent_organisasjoner(request: Request) -> dict:
+    """
+    Hent listen av orger brukeren kan handle for, via Altinn autoriserte parter.
+
+    Veksler ID-porten access_token (lagret i sesjonen etter /callback) mot et Altinn brukertoken,
+    og henter organisasjonslisten for den innloggede personen. Returnerer alltid en dict med
+    'organisasjoner'-liste – tom liste + 'feil' ved feil, slik at SPA-en kan falle tilbake til
+    manuell orgnr-input uten å kaste.
+    """
+    _krev_aktivert()
+    if not request.session.get("via_idporten"):
+        raise HTTPException(status_code=401, detail="Logg inn med ID-porten først.")
+    access_token = request.session.get("idporten_access_token", "")
+    if not access_token:
+        return {
+            "organisasjoner": [],
+            "feil": "Sesjonen er utløpt. Logg inn med ID-porten på nytt.",
+        }
+
+    s = settings()
+    try:
+        altinn_token = _veksle_til_altinn_token(access_token, s.env)
+        parter = _hent_altinn_parter(altinn_token, s.env)
+    except (httpx.HTTPError, ValueError, KeyError, IndexError):
+        _log.exception("Kunne ikke hente autoriserte parter fra Altinn")
+        return {
+            "organisasjoner": [],
+            "feil": "Kunne ikke hente selskapslisten fra Altinn. Skriv inn organisasjonsnummeret manuelt.",
+        }
+
+    return {"organisasjoner": _orger_fra_parter(parter)}
+
+
+@router.post("/velg-org")
+def velg_org_altinn(body: VelgOrgBody, request: Request) -> dict:
+    """
+    Bind sesjonen til orgnr valgt fra Altinn autoriserte parter-listen.
+
+    Altinn er autoritativ kilde: re-verifiserer at orgnr er i den godkjente listen for å hindre
+    at en manipulert request binder en vilkårlig org. Ingen brreg-sjekk nødvendig – Altinn er
+    allerede sterkere enn brreg-navnematchen. access_token slettes fra sesjonen etter binding.
+    """
+    _krev_aktivert()
+    if not request.session.get("via_idporten"):
+        raise HTTPException(status_code=401, detail="Logg inn med ID-porten først.")
+    access_token = request.session.get("idporten_access_token", "")
+    if not access_token:
+        s = settings()
+        return {
+            "ok": False,
+            "feil": "Sesjonen er utløpt. Logg inn med ID-porten på nytt.",
+            "kontakt": s.kontakt,
+        }
+
+    s = settings()
+    orgnr = "".join(c for c in body.org if c.isdigit())
+    if len(orgnr) != 9:
+        return {"ok": False, "feil": "Ugyldig organisasjonsnummer.", "kontakt": s.kontakt}
+
+    try:
+        altinn_token = _veksle_til_altinn_token(access_token, s.env)
+        parter = _hent_altinn_parter(altinn_token, s.env)
+    except (httpx.HTTPError, ValueError, KeyError, IndexError):
+        return {
+            "ok": False,
+            "feil": "Kunne ikke bekrefte tilgang mot Altinn. Prøv igjen.",
+            "kontakt": s.kontakt,
+        }
+
+    godkjente = {o["orgnr"] for o in _orger_fra_parter(parter)}
+
+    if orgnr not in godkjente:
+        return {
+            "ok": False,
+            "feil": "Du har ikke registrert tilgang for dette selskapet i Altinn.",
+            "kontakt": s.kontakt,
+        }
+
+    # Org bekreftet av Altinn – bind sesjonen og rydd access_token
+    request.session["invited"] = True
+    request.session["invite_org"] = orgnr
+    request.session.pop("idporten_access_token", None)
+    return {"ok": True, "invite_org": orgnr}
+
+
+def _valider_id_token(id_token: str, md: dict, nonce: str | None) -> dict:
+    """Valider signatur (JWKS), utsteder, mottaker og nonce. Kaster ved avvik."""
+    claims = jwt.decode(
+        id_token,
+        _jwks(settings().env),
+        claims_options={
+            "iss": {"essential": True, "value": md["issuer"]},
+            "aud": {"essential": True, "value": settings().idporten_client_id},
+        },
+    )
+    claims.validate(now=int(time.time()), leeway=_LEEWAY)
+    if not nonce or claims.get("nonce") != nonce:
+        raise ValueError("nonce-avvik i id_token")
+    return claims

--- a/hosted/api/idporten.py
+++ b/hosted/api/idporten.py
@@ -43,11 +43,20 @@ _log = logging.getLogger("wenche.idporten")
 
 # Tillatt klokkeskjev ved id_token-validering.
 _LEEWAY = 60
-# `altinn:reportees` («se hvem du kan representere») kreves for å (a) la Altinn godta
-# token-vekslingen (exchange/id-porten avviser tokens uten en altinn:-scope, AUTH-koden
-# HasAltinnScope) og (b) hente autoriserte parter. Scopet må også være tildelt ID-porten-
-# klienten i Samarbeidsportalen, ellers nekter ID-porten å utstede tokenet.
-_SCOPE = "openid profile altinn:reportees"
+
+
+def _scope() -> str:
+    """
+    OIDC-scope for innloggingen.
+
+    `altinn:reportees` («se hvem du kan representere») kreves for å (a) la Altinn godta
+    token-vekslingen (exchange/id-porten avviser tokens uten en altinn:-scope, jf. Altinns
+    HasAltinnScope) og (b) hente autoriserte parter. Men scopet må være tildelt klienten i
+    Samarbeidsportalen, ellers avviser ID-porten HELE innloggingen (invalid_scope). Derfor ber
+    vi om det kun når operatøren har skrudd på flagget; ellers logger man inn med bare
+    openid+profile og velger selskap manuelt.
+    """
+    return "openid profile altinn:reportees" if settings().idporten_reportees else "openid profile"
 
 # Well-known-metadata og JWKS per miljø (test/prod), cachet i minnet.
 _metadata_cache: dict[str, dict] = {}
@@ -196,7 +205,7 @@ def login(request: Request) -> RedirectResponse:
         "response_type": "code",
         "client_id": s.idporten_client_id,
         "redirect_uri": s.idporten_redirect_uri,
-        "scope": _SCOPE,
+        "scope": _scope(),
         "state": state,
         "nonce": nonce,
         "code_challenge": challenge,
@@ -295,6 +304,11 @@ def hent_organisasjoner(request: Request) -> dict:
     _krev_aktivert()
     if not request.session.get("via_idporten"):
         raise HTTPException(status_code=401, detail="Logg inn med ID-porten først.")
+    s = settings()
+    if not s.idporten_reportees:
+        # Scopet altinn:reportees er ikke tildelt, så vi har ikke tilgang til parter-lista.
+        # Tom liste uten feil: SPA-en viser manuell orgnr-inntasting (som den skal når flagget er av).
+        return {"organisasjoner": []}
     access_token = request.session.get("idporten_access_token", "")
     if not access_token:
         return {
@@ -302,7 +316,6 @@ def hent_organisasjoner(request: Request) -> dict:
             "feil": "Sesjonen er utløpt. Logg inn med ID-porten på nytt.",
         }
 
-    s = settings()
     try:
         altinn_token = _veksle_til_altinn_token(access_token, s.env)
         parter = _hent_altinn_parter(altinn_token, s.env)

--- a/hosted/api/main.py
+++ b/hosted/api/main.py
@@ -22,6 +22,7 @@ from wenche import __version__ as WENCHE_VERSJON
 from .auth import router as auth_router
 from .config import settings
 from .dokumenter import router as dokumenter_router
+from .idporten import router as idporten_router
 from .innsending import router as innsending_router
 from .saft import router as saft_router
 from .selskap import router as selskap_router
@@ -78,6 +79,7 @@ app.add_middleware(
 )
 
 app.include_router(auth_router)
+app.include_router(idporten_router)
 app.include_router(systembruker_router)
 app.include_router(innsending_router)
 app.include_router(dokumenter_router)

--- a/hosted/api/systembruker.py
+++ b/hosted/api/systembruker.py
@@ -17,7 +17,6 @@ from fastapi import APIRouter, HTTPException, Request
 
 from wenche import systembruker as wsb
 
-from .config import settings
 from .deps import admin_token, krev_invite_org, krev_invitert, krev_vendor
 
 logger = logging.getLogger("wenche.hosted.systembruker")
@@ -36,11 +35,10 @@ def request_systembruker(request: Request) -> dict:
     bindes kunde-org direkte (ingen ny BankID-godkjenning). Ny kunde: opprett
     forespørsel og returner godkjenningslenke.
 
-    Unntak for selvbetjente økter: AlreadyApproved-snarveien hopper over BankID, og
-    selvbetjent tilgang er bare et navneoppslag mot offentlige data (ikke identitetsbevis).
-    Å honorere snarveien der ville latt en som kjenner et offentlig styremedlemsnavn sende
-    inn for et alt-onboardet selskap. Slike kobles derfor enten via en manuell invitasjon
-    eller en handoff-lenke fra en alt koblet enhet (auth.py), aldri via selvbetjent snarvei.
+    AlreadyApproved-snarveien (binding uten ny BankID) er trygg fordi begge portene foran er
+    sterke: invite-lenken er operatør-attestert, og ID-porten-stien har bevist identiteten med
+    BankID + bekreftet rolle for orgnr i Enhetsregisteret (se auth.velg_org). En som bare kjenner
+    et offentlig styremedlemsnavn kommer ikke forbi porten i utgangspunktet.
     """
     krev_invitert(request)
     org = krev_invite_org(request)
@@ -48,13 +46,6 @@ def request_systembruker(request: Request) -> dict:
     token = admin_token(creds)
     eksisterende = wsb.hent_systembrukere(token, vendor_orgnr)
     if any(b.get("reporteeOrgNo") == org for b in eksisterende):
-        if request.session.get("via_selvbetjening"):
-            raise HTTPException(
-                status_code=409,
-                detail="Dette selskapet er alt satt opp i Wenche. Har du alt koblet det på en "
-                "annen enhet, åpne Wenche der og velg «Fortsett på en annen enhet» for å koble "
-                "denne. Ellers, ta kontakt for en invitasjon: " + settings().kontakt_tekst + ".",
-            )
         request.session["kunde_org"] = org
         request.session.pop("pending_org", None)
         request.session.pop("request_id", None)

--- a/hosted/dev_local.py
+++ b/hosted/dev_local.py
@@ -45,7 +45,12 @@ os.environ["HOSTED_VENDOR_KEY_PATH"] = next((str(p) for p in _cands if p.exists(
 os.environ["WENCHE_ENV"] = "test"
 os.environ.setdefault("HOSTED_INVITE_SECRET", "dev-invite-secret-bytt-i-prod")
 os.environ.setdefault("HOSTED_SESSION_SECRET", "dev-local-secret")
-os.environ.setdefault("HOSTED_PUBLIC_URL", "http://localhost:5173")
+# 127.0.0.1 (ikke localhost) for å matche ID-porten-redirect-URI-en og holde cookien på samme
+# vert hele veien (ID-porten anbefaler loopback-IP). Åpne SPA-en på http://127.0.0.1:5173.
+os.environ.setdefault("HOSTED_PUBLIC_URL", "http://127.0.0.1:5173")
+# ID-porten-innlogging er av lokalt med mindre HOSTED_IDPORTEN_* er satt (i .env). For å teste
+# OIDC-flyten mot test.idporten.no: sett HOSTED_IDPORTEN_CLIENT_ID/_KID/_KEY_PATH/_REDIRECT_URI
+# (=http://127.0.0.1:5173/api/auth/idporten/callback). Uten dem kjører dev på invite-flyten.
 # Hosted bruker org fra dataene/sesjonen (som i prod), ikke self-hosted sin globale
 # test-override. Sett tomme (ikke pop, da ville wenche.auth sin load_dotenv re-lese
 # repoets .env) så aksjonær/skattemelding bruker config-orgen = kunde-org.

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -558,22 +558,28 @@ function HjemFane({ me, onChange }: { me: Me; onChange: () => void }) {
           {melding && <span className="text-sm text-muted-foreground">{melding}</span>}
         </div>
       </Kort>
-      <Kort>
-        <p className={monoLabel}>Flere enheter</p>
-        <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
-          Tilkoblingen gjelder denne nettleseren.
-        </p>
-        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-          Vil du bruke Wenche på telefonen eller en annen maskin, lag en lenke her og åpne den
-          der, så kobles den enheten til i tillegg, uten ny godkjenning. Begge forblir koblet.
-        </p>
-        <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
-          En enhet du ikke vil bruke lenger, logger du ut med «Logg ut».
-        </p>
-        <div className="mt-4">
-          <FortsettAnnenEnhet />
-        </div>
-      </Kort>
+      {/* Handoff er bare relevant for invite-baserte økter (f.eks. demo, eller fallback-brukere
+          uten ID-porten-rolletreff): de kan ikke logge inn på nytt på en ny enhet uten lenken.
+          ID-porten-brukere logger bare inn på nytt på enhet to (og treffer AlreadyApproved), så
+          handoff er overflødig for dem. Skjules derfor for ID-porten-økter. */}
+      {!me.via_idporten && (
+        <Kort>
+          <p className={monoLabel}>Flere enheter</p>
+          <p className="mt-2 text-sm leading-relaxed text-muted-foreground">
+            Tilkoblingen gjelder denne nettleseren.
+          </p>
+          <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+            Vil du bruke Wenche på telefonen eller en annen maskin, lag en lenke her og åpne den
+            der, så kobles den enheten til i tillegg, uten ny godkjenning. Begge forblir koblet.
+          </p>
+          <p className="mt-3 text-sm leading-relaxed text-muted-foreground">
+            En enhet du ikke vil bruke lenger, logger du ut med «Logg ut».
+          </p>
+          <div className="mt-4">
+            <FortsettAnnenEnhet />
+          </div>
+        </Kort>
+      )}
     </div>
   );
 }

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -31,6 +31,7 @@ interface Me {
   env?: string;
   demo?: boolean;
   idporten?: boolean; // er ID-porten-innlogging tilgjengelig (prod) – styrer gateskjermen
+  reportees?: boolean; // har altinn:reportees-scopet (henter selskapslista fra Altinn) – ellers manuell orgnr
   kontakt?: string | null;
 }
 
@@ -133,10 +134,12 @@ interface OrgItem {
   navn: string;
 }
 
-// Etter ID-porten-innlogging: velg selskap fra listen over orger brukeren kan handle for i Altinn.
-// Henter listen automatisk; faller tilbake til manuell orgnr-input hvis listen er tom eller feiler.
+// Etter ID-porten-innlogging: velg selskap. Når altinn:reportees-scopet er tildelt (me.reportees),
+// hentes listen over orger brukeren kan representere fra Altinn automatisk. Ellers (eller ved feil)
+// faller steget tilbake til manuell orgnr-inntasting med brreg-navnematch.
 function VelgOrg({ me, onValgt }: { me: Me; onValgt: () => void }) {
-  const [orger, setOrger] = useState<OrgItem[] | null>(null);
+  // Uten reportees-scopet finnes ingen Altinn-liste å hente: start rett i manuell modus.
+  const [orger, setOrger] = useState<OrgItem[] | null>(me.reportees ? null : []);
   const [listeFeil, setListeFeil] = useState<string | null>(null);
   const [visManuel, setVisManuel] = useState(false);
   const [manueltOrgnr, setManueltOrgnr] = useState("");
@@ -144,6 +147,7 @@ function VelgOrg({ me, onValgt }: { me: Me; onValgt: () => void }) {
   const [handlingsFeil, setHandlingsFeil] = useState<string | null>(null);
 
   useEffect(() => {
+    if (!me.reportees) return; // ingen Altinn-liste uten scopet; manuell inntasting vises
     api
       .hentOrganisasjoner()
       .then((r) => {
@@ -154,7 +158,7 @@ function VelgOrg({ me, onValgt }: { me: Me; onValgt: () => void }) {
         setOrger([]);
         setListeFeil("Kunne ikke hente selskapslisten. Skriv inn organisasjonsnummeret manuelt.");
       });
-  }, []);
+  }, [me.reportees]);
 
   const velgFraListe = async (orgnr: string) => {
     setHandlingsFeil(null);

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -23,12 +23,14 @@ import {
 } from "@wenche/ui";
 
 interface Me {
-  invited: boolean;
-  invite_org?: string | null;
+  invited: boolean; // gate passert (ID-porten-innlogging eller invite-lenke)
+  via_idporten?: boolean; // logget inn via ID-porten (mangler bundet org til velg-org er gjort)
+  navn?: string | null; // verifisert navn fra ID-porten
+  invite_org?: string | null; // org bundet til økten (invite-token eller velg-org)
   kunde_org?: string | null;
   env?: string;
   demo?: boolean;
-  selvbetjening?: boolean;
+  idporten?: boolean; // er ID-porten-innlogging tilgjengelig (prod) – styrer gateskjermen
   kontakt?: string | null;
 }
 
@@ -92,88 +94,183 @@ function KontaktLenke({ kontakt }: { kontakt?: string | null }) {
 const tilgangInput =
   "w-full rounded-md border border-border bg-background px-4 py-2.5 text-sm outline-none focus:border-spruce";
 
-function KunInviterte({ me, onApproved }: { me: Me; onApproved: () => void }) {
-  const [navn, setNavn] = useState("");
-  const [org, setOrg] = useState("");
-  const [sender, setSender] = useState(false);
-  const [feil, setFeil] = useState<string | null>(null);
+// Gateskjerm. I prod (ID-porten konfigurert): logg inn med BankID. På demo (ID-porten av):
+// invite-lenke (løses inn via URL-parameter) er porten, ellers en kontaktvei. Den frie
+// navnematchen er fjernet; med ID-porten er navnet verifisert, ikke innskrevet.
+function Gate({ me }: { me: Me }) {
+  return (
+    <Kort>
+      <p className={monoLabel}>Tilgang</p>
+      <h1 className="mt-3 font-display text-3xl font-normal">Logg inn i Wenche</h1>
+      {me.idporten ? (
+        <>
+          <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+            Logg inn med ID-porten (BankID). Jeg henter navnet ditt og bekrefter at du står som
+            daglig leder eller styreleder for selskapet du vil sende inn for. Fødselsnummeret
+            ditt lagres ikke.
+          </p>
+          {/* Full-page navigasjon: backenden redirecter videre til ID-porten. */}
+          <a
+            className={`${btnPrimar} mt-6 inline-block`}
+            href="/api/auth/idporten/login"
+            onClick={() => sporHendelse("idporten-start")}
+          >
+            Logg inn med ID-porten
+          </a>
+        </>
+      ) : (
+        <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+          Wenche er i en tidlig testfase. Vil du prøve den? Ta kontakt:{" "}
+          <KontaktLenke kontakt={me.kontakt} />.
+        </p>
+      )}
+    </Kort>
+  );
+}
 
-  const send = async (e: FormEvent) => {
-    e.preventDefault();
-    setFeil(null);
+interface OrgItem {
+  orgnr: string;
+  navn: string;
+}
+
+// Etter ID-porten-innlogging: velg selskap fra listen over orger brukeren kan handle for i Altinn.
+// Henter listen automatisk; faller tilbake til manuell orgnr-input hvis listen er tom eller feiler.
+function VelgOrg({ me, onValgt }: { me: Me; onValgt: () => void }) {
+  const [orger, setOrger] = useState<OrgItem[] | null>(null);
+  const [listeFeil, setListeFeil] = useState<string | null>(null);
+  const [visManuel, setVisManuel] = useState(false);
+  const [manueltOrgnr, setManueltOrgnr] = useState("");
+  const [sender, setSender] = useState(false);
+  const [handlingsFeil, setHandlingsFeil] = useState<string | null>(null);
+
+  useEffect(() => {
+    api
+      .hentOrganisasjoner()
+      .then((r) => {
+        setOrger(r.organisasjoner ?? []);
+        if (r.feil) setListeFeil(r.feil);
+      })
+      .catch(() => {
+        setOrger([]);
+        setListeFeil("Kunne ikke hente selskapslisten. Skriv inn organisasjonsnummeret manuelt.");
+      });
+  }, []);
+
+  const velgFraListe = async (orgnr: string) => {
+    setHandlingsFeil(null);
     setSender(true);
     try {
-      const r = await api.beOmTilgang(navn, org);
-      if (r.invited) {
-        sporHendelse("tilgang-innvilget");
-        onApproved();
+      const r = await api.velgOrgAltinn(orgnr);
+      if (r.ok) {
+        sporHendelse("velg-org-altinn-ok");
+        onValgt();
       } else {
-        sporHendelse("tilgang-avvist");
-        setFeil(r.feil ?? "Kunne ikke gi tilgang.");
+        setHandlingsFeil(r.feil ?? "Kunne ikke gi tilgang.");
       }
     } catch (err) {
-      setFeil((err as Error).message);
+      setHandlingsFeil((err as Error).message);
     } finally {
       setSender(false);
     }
   };
 
+  const velgManuelt = async (e: FormEvent) => {
+    e.preventDefault();
+    setHandlingsFeil(null);
+    setSender(true);
+    try {
+      const r = await api.velgOrg(manueltOrgnr);
+      if (r.ok) {
+        sporHendelse("velg-org-manuell-ok");
+        onValgt();
+      } else {
+        sporHendelse("velg-org-avvist");
+        setHandlingsFeil(r.feil ?? "Kunne ikke gi tilgang.");
+      }
+    } catch (err) {
+      setHandlingsFeil((err as Error).message);
+    } finally {
+      setSender(false);
+    }
+  };
+
+  const laster = orger === null;
+  const visListe = !laster && (orger?.length ?? 0) > 0 && !visManuel;
+
   return (
     <Kort>
-      <p className={monoLabel}>Tilgang</p>
-      <h1 className="mt-3 font-display text-3xl font-normal">Wenche er i en tidlig testfase</h1>
-      <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
-        Jeg holder fortsatt på å teste tjenesten og gjøre den stabil.
-      </p>
+      <p className={monoLabel}>Velg selskap</p>
+      <h1 className="mt-3 font-display text-3xl font-normal">
+        Hei{me.navn ? `, ${me.navn}` : ""}
+      </h1>
 
-      {me.selvbetjening ? (
+      {laster ? (
+        <p className="mt-4 text-sm text-muted-foreground">Henter selskapslisten...</p>
+      ) : visListe ? (
         <>
           <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
-            Vil du prøve den for ditt eget selskap? Skriv inn navnet ditt og organisasjonsnummeret
-            til selskapet du vil bruke Wenche for. Står du som daglig leder eller styremedlem i
-            Enhetsregisteret, slipper du inn med en gang og kobler selskapet med BankID i neste
-            steg. Navnet brukes bare til oppslaget og lagres ikke.
+            Velg selskapet du vil sende inn for.
           </p>
-          <form className="mt-6 space-y-4" onSubmit={send}>
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-              <label className="block">
-                <span className="mb-1 block text-xs text-muted-foreground">Fullt navn</span>
-                <input
-                  className={tilgangInput}
-                  autoComplete="name"
-                  value={navn}
-                  onChange={(e) => setNavn(e.target.value)}
-                  aria-invalid={!!feil}
-                  required
-                />
-              </label>
-              <label className="block">
-                <span className="mb-1 block text-xs text-muted-foreground">Organisasjonsnummer</span>
-                <input
-                  className={tilgangInput}
-                  inputMode="numeric"
-                  autoComplete="off"
-                  value={org}
-                  onChange={(e) => setOrg(e.target.value)}
-                  aria-invalid={!!feil}
-                  required
-                />
-              </label>
-            </div>
-            <button className={`${btnPrimar} w-full sm:w-auto`} type="submit" disabled={sender}>
-              {sender ? "Sjekker…" : "Be om tilgang"}
-            </button>
-          </form>
-          {feil && (
-            <p role="alert" className="mt-4 text-sm leading-relaxed text-red-700">
-              {feil} Stemmer ikke dette, eller har du skjermet adresse, ta kontakt:{" "}
-              <KontaktLenke kontakt={me.kontakt} />.
-            </p>
-          )}
+          <div className="mt-6 space-y-3">
+            {orger!.map((org) => (
+              <button
+                key={org.orgnr}
+                className={`${btnOutline} w-full text-left`}
+                disabled={sender}
+                onClick={() => velgFraListe(org.orgnr)}
+              >
+                <span className="block font-medium">{org.navn}</span>
+                <span className="block text-xs text-muted-foreground">{org.orgnr}</span>
+              </button>
+            ))}
+          </div>
+          <button
+            className="mt-4 text-xs text-muted-foreground underline-offset-2 hover:underline"
+            onClick={() => setVisManuel(true)}
+          >
+            Ikke i listen?
+          </button>
         </>
       ) : (
-        <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
-          Vil du prøve den? Ta kontakt: <KontaktLenke kontakt={me.kontakt} />.
+        <>
+          {!laster && (
+            <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
+              {listeFeil ??
+                "Skriv inn organisasjonsnummeret til selskapet du vil sende inn for. Jeg " +
+                  "bekrefter at du står som daglig leder eller styreleder i Enhetsregisteret."}
+            </p>
+          )}
+          <form className="mt-6 space-y-4" onSubmit={velgManuelt}>
+            <label className="block">
+              <span className="mb-1 block text-xs text-muted-foreground">Organisasjonsnummer</span>
+              <input
+                className={tilgangInput}
+                inputMode="numeric"
+                autoComplete="off"
+                value={manueltOrgnr}
+                onChange={(e) => setManueltOrgnr(e.target.value)}
+                aria-invalid={!!handlingsFeil}
+                required
+              />
+            </label>
+            <button className={`${btnPrimar} w-full sm:w-auto`} type="submit" disabled={sender}>
+              {sender ? "Sjekker…" : "Fortsett"}
+            </button>
+          </form>
+          {visManuel && (
+            <button
+              className="mt-4 text-xs text-muted-foreground underline-offset-2 hover:underline"
+              onClick={() => setVisManuel(false)}
+            >
+              Tilbake til listen
+            </button>
+          )}
+        </>
+      )}
+
+      {handlingsFeil && (
+        <p role="alert" className="mt-4 text-sm leading-relaxed text-red-700">
+          {handlingsFeil} Ta kontakt: <KontaktLenke kontakt={me.kontakt} />.
         </p>
       )}
     </Kort>
@@ -606,6 +703,9 @@ export default function App() {
     const params = new URLSearchParams(window.location.search);
     const invite = params.get("invite");
     const handoff = params.get("handoff");
+    // ID-porten-callbacken redirecter tilbake hit, ev. med en lesbar feil (avbrutt innlogging,
+    // teknisk svikt). Vis den som banner, og rydd den ut av URL-en som med invite/handoff.
+    const idpFeil = params.get("idp_feil");
     // En invite-lenke åpner porten; en handoff-lenke (fra en alt koblet enhet) arver bindingen
     // direkte. Begge løses inn FØR URL-en ryddes og analytics kjører, så tokenet aldri lekker.
     const losInn = invite
@@ -628,6 +728,10 @@ export default function App() {
           sporVisning();
         });
     } else {
+      if (idpFeil) {
+        setLenkeFeil(idpFeil);
+        window.history.replaceState({}, "", window.location.pathname);
+      }
       refresh();
       sporVisning();
     }
@@ -730,7 +834,10 @@ export default function App() {
         {!me ? (
           <p className="text-sm text-muted-foreground">Laster…</p>
         ) : !me.invited ? (
-          <KunInviterte me={me} onApproved={refresh} />
+          <Gate me={me} />
+        ) : me.via_idporten && !me.invite_org ? (
+          // Logget inn med ID-porten, men ingen org bundet ennå: velg selskap.
+          <VelgOrg me={me} onValgt={refresh} />
         ) : !me.kunde_org ? (
           // Port: før selskapet er koblet er dette den eneste skjermen (ingen steg).
           <HjemFane me={me} onChange={refresh} />

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -102,13 +102,13 @@ function Gate({ me }: { me: Me }) {
   return (
     <Kort>
       <p className={monoLabel}>Tilgang</p>
-      <h1 className="mt-3 font-display text-3xl font-normal">Logg inn i Wenche</h1>
+      <h1 className="mt-3 font-display text-3xl font-normal">Logg inn</h1>
       {me.idporten ? (
         <>
           <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
-            Logg inn med ID-porten (BankID). Jeg henter navnet ditt og bekrefter at du står som
-            daglig leder eller styreleder for selskapet du vil sende inn for. Fødselsnummeret
-            ditt lagres ikke.
+            Wenche er ikke kravstor. Men hun må vite hvem hun jobber for. Logg inn med ID-porten,
+            velg BankID og gå videre. Ditt fødselsnummer benyttes kun for autentisering og lagres
+            ikke.
           </p>
           {/* Full-page navigasjon: backenden redirecter videre til ID-porten. */}
           <a
@@ -116,7 +116,7 @@ function Gate({ me }: { me: Me }) {
             href="/api/auth/idporten/login"
             onClick={() => sporHendelse("idporten-start")}
           >
-            Logg inn med ID-porten
+            Logg inn med BankID
           </a>
         </>
       ) : (

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -240,8 +240,9 @@ function VelgOrg({ me, onValgt }: { me: Me; onValgt: () => void }) {
           {!laster && (
             <p className="mt-4 text-sm leading-relaxed text-muted-foreground">
               {listeFeil ??
-                "Skriv inn organisasjonsnummeret til selskapet du vil sende inn for. Jeg " +
-                  "bekrefter at du står som daglig leder eller styreleder i Enhetsregisteret."}
+                "Wenche må vite hvilket organisasjonsnummer hun skal ordne papirene for. Husk " +
+                  "at du må være daglig leder eller styreleder for å kunne gi henne fullmakt til " +
+                  "å sende inn på dine vegne."}
             </p>
           )}
           <form className="mt-6 space-y-4" onSubmit={velgManuelt}>

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -275,7 +275,7 @@ function VelgOrg({ me, onValgt }: { me: Me; onValgt: () => void }) {
 
       {handlingsFeil && (
         <p role="alert" className="mt-4 text-sm leading-relaxed text-red-700">
-          {handlingsFeil} Ta kontakt: <KontaktLenke kontakt={me.kontakt} />.
+          {handlingsFeil}
         </p>
       )}
     </Kort>

--- a/hosted/web/src/api.ts
+++ b/hosted/web/src/api.ts
@@ -6,9 +6,17 @@ export const api = {
   me: () => req("/api/auth/me"),
   invite: (token: string) =>
     req("/api/auth/invite", { method: "POST", body: JSON.stringify({ token }) }),
-  // Selvbetjent tilgang: navn + orgnr verifiseres mot Enhetsregisteret. Navnet lagres ikke.
-  beOmTilgang: (navn: string, org: string) =>
-    req("/api/auth/be-om-tilgang", { method: "POST", body: JSON.stringify({ navn, org }) }),
+  // ID-porten + Altinn: hent liste over orger brukeren kan handle for (bruker access_token
+  // fra sesjonen til å veksle mot Altinn og hente autoriserte parter). Returnerer alltid
+  // {organisasjoner, feil?} – tom liste ved feil, så SPA-en kan falle tilbake til manuell input.
+  hentOrganisasjoner: () => req("/api/auth/idporten/organisasjoner"),
+  // Bind sesjonen til org valgt fra Altinn-listen (re-verifiserer mot Altinn, ingen brreg-sjekk).
+  velgOrgAltinn: (org: string) =>
+    req("/api/auth/idporten/velg-org", { method: "POST", body: JSON.stringify({ org }) }),
+  // ID-porten-rollesjekk (manuell fallback): etter BankID-innlogging bekreftes det verifiserte
+  // navnet (fra sesjonen) mot orgnr i Enhetsregisteret. Navnet sendes ikke fra klienten, bare orgnr.
+  velgOrg: (org: string) =>
+    req("/api/auth/velg-org", { method: "POST", body: JSON.stringify({ org }) }),
   // Fortsett på en annen enhet: en koblet økt lager en kortvarig overføringslenke (QR),
   // den nye enheten løser den inn og arver bindingen.
   handoffCreate: () => req("/api/auth/handoff/create", { method: "POST" }),

--- a/hosted/web/vite.config.ts
+++ b/hosted/web/vite.config.ts
@@ -13,6 +13,10 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   resolve: { alias: { "@wenche/ui": wencheUi } },
   server: {
+    // Bind til IPv4-loopbacken eksplisitt. Default «localhost» kan bli IPv6 (::1) på macOS, og
+    // da feiler ID-porten-callbacken som alltid går til http://127.0.0.1:5173 (registrert
+    // redirect-URI). Bruk 127.0.0.1 konsekvent i nettleseren så sesjonscookien følger med.
+    host: "127.0.0.1",
     port: 5173,
     proxy: {
       "/api": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.33.5"
+version = "0.34.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_hosted_idporten.py
+++ b/tests/test_hosted_idporten.py
@@ -30,8 +30,8 @@ _META = {
 }
 
 
-@pytest.fixture
-def klient(monkeypatch):
+def _bygg_klient(monkeypatch, *, reportees: bool):
+    """Felles oppsett for ID-porten-test-klienten. reportees styrer altinn:reportees-scopet."""
     monkeypatch.setenv("WENCHE_ENV", "test")
     monkeypatch.setenv("HOSTED_SESSION_SECRET", "test-session-secret")
     monkeypatch.setenv("HOSTED_INVITE_SECRET", "test-invite-secret")
@@ -42,6 +42,10 @@ def klient(monkeypatch):
         "HOSTED_IDPORTEN_REDIRECT_URI", "http://127.0.0.1:5173/api/auth/idporten/callback"
     )
     monkeypatch.setenv("HOSTED_KONTAKT", "mailto:test@wenche.cloud")
+    if reportees:
+        monkeypatch.setenv("HOSTED_IDPORTEN_REPORTEES", "1")
+    else:
+        monkeypatch.delenv("HOSTED_IDPORTEN_REPORTEES", raising=False)
     from hosted.api import config
 
     config.settings.cache_clear()
@@ -54,12 +58,32 @@ def klient(monkeypatch):
     # Well-known og client-assertion mockes; ingen nett, ingen ekte nøkkel brukes.
     monkeypatch.setattr(idp, "_metadata", lambda env: _META)
     monkeypatch.setattr(idp, "_client_assertion", lambda aud: "fake-assertion")
+    return main_mod
+
+
+@pytest.fixture
+def klient(monkeypatch):
+    """ID-porten PÅ med altinn:reportees-scopet (selskapslista hentes fra Altinn)."""
+    from hosted.api import config
+
+    main_mod = _bygg_klient(monkeypatch, reportees=True)
     with TestClient(main_mod.app) as klient:
         yield klient
     config.settings.cache_clear()
 
 
-def _login(klient) -> str:
+@pytest.fixture
+def klient_uten_reportees(monkeypatch):
+    """ID-porten PÅ men UTEN altinn:reportees (scopet ikke tildelt): manuell orgnr-inntasting."""
+    from hosted.api import config
+
+    main_mod = _bygg_klient(monkeypatch, reportees=False)
+    with TestClient(main_mod.app) as klient:
+        yield klient
+    config.settings.cache_clear()
+
+
+def _login(klient, *, scope: str = "openid profile altinn:reportees") -> str:
     """Start innlogging og returner state-en (uten å følge redirecten til ID-porten)."""
     r = klient.get("/api/auth/idporten/login", follow_redirects=False)
     assert r.status_code in (302, 307)
@@ -67,8 +91,7 @@ def _login(klient) -> str:
     assert r.headers["location"].startswith(_META["authorization_endpoint"])
     assert q["client_id"] == ["test-client"]
     assert q["code_challenge_method"] == ["S256"]
-    # altinn:reportees kreves for at Altinn skal godta token-vekslingen og for parter-kallet.
-    assert q["scope"] == ["openid profile altinn:reportees"]
+    assert q["scope"] == [scope]
     return q["state"][0]
 
 
@@ -131,6 +154,58 @@ def test_me_eksponerer_idporten(klient):
 
 def test_login_bygger_pkce_redirect(klient):
     _login(klient)  # assertene ligger i hjelperen
+
+
+def test_login_uten_reportees_ber_kun_om_openid_profile(klient_uten_reportees):
+    """
+    Uten altinn:reportees-scopet (ikke tildelt klienten) ber innloggingen kun om openid+profile,
+    så ID-porten ikke avviser autorisasjonsforespørselen (invalid_scope). Regresjonsvern: scopet
+    skal aldri snike seg inn i forespørselen før operatøren har skrudd det på.
+    """
+    state = _login(klient_uten_reportees, scope="openid profile")
+    assert state
+
+
+def test_me_reportees_av_naar_scope_ikke_satt(klient_uten_reportees, monkeypatch):
+    """/me melder reportees=False så SPA-en hopper over Altinn-lista og viser manuell inntasting."""
+    state = _login(klient_uten_reportees, scope="openid profile")
+    monkeypatch.setattr(
+        idp, "_valider_id_token", lambda id_token, md, nonce: {"name": "Ole Fredrik Lie"}
+    )
+    monkeypatch.setattr(
+        idp.httpx, "post",
+        lambda *a, **k: SimpleNamespace(
+            raise_for_status=lambda: None, json=lambda: {"id_token": "x", "access_token": "t"}
+        ),
+    )
+    klient_uten_reportees.get(
+        f"/api/auth/idporten/callback?code=abc&state={state}", follow_redirects=False
+    )
+    assert klient_uten_reportees.get("/api/auth/me").json()["reportees"] is False
+
+
+def test_organisasjoner_uten_reportees_gir_tom_liste_uten_altinn_kall(klient_uten_reportees, monkeypatch):
+    """Uten scopet skal /organisasjoner returnere tom liste UTEN å kalle Altinn (SPA går manuelt)."""
+    state = _login(klient_uten_reportees, scope="openid profile")
+    monkeypatch.setattr(
+        idp, "_valider_id_token", lambda id_token, md, nonce: {"name": "Ole Fredrik Lie"}
+    )
+    monkeypatch.setattr(
+        idp.httpx, "post",
+        lambda *a, **k: SimpleNamespace(
+            raise_for_status=lambda: None, json=lambda: {"id_token": "x", "access_token": "t"}
+        ),
+    )
+
+    def feil(*a, **k):
+        raise AssertionError("skal ikke kalle Altinn når reportees-scopet er av")
+
+    monkeypatch.setattr(idp.httpx, "get", feil)
+    klient_uten_reportees.get(
+        f"/api/auth/idporten/callback?code=abc&state={state}", follow_redirects=False
+    )
+    r = klient_uten_reportees.get("/api/auth/idporten/organisasjoner").json()
+    assert r == {"organisasjoner": []}
 
 
 def test_callback_binder_verifisert_navn(klient, monkeypatch):

--- a/tests/test_hosted_idporten.py
+++ b/tests/test_hosted_idporten.py
@@ -1,0 +1,303 @@
+"""
+ID-porten-innloggingsflyten for hostet Wenche (HTTP-nivå).
+
+Beviser:
+- ID-porten eksponeres som tilgjengelig port i /me når den er konfigurert.
+- /login bygger en authorization_code-redirect med PKCE (S256), state og nonce.
+- /callback (well-known, token og id_token-validering mocket) binder det VERIFISERTE navnet
+  til økten uten å lagre fødselsnummer.
+- velg_org matcher det verifiserte navnet (fra sesjonen, ikke request-body) mot Enhetsregisteret.
+- En ID-porten-verifisert økt får AlreadyApproved-snarveien (ingen via_selvbetjening-sperre mer).
+
+Well-known-dokument, JWKS, token-kall og id_token-signaturen mockes, så testen treffer verken
+nett, ID-porten eller ekte krypto.
+"""
+import importlib
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from fastapi.testclient import TestClient
+
+import hosted.api.idporten as idp
+import hosted.api.systembruker as sb
+
+_META = {
+    "issuer": "https://test.idporten.no",
+    "authorization_endpoint": "https://test.idporten.no/authorize",
+    "token_endpoint": "https://test.idporten.no/token",
+    "jwks_uri": "https://test.idporten.no/jwks",
+}
+
+
+@pytest.fixture
+def klient(monkeypatch):
+    monkeypatch.setenv("WENCHE_ENV", "test")
+    monkeypatch.setenv("HOSTED_SESSION_SECRET", "test-session-secret")
+    monkeypatch.setenv("HOSTED_INVITE_SECRET", "test-invite-secret")
+    monkeypatch.setenv("HOSTED_IDPORTEN_CLIENT_ID", "test-client")
+    monkeypatch.setenv("HOSTED_IDPORTEN_KID", "test-kid")
+    monkeypatch.setenv("HOSTED_IDPORTEN_KEY_PEM", "dummy-key")
+    monkeypatch.setenv(
+        "HOSTED_IDPORTEN_REDIRECT_URI", "http://127.0.0.1:5173/api/auth/idporten/callback"
+    )
+    monkeypatch.setenv("HOSTED_KONTAKT", "mailto:test@wenche.cloud")
+    from hosted.api import config
+
+    config.settings.cache_clear()
+    from hosted.api import main as main_mod
+
+    importlib.reload(main_mod)
+    import hosted.api.auth as auth_mod
+
+    auth_mod._RATE.clear()  # in-memory rate-limit lever på tvers av tester
+    # Well-known og client-assertion mockes; ingen nett, ingen ekte nøkkel brukes.
+    monkeypatch.setattr(idp, "_metadata", lambda env: _META)
+    monkeypatch.setattr(idp, "_client_assertion", lambda aud: "fake-assertion")
+    with TestClient(main_mod.app) as klient:
+        yield klient
+    config.settings.cache_clear()
+
+
+def _login(klient) -> str:
+    """Start innlogging og returner state-en (uten å følge redirecten til ID-porten)."""
+    r = klient.get("/api/auth/idporten/login", follow_redirects=False)
+    assert r.status_code in (302, 307)
+    q = parse_qs(urlparse(r.headers["location"]).query)
+    assert r.headers["location"].startswith(_META["authorization_endpoint"])
+    assert q["client_id"] == ["test-client"]
+    assert q["code_challenge_method"] == ["S256"]
+    # altinn:reportees kreves for at Altinn skal godta token-vekslingen og for parter-kallet.
+    assert q["scope"] == ["openid profile altinn:reportees"]
+    return q["state"][0]
+
+
+def _logg_inn(klient, monkeypatch, navn="Ole Fredrik Lie", access_token="fake-access-token"):
+    """Fullfør login + callback med mocket token og id_token-validering."""
+    state = _login(klient)
+    monkeypatch.setattr(
+        idp, "_valider_id_token", lambda id_token, md, nonce: {"name": navn, "pid": "12345678901"}
+    )
+    monkeypatch.setattr(
+        idp.httpx, "post",
+        lambda *a, **k: SimpleNamespace(
+            raise_for_status=lambda: None,
+            json=lambda: {"id_token": "x", "access_token": access_token},
+        ),
+    )
+    r = klient.get(
+        f"/api/auth/idporten/callback?code=abc&state={state}", follow_redirects=False
+    )
+    assert r.status_code in (302, 307)
+    return r
+
+
+def _brreg_rollesvar(*navn):
+    """Fake Enhetsregister-rollesvar med gitte 'Fornavn Etternavn'-strenger som styremedlemmer."""
+    roller = []
+    for fullt in navn:
+        deler = fullt.split()
+        roller.append({
+            "type": {"kode": "MEDL"},
+            "fratraadt": False,
+            "avregistrert": False,
+            "person": {"erDoed": False, "navn": {"fornavn": " ".join(deler[:-1]), "etternavn": deler[-1]}},
+        })
+    return SimpleNamespace(
+        status_code=200,
+        raise_for_status=lambda: None,
+        json=lambda: {"rollegrupper": [{"type": {"kode": "STYR"}, "roller": roller}]},
+    )
+
+
+def _stub_brreg(monkeypatch, svar):
+    import hosted.api.auth as auth_mod
+
+    monkeypatch.setattr(auth_mod.httpx, "get", lambda *a, **k: svar)
+
+
+def _stub_vendor(monkeypatch, org):
+    creds = SimpleNamespace(client_id="fake-client-id")
+    monkeypatch.setattr(sb, "krev_vendor", lambda: (creds, "999999999"))
+    monkeypatch.setattr(sb, "admin_token", lambda creds: "fake-token")
+    monkeypatch.setattr(sb.wsb, "hent_systembrukere", lambda tok, vendor: [{"reporteeOrgNo": org}])
+
+
+def test_me_eksponerer_idporten(klient):
+    me = klient.get("/api/auth/me").json()
+    assert me["invited"] is False
+    assert me["idporten"] is True
+
+
+def test_login_bygger_pkce_redirect(klient):
+    _login(klient)  # assertene ligger i hjelperen
+
+
+def test_callback_binder_verifisert_navn(klient, monkeypatch):
+    _logg_inn(klient, monkeypatch, navn="Ole Fredrik Lie")
+    me = klient.get("/api/auth/me").json()
+    assert me["invited"] is True
+    assert me["via_idporten"] is True
+    assert me["navn"] == "Ole Fredrik Lie"
+    # Ingen org bundet før velg_org; SPA-en viser velg-org-steget.
+    assert me["invite_org"] is None
+
+
+def test_callback_avvist_ved_feil_state(klient, monkeypatch):
+    _login(klient)
+    r = klient.get("/api/auth/idporten/callback?code=abc&state=feil", follow_redirects=False)
+    assert r.status_code in (302, 307)
+    assert "idp_feil" in r.headers["location"]
+    assert klient.get("/api/auth/me").json()["invited"] is False
+
+
+def test_velg_org_match_binder(klient, monkeypatch):
+    _logg_inn(klient, monkeypatch, navn="Ole Fredrik Lie")
+    _stub_brreg(monkeypatch, _brreg_rollesvar("Ole Fredrik Lie"))
+    # «Ole Lie» fanges av at det verifiserte navnet er «Ole Fredrik Lie» (mellomnavn utelatt).
+    r = klient.post("/api/auth/velg-org", json={"org": "922 020 523"}).json()
+    assert r == {"ok": True, "invite_org": "922020523"}
+    assert klient.get("/api/auth/me").json()["invite_org"] == "922020523"
+
+
+def test_velg_org_uten_match_avvises(klient, monkeypatch):
+    _logg_inn(klient, monkeypatch, navn="Ole Fredrik Lie")
+    _stub_brreg(monkeypatch, _brreg_rollesvar("Kari Nordmann"))
+    r = klient.post("/api/auth/velg-org", json={"org": "922020523"}).json()
+    assert r["ok"] is False
+    assert r["kontakt"] == "mailto:test@wenche.cloud"
+    assert klient.get("/api/auth/me").json()["invite_org"] is None
+
+
+def test_velg_org_ugyldig_orgnr_uten_oppslag(klient, monkeypatch):
+    _logg_inn(klient, monkeypatch)
+
+    def feil(*a, **k):
+        raise AssertionError("skal ikke slå opp i Enhetsregisteret ved ugyldig orgnr")
+
+    import hosted.api.auth as auth_mod
+
+    monkeypatch.setattr(auth_mod.httpx, "get", feil)
+    r = klient.post("/api/auth/velg-org", json={"org": "123456789"}).json()
+    assert r["ok"] is False and "rganisasjonsnummer" in r["feil"]
+
+
+def _part(orgnr, navn, *, type="Organization", isDeleted=False, onlyHierarchy=False):
+    """Bygg en Altinn AuthorizedPartyExternal-lignende dict med riktige feltnavn."""
+    return {
+        "type": type,
+        "organizationNumber": orgnr,
+        "name": navn,
+        "isDeleted": isDeleted,
+        "onlyHierarchyElementWithNoAccess": onlyHierarchy,
+    }
+
+
+def _stub_altinn(monkeypatch, parter: list):
+    """Mock Altinn token-veksling (exchange) og autoriserte-parter-kallet (status 200)."""
+    def fake_get(url, **k):
+        if "exchange" in url:
+            return SimpleNamespace(
+                status_code=200, raise_for_status=lambda: None, text='"fake.altinn.token"'
+            )
+        return SimpleNamespace(
+            status_code=200, raise_for_status=lambda: None, json=lambda: parter
+        )
+
+    monkeypatch.setattr(idp.httpx, "get", fake_get)
+
+
+def test_hent_organisasjoner_returnerer_liste(klient, monkeypatch):
+    """Org-listen hentes fra Altinn og filtreres til kun orger (ikke personer)."""
+    _logg_inn(klient, monkeypatch)
+    _stub_altinn(monkeypatch, [
+        _part("922020523", "OFL Holding AS"),
+        _part(None, "Ole Fredrik Lie", type="Person"),
+    ])
+    r = klient.get("/api/auth/idporten/organisasjoner").json()
+    assert r["organisasjoner"] == [{"orgnr": "922020523", "navn": "OFL Holding AS"}]
+    assert "feil" not in r
+
+
+def test_hent_organisasjoner_filtrerer_slettet(klient, monkeypatch):
+    """Slettede og hierarki-only-orger (uten reell tilgang) vises ikke."""
+    _logg_inn(klient, monkeypatch)
+    _stub_altinn(monkeypatch, [
+        _part("111111111", "Slettet AS", isDeleted=True),
+        _part("222222222", "Hierarki AS", onlyHierarchy=True),
+        _part("922020523", "OFL Holding AS"),
+    ])
+    r = klient.get("/api/auth/idporten/organisasjoner").json()
+    assert len(r["organisasjoner"]) == 1
+    assert r["organisasjoner"][0]["orgnr"] == "922020523"
+
+
+def test_hent_organisasjoner_krever_idporten_okt(klient, monkeypatch):
+    """Kaller uten ID-porten-sesjon gir 401."""
+    r = klient.get("/api/auth/idporten/organisasjoner")
+    assert r.status_code == 401
+
+
+def test_hent_organisasjoner_ved_altinn_feil_returnerer_tom_liste(klient, monkeypatch):
+    """Altinn-feil gir tom liste med feilmelding, ikke 500."""
+    _logg_inn(klient, monkeypatch)
+
+    def kast(*a, **k):
+        raise idp.httpx.HTTPError("nett-feil")
+
+    monkeypatch.setattr(idp.httpx, "get", kast)
+    r = klient.get("/api/auth/idporten/organisasjoner").json()
+    assert r["organisasjoner"] == []
+    assert "feil" in r
+
+
+def test_velg_org_altinn_binder_godkjent_org(klient, monkeypatch):
+    """Velg org fra listen bekreftes mot Altinn og binder sesjonen."""
+    _logg_inn(klient, monkeypatch)
+    _stub_altinn(monkeypatch, [_part("922020523", "OFL Holding AS")])
+    r = klient.post("/api/auth/idporten/velg-org", json={"org": "922020523"}).json()
+    assert r == {"ok": True, "invite_org": "922020523"}
+    assert klient.get("/api/auth/me").json()["invite_org"] == "922020523"
+
+
+def test_velg_org_altinn_avviser_org_ikke_i_listen(klient, monkeypatch):
+    """Org som ikke er i Altinn-listen avvises selv om request inneholder gyldig orgnr."""
+    _logg_inn(klient, monkeypatch)
+    _stub_altinn(monkeypatch, [_part("922020523", "OFL Holding AS")])
+    r = klient.post("/api/auth/idporten/velg-org", json={"org": "314273818"}).json()
+    assert r["ok"] is False
+    assert klient.get("/api/auth/me").json().get("invite_org") is None
+
+
+def test_velg_org_altinn_krever_idporten_okt(klient, monkeypatch):
+    """Kaller uten ID-porten-sesjon gir 401."""
+    r = klient.post("/api/auth/idporten/velg-org", json={"org": "922020523"})
+    assert r.status_code == 401
+
+
+def test_velg_org_altinn_rydder_access_token(klient, monkeypatch):
+    """access_token fjernes fra sesjonen etter vellykket org-valg."""
+    _logg_inn(klient, monkeypatch)
+    _stub_altinn(monkeypatch, [_part("922020523", "OFL Holding AS")])
+    assert klient.post("/api/auth/idporten/velg-org", json={"org": "922020523"}).json()["ok"]
+    # access_token er slettet; en ny org-lista-forespørsel skal returnere feil, ikke liste
+    r = klient.get("/api/auth/idporten/organisasjoner").json()
+    assert r["organisasjoner"] == []
+    assert "utløpt" in r["feil"].lower()
+
+
+def test_idporten_okt_faar_already_approved(klient, monkeypatch):
+    """
+    En ID-porten-verifisert, rolle-bekreftet økt skal få AlreadyApproved-snarveien (binding uten
+    ny BankID). Regresjonsvern for at via_selvbetjening-sperren er fjernet: identiteten er nå
+    bevist, så snarveien er trygg.
+    """
+    _logg_inn(klient, monkeypatch, navn="Ole Fredrik Lie")
+    _stub_brreg(monkeypatch, _brreg_rollesvar("Ole Fredrik Lie"))
+    assert klient.post("/api/auth/velg-org", json={"org": "922020523"}).json()["ok"] is True
+
+    _stub_vendor(monkeypatch, org="922020523")
+    res = klient.post("/api/systembruker/request").json()
+    assert res["status"] == "AlreadyApproved"
+    assert res["kunde_org"] == "922020523"
+    assert klient.get("/api/auth/me").json()["kunde_org"] == "922020523"

--- a/tests/test_hosted_invite.py
+++ b/tests/test_hosted_invite.py
@@ -30,6 +30,17 @@ def klient(monkeypatch):
     monkeypatch.setenv("WENCHE_ENV", "test")
     monkeypatch.setenv("HOSTED_SESSION_SECRET", "test-session-secret")
     monkeypatch.setenv("HOSTED_INVITE_SECRET", _INVITE_SECRET)
+    # Denne fixturen representerer invite-only (ID-porten av, som demo). .env kan ha
+    # HOSTED_IDPORTEN_* satt for lokal dev (load_dotenv lekker dem inn), så fjern dem
+    # eksplisitt for at testen skal være deterministisk uavhengig av maskinens .env.
+    for var in (
+        "HOSTED_IDPORTEN_CLIENT_ID",
+        "HOSTED_IDPORTEN_KID",
+        "HOSTED_IDPORTEN_KEY_PEM",
+        "HOSTED_IDPORTEN_KEY_PATH",
+        "HOSTED_IDPORTEN_REDIRECT_URI",
+    ):
+        monkeypatch.delenv(var, raising=False)
     from hosted.api import config
 
     config.settings.cache_clear()
@@ -78,15 +89,14 @@ def _gyldig_config(org="314273818"):
 def test_uten_invite_er_stengt(klient):
     me = klient.get("/api/auth/me").json()
     assert me["invited"] is False
-    assert me["selvbetjening"] is False  # av som standard
+    assert me["idporten"] is False  # ID-porten av uten config (invite-only, som demo)
     assert klient.post("/api/systembruker/request").status_code == 401
 
 
-def test_be_om_tilgang_av_som_standard(klient):
-    """Selvbetjening er av med mindre operatøren skrur den på; skjemaet skal avvises da."""
-    r = klient.post("/api/auth/be-om-tilgang", json={"navn": "Ole Lie", "org": "922020523"})
-    assert r.json()["invited"] is False
-    assert klient.get("/api/auth/me").json()["invited"] is False
+def test_velg_org_krever_idporten_okt(klient):
+    """velg-org (rollesjekken) krever en etablert ID-porten-økt; uten den avvises den (401)."""
+    r = klient.post("/api/auth/velg-org", json={"org": "922020523"})
+    assert r.status_code == 401
 
 
 def test_ugyldig_og_gammelt_token_avvises(klient):
@@ -203,127 +213,6 @@ def test_binding_overlever_restart(klient, monkeypatch):
     with TestClient(main_mod.app, cookies=klient.cookies) as ny_klient:
         # Ingen ny BankID, ingen ny invite: bindingen overlever restarten.
         assert ny_klient.get("/api/auth/me").json()["kunde_org"] == "314273818"
-
-
-@pytest.fixture
-def klient_selvbetjening(monkeypatch):
-    """Som klient, men med selvbetjent tilgang påskrudd og en kjent kontaktvei."""
-    monkeypatch.setenv("WENCHE_ENV", "test")
-    monkeypatch.setenv("HOSTED_SESSION_SECRET", "test-session-secret")
-    monkeypatch.setenv("HOSTED_INVITE_SECRET", _INVITE_SECRET)
-    monkeypatch.setenv("HOSTED_SELVBETJENING", "1")
-    monkeypatch.setenv("HOSTED_KONTAKT", "mailto:test@wenche.cloud")
-    from hosted.api import config
-
-    config.settings.cache_clear()
-    from hosted.api import main as main_mod
-
-    importlib.reload(main_mod)
-    import hosted.api.auth as auth_mod
-
-    auth_mod._RATE.clear()  # in-memory rate-limit lever på tvers av tester
-    with TestClient(main_mod.app) as klient:
-        yield klient
-    config.settings.cache_clear()
-
-
-def _brreg_rollesvar(*navn):
-    """Fake Enhetsregister-rollesvar med gitte 'Fornavn Etternavn'-strenger som styremedlemmer."""
-    roller = []
-    for fullt in navn:
-        deler = fullt.split()
-        roller.append({
-            "type": {"kode": "MEDL"},
-            "fratraadt": False,
-            "avregistrert": False,
-            "person": {"erDoed": False, "navn": {"fornavn": " ".join(deler[:-1]), "etternavn": deler[-1]}},
-        })
-    return SimpleNamespace(
-        status_code=200,
-        raise_for_status=lambda: None,
-        json=lambda: {"rollegrupper": [{"type": {"kode": "STYR"}, "roller": roller}]},
-    )
-
-
-def _stub_brreg(monkeypatch, svar):
-    import hosted.api.auth as auth_mod
-
-    monkeypatch.setattr(auth_mod.httpx, "get", lambda *a, **k: svar)
-
-
-def test_me_eksponerer_selvbetjening(klient_selvbetjening):
-    me = klient_selvbetjening.get("/api/auth/me").json()
-    assert me["invited"] is False
-    assert me["selvbetjening"] is True
-    assert me["kontakt"] == "mailto:test@wenche.cloud"
-
-
-def test_be_om_tilgang_match_gir_tilgang(klient_selvbetjening, monkeypatch):
-    """Navn som matcher en aktiv rolleinnehaver gir tilgang umiddelbart, bundet til orgnr."""
-    _stub_brreg(monkeypatch, _brreg_rollesvar("Ole Fredrik Lie"))
-    # «Ole Lie» er en delmengde av «Ole Fredrik Lie» → match til tross for utelatt mellomnavn.
-    r = klient_selvbetjening.post(
-        "/api/auth/be-om-tilgang", json={"navn": "Ole Lie", "org": "922 020 523"}
-    ).json()
-    assert r == {"invited": True, "invite_org": "922020523"}
-    me = klient_selvbetjening.get("/api/auth/me").json()
-    assert me["invited"] is True and me["invite_org"] == "922020523"
-
-
-def test_be_om_tilgang_uten_match_avvises(klient_selvbetjening, monkeypatch):
-    _stub_brreg(monkeypatch, _brreg_rollesvar("Kari Nordmann"))
-    r = klient_selvbetjening.post(
-        "/api/auth/be-om-tilgang", json={"navn": "Ole Lie", "org": "922020523"}
-    ).json()
-    assert r["invited"] is False
-    assert r["kontakt"] == "mailto:test@wenche.cloud"
-    assert klient_selvbetjening.get("/api/auth/me").json()["invited"] is False
-
-
-def test_be_om_tilgang_ugyldig_orgnr_uten_oppslag(klient_selvbetjening, monkeypatch):
-    """Ugyldig MOD11 avvises før vi i det hele tatt slår opp i registeret."""
-    import hosted.api.auth as auth_mod
-
-    def feil(*a, **k):
-        raise AssertionError("skal ikke slå opp i Enhetsregisteret ved ugyldig orgnr")
-
-    monkeypatch.setattr(auth_mod.httpx, "get", feil)
-    r = klient_selvbetjening.post(
-        "/api/auth/be-om-tilgang", json={"navn": "Ole Lie", "org": "123456789"}
-    ).json()
-    assert r["invited"] is False and "rganisasjonsnummer" in r["feil"]
-
-
-def test_be_om_tilgang_krever_fullt_navn(klient_selvbetjening, monkeypatch):
-    _stub_brreg(monkeypatch, _brreg_rollesvar("Ole Fredrik Lie"))
-    r = klient_selvbetjening.post(
-        "/api/auth/be-om-tilgang", json={"navn": "Ole", "org": "922020523"}
-    ).json()
-    assert r["invited"] is False
-
-
-def test_selvbetjening_nektes_already_approved_snarvei(klient_selvbetjening, monkeypatch):
-    """
-    Sikkerhetsegenskap: selvbetjent tilgang er bare et offentlig navneoppslag, så
-    AlreadyApproved-snarveien (binding uten BankID) skal IKKE gjelde. Et alt-onboardet
-    selskap kan dermed ikke kapres av en som kjenner et offentlig styremedlemsnavn.
-    """
-    _stub_vendor(monkeypatch)
-    # Selskapet har alt en godkjent systembruker:
-    monkeypatch.setattr(sb.wsb, "hent_systembrukere", lambda tok, vendor: [{"reporteeOrgNo": "922020523"}])
-    _stub_brreg(monkeypatch, _brreg_rollesvar("Ole Fredrik Lie"))
-
-    assert klient_selvbetjening.post(
-        "/api/auth/be-om-tilgang", json={"navn": "Ole Lie", "org": "922020523"}
-    ).json()["invited"] is True
-    # Snarveien nektes; kunde-org blir aldri bundet uten manuell invitasjon.
-    r = klient_selvbetjening.post("/api/systembruker/request")
-    assert r.status_code == 409
-    # Kontaktvei vises uten URL-skjema (ingen «mailto:» lekker inn i lesbar tekst).
-    detail = r.json()["detail"]
-    assert "test@wenche.cloud" in detail
-    assert "mailto:" not in detail
-    assert klient_selvbetjening.get("/api/auth/me").json()["kunde_org"] is None
 
 
 def test_prod_uten_secrets_nekter_oppstart(monkeypatch):


### PR DESCRIPTION
## Hva

Erstatter den svake, fritt innskrevne navnematchen i den hostede onboardingen med
**ID-porten (BankID)** som primær port i prod. Brukeren logger inn, jeg får et
verifisert navn, og hen velger selskap fra listen over selskaper hen kan
representere i Altinn (autoriserte parter).

## Flyt

1. `GET /api/auth/idporten/login` bygger autorisasjons-URL (authorization_code + PKCE S256) og redirecter til ID-porten.
2. `GET /api/auth/idporten/callback` veksler koden mot tokens (private_key_jwt), validerer id_token, legger verifisert navn + et kortvarig access_token i sesjonen.
3. `GET /api/auth/idporten/organisasjoner` veksler access_token mot Altinn-token og henter autoriserte parter, returnerer selskapslista.
4. `POST /api/auth/idporten/velg-org` re-verifiserer valget mot Altinn og binder økten. access_token slettes etterpå.
5. Videre: systembruker-godkjenning nøyaktig som før.

## Sikkerhet og personvern

- Fødselsnummeret (`pid`) er transient og lagres **aldri**. Kun verifisert navn og et kortvarig access_token ligger i den signerte sesjonscookien (sistnevnte slettes når selskap er valgt).
- Minst mulig scope: ID-porten-tokenet brukes kun til å lese autoriserte parter, ikke til innsending (det går fortsatt på operatørens Maskinporten-systembruker).
- Den frie selvbetjeningen (`be_om_tilgang`/`HOSTED_SELVBETJENING`) er fjernet. `via_selvbetjening`-sperren i systembruker er borte: begge gjenværende porter er sterke (BankID-verifisert eller operatør-attestert).
- Invite-lenken beholdes som operatør-fallback (skjermet person, selskap uten registrert rolleinnehaver).

## Konfig (env-flagget)

ID-porten slås på ved å sette alle fire `HOSTED_IDPORTEN_*`. Utelates de, kjører appen invite-only (slik demo gjør). Delvis config i prod gir fail-closed ved oppstart.

## Status

- [x] ID-porten-innlogging verifisert lokalt ende-til-ende mot test.idporten.no (BankID, callback, verifisert navn).
- [x] Manuell orgnr-inntasting (brreg-navnematch) som fallback. Fungerer for ekte prod-brukere; syntetiske Tenor-personer finnes ikke i åpent brreg og avvises der (forventet).
- [ ] **Auto-lista fra Altinn er kodeferdig og verifisert mot Altinns kildekode, men venter på at Altinn tildeler scopet `altinn:reportees` til org 922020523** (forespørsel sendt til Digdir servicedesk). Til da degraderer steget pent til manuell inntasting. Aktiveres uten ny kode når scopet er på plass.

## Versjon

Bumpet til 0.34.0 (ny funksjonalitet, MINOR). Versjonen eksponeres i hostet `/api/health`.

## Tester

482 grønne, inkludert ny dekning for login/callback (PKCE, verifisert navn), Altinn token-veksling og parter-filtrering, velg-org mot Altinn-lista, og invite-isolasjon.