### PR TITLE
fix(hosted): lagre ID-porten-access_token kun når selskapslista er på

### DIFF
--- a/hosted/api/idporten.py
+++ b/hosted/api/idporten.py
@@ -277,12 +277,14 @@ def callback(
     request.session["via_idporten"] = True
     request.session["idporten_navn"] = navn
 
-    # access_token lagres midlertidig for å hente Altinn-autoriserte parter i org-listen.
-    # Slettes etter at org er valgt (se velg_org nedenfor). Tokenet lever i den signerte
-    # sesjonscookien (ikke i databasen) og utløper med ID-portens token-levetid (~10-15 min).
-    access_token = token_resp.json().get("access_token", "")
-    if access_token:
-        request.session["idporten_access_token"] = access_token
+    # access_token lagres KUN når selskapslista fra Altinn er på (reportees): da skal det veksles
+    # mot et Altinn-token for å hente autoriserte parter, og slettes straks selskap er valgt. Er
+    # lista av, har tokenet ingen funksjon, så vi lagrer det ikke (datasparsommelighet, og
+    # sesjonscookien er signert men ikke kryptert). Fødselsnummeret lagres uansett aldri.
+    if s.idporten_reportees:
+        access_token = token_resp.json().get("access_token", "")
+        if access_token:
+            request.session["idporten_access_token"] = access_token
 
     return _tilbake()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.34.0"
+version = "0.34.1"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_hosted_idporten.py
+++ b/tests/test_hosted_idporten.py
@@ -95,9 +95,12 @@ def _login(klient, *, scope: str = "openid profile altinn:reportees") -> str:
     return q["state"][0]
 
 
-def _logg_inn(klient, monkeypatch, navn="Ole Fredrik Lie", access_token="fake-access-token"):
+def _logg_inn(
+    klient, monkeypatch, navn="Ole Fredrik Lie", access_token="fake-access-token",
+    scope="openid profile altinn:reportees",
+):
     """Fullfør login + callback med mocket token og id_token-validering."""
-    state = _login(klient)
+    state = _login(klient, scope=scope)
     monkeypatch.setattr(
         idp, "_valider_id_token", lambda id_token, md, nonce: {"name": navn, "pid": "12345678901"}
     )
@@ -113,6 +116,39 @@ def _logg_inn(klient, monkeypatch, navn="Ole Fredrik Lie", access_token="fake-ac
     )
     assert r.status_code in (302, 307)
     return r
+
+
+def _sesjon(klient) -> dict:
+    """Dekod Starlettes signerte sesjonscookie så vi kan inspisere hva som faktisk lagres."""
+    import base64 as _b64
+    import json as _json
+
+    from itsdangerous import TimestampSigner
+
+    raw = klient.cookies.get("session")
+    if raw is None:
+        return {}
+    data = TimestampSigner("test-session-secret").unsign(raw)
+    return _json.loads(_b64.b64decode(data))
+
+
+def test_callback_lagrer_access_token_naar_reportees_paa(klient, monkeypatch):
+    """Med reportees på lagres access_token i sesjonen (skal veksles mot Altinn-token siden)."""
+    _logg_inn(klient, monkeypatch, access_token="hemmelig-token")
+    assert _sesjon(klient).get("idporten_access_token") == "hemmelig-token"
+
+
+def test_callback_lagrer_ikke_access_token_uten_reportees(klient_uten_reportees, monkeypatch):
+    """
+    Uten reportees har tokenet ingen funksjon, så det skal IKKE lagres i sesjonscookien
+    (datasparsommelighet; cookien er signert men ikke kryptert). Kun navnet beholdes.
+    """
+    _logg_inn(
+        klient_uten_reportees, monkeypatch, access_token="hemmelig-token", scope="openid profile"
+    )
+    s = _sesjon(klient_uten_reportees)
+    assert "idporten_access_token" not in s
+    assert s.get("idporten_navn") == "Ole Fredrik Lie"
 
 
 def _brreg_rollesvar(*navn):


### PR DESCRIPTION
## Hva

Datasparsommelighet for ID-porten-økten: callbacken lagret access_token i sesjonscookien **ubetinget**, også når `HOSTED_IDPORTEN_REPORTEES` er av og tokenet aldri brukes. Sesjonscookien er signert, men ikke kryptert, så et ubrukt ID-porten-bearer-token (som kan veksles til et Altinn-token) lå lesbart i brukerens cookie uten å ha noen funksjon.

## Endring

Lagrer `idporten_access_token` **kun når reportees er på** (da skal det veksles mot et Altinn-token for å hente autoriserte parter, og slettes straks selskap er valgt). Med lista av holder sesjonen kun verifisert navn + organisasjonsnummer. Fødselsnummeret (`pid`) lagres uansett aldri.

## Hvorfor

Gjør personvernteksten (under revisjon i wenche-web) bokstavelig korrekt: «kun det verifiserte navnet, knyttet til organisasjonsnummeret, beholdes» stemmer nå når lista er av (som i prod i dag). Velger kode framfor å dokumentere at vi holder et ubrukt token, minimering er målet.

## Tester

487 grønne. To nye dekker at access_token lagres med reportees på og IKKE lagres uten (dekoder sesjonscookien for å verifisere). Hosted-only + versjonsbump (0.34.1), ingen kjerne/`wenche`-endring.
