### PR TITLE
fix: tydeligere feilmelding når selskap uten aksjer eller med drift faller utenfor scope

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.33.4"
+version = "0.33.5"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_valideringskode_forklaringer.py
+++ b/tests/test_valideringskode_forklaringer.py
@@ -34,6 +34,10 @@ def test_forklarer_kjent_veiledningskode():
     assert "passivt holdingselskap" in ut
     assert "utenfor" in ut
     assert "skatteetaten.no" in ut
+    # Forklaringen skal dekke selskap uten aksjer (hvilende), ikke bare anta at
+    # det eier aksjer og mangler formuesgrunnlag (jf. issue #138).
+    assert "ingen aksjer" in ut
+    assert "hvilende" in ut
 
 
 def test_forklarer_kjent_aarsakskode():

--- a/wenche/skd_skattemelding_client.py
+++ b/wenche/skd_skattemelding_client.py
@@ -316,13 +316,15 @@ def _parse_valideringsrespons(raw: bytes) -> dict:
 _KODE_FORKLARINGER = {
     "UP_HAR_NÆRINGSSPESIFIKASJON_MANGLER_SKATTEMELDING": (
         "Skattemeldingen inneholder ingen skattepliktige poster, mens "
-        "næringsspesifikasjonen har innhold. For et passivt holdingselskap "
-        "betyr det som regel at formuesgrunnlaget mangler: fyll inn "
-        "«Formuesverdi aksjer» (formuesverdien av aksjene i datterselskapet), "
-        "så får skattemeldingen et formuesgrunnlag bak aksjene. Har selskapet "
-        "derimot ordinær drift med skattepliktig over- eller underskudd, er det "
-        "utenfor Wenches støtteområde og må leveres via skatteetaten.no eller et "
-        "regnskapsprogram."
+        "næringsspesifikasjonen har innhold. Eier selskapet aksjer i andre "
+        "selskaper (et passivt holdingselskap), mangler det som regel bare "
+        "formuesgrunnlaget: fyll inn «Formuesverdi aksjer» (formuesverdien av "
+        "aksjene selskapet eier), så får skattemeldingen et formuesgrunnlag bak "
+        "aksjene. Eier selskapet derimot ingen aksjer, eller har ordinær drift, "
+        "faller det utenfor det Wenche dekker. Wenche er laget for passive "
+        "holdingselskaper som eier aksjer i andre selskaper, ikke for hvilende "
+        "selskaper uten aksjer eller for selskaper med drift. Slike må leveres "
+        "via skatteetaten.no eller et regnskapsprogram."
     ),
     "innkommendeForespoerselManglerReferanseTilGjeldendeSkattemelding": (
         "Innsendingen mangler referanse til den forhåndsutfylte skattemeldingen. "


### PR DESCRIPTION
## Bakgrunn

Issue #138: en bruker prøvde å levere for et selskap uten aktivitet, med tapt egenkapital og ingen aksjebeholdning. Skattemeldingen ble «tom» mot næringsspesifikasjonen, og Skatteetaten avviste med `UP_HAR_NÆRINGSSPESIFIKASJON_MANGLER_SKATTEMELDING`.

Wenche ga da misvisende veiledning: forklaringsteksten foreslo å fylle inn «Formuesverdi aksjer», men selskapet eide ingen aksjer. Et selskap som verken har drift eller aksjer er et hvilende selskap, og faller utenfor Wenches bevisst smale scope (passive holdingselskaper som eier aksjer i andre selskaper).

## Endring

Forklaringen for `UP_HAR_NÆRINGSSPESIFIKASJON_MANGLER_SKATTEMELDING` skiller nå mellom to tilfeller:

- Eier selskapet aksjer (passivt holding): rådet er som før, fyll inn formuesverdien av aksjene.
- Eier selskapet ingen aksjer (hvilende), eller har drift: teksten sier nå tydelig at det faller utenfor det Wenche dekker og må leveres via skatteetaten.no eller et regnskapsprogram.

Rettet samtidig «aksjene i datterselskapet» til «aksjene selskapet eier», siden et holding kan eie en mindre aksjepost uten at det er et datterselskap.

Dette er kun brukerrettet tekst. Ingen endring i hva som genereres eller sendes til Skatteetaten.

## Test

- Utvidet `test_valideringskode_forklaringer.py` til å pinne at forklaringen nå dekker selskap uten aksjer (hvilende), ikke bare antar formuesgrunnlag.
- Hele suiten grøn (472 passed).

## Versjon

Patch-bump 0.33.4 → 0.33.5 (wheel-relevant, force-included SPA påvirkes ikke).

Closes #138
