### PR TITLE
feat(hosted): velg selskap fra Altinn-liste etter ID-porten-innlogging

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,13 @@ Før første innsending må du generere et RSA-nøkkelpar og registrere en Maski
 
 I tillegg til å kjøre Wenche selv, finnes en hostet versjon på
 **[wenche.cloud](https://wenche.cloud)**. Der er Maskinporten-/Altinn-oppsettet gjort én
-gang av operatøren, så du slipper å generere egne nøkler. Du kommer inn enten via en
-invitasjonslenke, eller ved å skrive inn navnet ditt og organisasjonsnummeret til selskapet:
-står du som daglig leder eller styremedlem i Enhetsregisteret, bindes økten til selskapet med
-en gang. Deretter godkjenner du Wenche i Altinn med BankID, fyller inn tallene og sender.
-Dataene behandles kun i økten og lagres ikke. Tjenesten er fortsatt i beta, og bygger på
-nøyaktig samme åpne kildekode som denne self-hosted-versjonen.
+gang av operatøren, så du slipper å generere egne nøkler. Du logger inn med BankID via
+ID-porten og kobler økten til selskapet du representerer. Har operatøren delt en
+invitasjonslenke med deg, kommer du rett inn via den i stedet. Deretter godkjenner du Wenche
+i Altinn, slik at den får rett til å sende inn på vegne av selskapet, og så fyller du inn
+tallene og sender. Fødselsnummeret ditt lagres aldri, og dataene behandles kun i økten.
+Tjenesten er fortsatt i beta, og bygger på nøyaktig samme åpne kildekode som denne
+self-hosted-versjonen.
 
 Drifts- og deploy-dokumentasjon for operatøren: [`hosted/README.md`](hosted/README.md).
 

--- a/docs/hostet.md
+++ b/docs/hostet.md
@@ -16,11 +16,11 @@ Den hostede tjenesten er for deg som heller vil slippe det tekniske oppsettet. D
 nøyaktig samme åpne kildekode under panseret, så du kan når som helst velge å kjøre
 self-hosted i stedet.
 
-Du logger inn med **ID-porten** (BankID) og oppgir organisasjonsnummeret til selskapet du vil
-sende inn for. Jeg bekrefter at du står registrert som daglig leder eller styreleder for selskapet
-i Enhetsregisteret før du kobles til. Fødselsnummeret ditt lagres ikke. (Står du ikke oppført slik,
-for eksempel ved skjermet adresse eller selskap uten registrert rolleinnehaver, ta kontakt, så
-ordner jeg en invitasjonslenke manuelt.)
+Du logger inn med **ID-porten** (BankID) og velger selskapet du vil sende inn for fra listen over
+selskapene du kan representere i Altinn. Fødselsnummeret ditt brukes kun til innloggingen og lagres
+ikke. (Mangler selskapet i listen, kan du taste organisasjonsnummeret manuelt; det bekreftes da mot
+at du står registrert som daglig leder eller styreleder i Enhetsregisteret. Ved skjermet adresse
+eller selskap uten registrert rolleinnehaver, ta kontakt, så ordner jeg en invitasjonslenke manuelt.)
 
 Deretter følger du en enkel stegvis flyt: koble selskapet til Altinn (én gang, med BankID), fylle inn
 tallene, eventuelt laste ned dokumentene (skattemelding, årsregnskap, aksjonæroppgave og noter)

--- a/hosted/README.md
+++ b/hosted/README.md
@@ -63,7 +63,7 @@ Per-org invite-lenker lages med `./.venv/bin/python hosted/mint_invite.py <orgnr
 | `HOSTED_IDPORTEN_KEY_PEM` | (valgfri) PEM-innhold for ID-porten-klientens private nøkkel (egen, *ikke* vendor-nøkkelen). Foretrukket i prod (Fly-secret). |
 | `HOSTED_IDPORTEN_KEY_PATH` | (valgfri) Sti til ID-porten-privatnøkkelen (PEM). Brukes i dev; `_PEM` har forrang. |
 | `HOSTED_IDPORTEN_REDIRECT_URI` | (valgfri) Callback-URL registrert på klienten (HTTPS i prod, `http://127.0.0.1:5173/...` i dev). |
-| `HOSTED_IDPORTEN_REPORTEES` | (valgfri, `1`/`true`) Be om `altinn:reportees` og hent selskapslista fra Altinn autoriserte parter. Krever at scopet er tildelt klienten (se under). Av som standard: da logger man inn med kun `openid profile` og taster orgnr manuelt. Skru ALDRI på før scopet faktisk er tildelt, ellers avviser ID-porten innloggingen (`invalid_scope`). |
+| `HOSTED_IDPORTEN_REPORTEES` | (valgfri, `1`/`true`) Be om `altinn:accessmanagement/authorizedparties` og hent selskapslista fra Altinn autoriserte parter. Krever at scopet er tildelt klienten (se under). Av som standard: da logger man inn med kun `openid profile` og taster orgnr manuelt. Skru ALDRI på før scopet faktisk er tildelt, ellers avviser ID-porten innloggingen (`invalid_scope`). |
 | `HOSTED_VENDOR_ORGNR` | Operatørens organisasjonsnummer (vendor). |
 | `HOSTED_VENDOR_CLIENT_ID` | Operatørens Maskinporten-klient-ID. |
 | `HOSTED_VENDOR_KID` | Operatørens nøkkel-ID (KID). |
@@ -98,16 +98,17 @@ ID-porten-innlogging, gjør dette én gang per miljø (test og prod hver for seg
 Endepunkter og JWKS hentes fra ID-portens well-known-dokument ved kjøretid
 (`test.idporten.no` / `idporten.no` etter `WENCHE_ENV`), så ingen URL-er hardkodes.
 
-### Selskapsvalg fra Altinn (valgfritt, `altinn:reportees`)
+### Selskapsvalg fra Altinn (valgfritt, `altinn:accessmanagement/authorizedparties`)
 
 Med kun `openid profile` taster brukeren inn organisasjonsnummeret selv, og det bekreftes mot
 det åpne Enhetsregisteret (verifisert navn mot daglig leder/styreleder). Vil du i stedet vise en
 liste over selskapene brukeren kan representere, hentet fra **Altinn autoriserte parter**, kreves
-scopet **`altinn:reportees`**:
+scopet **`altinn:accessmanagement/authorizedparties`** (Altinn III; det gamle `altinn:reportees`
+er Altinn II og forsvinner når Altinn II skrus av):
 
-1. Be Altinn/Digdir tildele org-en din tilgang til `altinn:reportees` (servicedesk@digdir.no), og
-   legg deretter scopet på ID-porten-klienten i Samarbeidsportalen. Scopet eies av Altinn, så det
-   dukker ikke opp i scope-velgeren før det er tildelt.
+1. Be Altinn/Digdir tildele org-en din tilgang til `altinn:accessmanagement/authorizedparties`
+   (servicedesk@digdir.no), og legg deretter scopet på ID-porten-klienten i Samarbeidsportalen.
+   Scopet eies av Altinn, så det dukker ikke opp i scope-velgeren før det er tildelt.
 2. Sett `HOSTED_IDPORTEN_REPORTEES=1`.
 
 Da veksles ID-porten-tokenet mot et Altinn-token (`exchange/id-porten`) og selskapslista hentes fra
@@ -118,7 +119,7 @@ avviser ID-porten hele innloggingen.
 
 For å teste ID-porten-innloggingen mot ekte BankID og din egen org uten å deploye, kjør den hostede
 appen lokalt med prod-miljø og prod-creds. ID-porten-login + manuell orgnr-inntasting (brreg-match)
-kan testes slik; selskapslista krever at `altinn:reportees` er tildelt prod-klienten.
+kan testes slik; selskapslista krever at `altinn:accessmanagement/authorizedparties` er tildelt prod-klienten.
 
 Forutsetning: prod-ID-porten-klienten må ha `http://127.0.0.1:5173/api/auth/idporten/callback`
 registrert som redirect-URI (sjekk at prod-klienten godtar loopback-IP).

--- a/hosted/README.md
+++ b/hosted/README.md
@@ -81,7 +81,9 @@ ID-porten-innlogging, gjør dette én gang per miljø (test og prod hver for seg
    «ID-porten & API-Klient»):
    - Applikasjonstype **web**, autentiseringsmetode **private_key_jwt**.
    - Grant **authorization_code** (ikke refresh), PKCE **S256**.
-   - Eksterne scope **Nei** (`openid` + `profile` holder; fødselsnummer kommer som `pid`-claim).
+   - Eksterne scope **Nei** for ren innlogging (`openid` + `profile` holder; fødselsnummer kommer
+     som `pid`-claim). Skal appen hente selskapslista fra Altinn (se under), svar i stedet **Ja**
+     her, da registreres klienten som en API-klient som kan bære Altinn-scopet.
    - **Redirect URI** = `https://<din-app>/api/auth/idporten/callback` (prod, HTTPS) eller
      `http://127.0.0.1:5173/api/auth/idporten/callback` (dev; loopback-IP, ikke `localhost`).
 2. **Generer et eget RSA-nøkkelpar** (ikke gjenbruk vendor/Maskinporten-nøkkelen) og registrer
@@ -106,14 +108,20 @@ liste over selskapene brukeren kan representere, hentet fra **Altinn autoriserte
 scopet **`altinn:accessmanagement/authorizedparties`** (Altinn III; det gamle `altinn:reportees`
 er Altinn II og forsvinner når Altinn II skrus av):
 
-1. Be Altinn/Digdir tildele org-en din tilgang til `altinn:accessmanagement/authorizedparties`
-   (servicedesk@digdir.no), og legg deretter scopet på ID-porten-klienten i Samarbeidsportalen.
-   Scopet eies av Altinn, så det dukker ikke opp i scope-velgeren før det er tildelt.
-2. Sett `HOSTED_IDPORTEN_REPORTEES=1`.
+1. Be Altinn tildele org-en din tilgang til scopet (servicedesk@digdir.no). Scopet eies av Altinn,
+   så det dukker ikke opp i scope-velgeren før det er tildelt.
+2. ID-porten-klienten må være en **API-klient** (svar **Ja** på «Skal klienten benytte eksterne
+   scope?» ved opprettelse). En ren innloggings-klient kan ikke bære eksterne scope. Legg så til
+   scopet under klientens **Scopes**-fane (hjelp fra Digdir: servicedesk@digdir.no).
+3. Nøkler registreres **per klient**, så en ny API-klient trenger egen nøkkelregistrering. Du kan
+   gjenbruke samme nøkkelpar, men `kid` blir ny, oppdater `HOSTED_IDPORTEN_KID` deretter.
+4. Sett `HOSTED_IDPORTEN_REPORTEES=1`.
 
 Da veksles ID-porten-tokenet mot et Altinn-token (`exchange/id-porten`) og selskapslista hentes fra
-`accessmanagement/api/v1/authorizedparties`. Er scopet ikke tildelt, MÅ flagget være av, ellers
-avviser ID-porten hele innloggingen.
+`accessmanagement/api/v1/authorizedparties`. Brukeren samtykker til oppslaget ved innlogging
+(ID-porten husker samtykket en kort stund); lista hentes én gang per innlogging, og access_tokenet
+slettes straks selskap er valgt. Er scopet ikke på klienten, MÅ flagget være av, ellers avviser
+ID-porten hele innloggingen (`invalid_scope`).
 
 ### Kjøre lokalt mot prod (røyktest uten deploy)
 

--- a/hosted/api/auth.py
+++ b/hosted/api/auth.py
@@ -267,7 +267,7 @@ def me(request: Request) -> dict:
     return {
         "invited": True,
         "via_idporten": request.session.get("via_idporten", False),
-        # reportees styrer om SPA-en henter selskapslista fra Altinn (krever altinn:reportees-scopet)
+        # reportees styrer om SPA-en henter selskapslista fra Altinn (krever altinn:accessmanagement/authorizedparties-scopet)
         # eller går rett til manuell orgnr-inntasting.
         "reportees": s.idporten_reportees,
         "navn": request.session.get("idporten_navn"),

--- a/hosted/api/config.py
+++ b/hosted/api/config.py
@@ -57,7 +57,7 @@ class Settings:
         self._idporten_key_pem = os.getenv("HOSTED_IDPORTEN_KEY_PEM")
         self._idporten_key_path = os.getenv("HOSTED_IDPORTEN_KEY_PATH")
         self.idporten_redirect_uri = os.getenv("HOSTED_IDPORTEN_REDIRECT_URI")
-        # Be om Altinn-scopet altinn:reportees (for å hente selskapslista fra autoriserte parter)
+        # Be om Altinn-scopet altinn:accessmanagement/authorizedparties (for å hente selskapslista fra autoriserte parter)
         # KUN når operatøren har fått scopet tildelt klienten i Samarbeidsportalen. Ber vi om et
         # ikke-tildelt scope, avviser ID-porten hele innloggingen (invalid_scope). Av som standard:
         # da logger man inn med bare openid+profile, og selskap velges ved manuell orgnr-inntasting.
@@ -82,7 +82,7 @@ class Settings:
     @property
     def idporten_reportees(self) -> bool:
         """
-        Om vi skal be om altinn:reportees og tilby selskapsvalg fra Altinn autoriserte parter.
+        Om vi skal be om altinn:accessmanagement/authorizedparties og tilby selskapsvalg fra Altinn autoriserte parter.
 
         Krever at ID-porten er aktivert og at scopet faktisk er tildelt klienten (env-flagget
         settes da av operatøren). Er det av, hoppes auto-lista over og brukeren taster orgnr selv.

--- a/hosted/api/idporten.py
+++ b/hosted/api/idporten.py
@@ -49,14 +49,19 @@ def _scope() -> str:
     """
     OIDC-scope for innloggingen.
 
-    `altinn:reportees` («se hvem du kan representere») kreves for å (a) la Altinn godta
-    token-vekslingen (exchange/id-porten avviser tokens uten en altinn:-scope, jf. Altinns
-    HasAltinnScope) og (b) hente autoriserte parter. Men scopet må være tildelt klienten i
-    Samarbeidsportalen, ellers avviser ID-porten HELE innloggingen (invalid_scope). Derfor ber
-    vi om det kun når operatøren har skrudd på flagget; ellers logger man inn med bare
+    `altinn:accessmanagement/authorizedparties` («se hvem du kan representere») kreves for å (a)
+    la Altinn godta token-vekslingen (exchange/id-porten avviser tokens uten en altinn:-scope, jf.
+    Altinns HasAltinnScope) og (b) hente autoriserte parter. Dette er Altinn III-scopet (det gamle
+    altinn:reportees er Altinn II og forsvinner når Altinn II skrus av). Men scopet må være tildelt
+    klienten i Samarbeidsportalen, ellers avviser ID-porten HELE innloggingen (invalid_scope).
+    Derfor ber vi om det kun når operatøren har skrudd på flagget; ellers logger man inn med bare
     openid+profile og velger selskap manuelt.
     """
-    return "openid profile altinn:reportees" if settings().idporten_reportees else "openid profile"
+    return (
+        "openid profile altinn:accessmanagement/authorizedparties"
+        if settings().idporten_reportees
+        else "openid profile"
+    )
 
 # Well-known-metadata og JWKS per miljø (test/prod), cachet i minnet.
 _metadata_cache: dict[str, dict] = {}
@@ -308,7 +313,7 @@ def hent_organisasjoner(request: Request) -> dict:
         raise HTTPException(status_code=401, detail="Logg inn med ID-porten først.")
     s = settings()
     if not s.idporten_reportees:
-        # Scopet altinn:reportees er ikke tildelt, så vi har ikke tilgang til parter-lista.
+        # Scopet altinn:accessmanagement/authorizedparties er ikke tildelt, så vi har ikke tilgang til parter-lista.
         # Tom liste uten feil: SPA-en viser manuell orgnr-inntasting (som den skal når flagget er av).
         return {"organisasjoner": []}
     access_token = request.session.get("idporten_access_token", "")

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -31,7 +31,7 @@ interface Me {
   env?: string;
   demo?: boolean;
   idporten?: boolean; // er ID-porten-innlogging tilgjengelig (prod) – styrer gateskjermen
-  reportees?: boolean; // har altinn:reportees-scopet (henter selskapslista fra Altinn) – ellers manuell orgnr
+  reportees?: boolean; // har altinn:accessmanagement/authorizedparties-scopet (henter selskapslista fra Altinn), ellers manuell orgnr
   kontakt?: string | null;
 }
 
@@ -134,7 +134,7 @@ interface OrgItem {
   navn: string;
 }
 
-// Etter ID-porten-innlogging: velg selskap. Når altinn:reportees-scopet er tildelt (me.reportees),
+// Etter ID-porten-innlogging: velg selskap. Når altinn:accessmanagement/authorizedparties-scopet er tildelt (me.reportees),
 // hentes listen over orger brukeren kan representere fra Altinn automatisk. Ellers (eller ved feil)
 // faller steget tilbake til manuell orgnr-inntasting med brreg-navnematch.
 function VelgOrg({ me, onValgt }: { me: Me; onValgt: () => void }) {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.34.2"
+version = "0.35.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.34.1"
+version = "0.34.2"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_hosted_idporten.py
+++ b/tests/test_hosted_idporten.py
@@ -31,7 +31,7 @@ _META = {
 
 
 def _bygg_klient(monkeypatch, *, reportees: bool):
-    """Felles oppsett for ID-porten-test-klienten. reportees styrer altinn:reportees-scopet."""
+    """Felles oppsett for ID-porten-test-klienten. reportees styrer altinn:accessmanagement/authorizedparties-scopet."""
     monkeypatch.setenv("WENCHE_ENV", "test")
     monkeypatch.setenv("HOSTED_SESSION_SECRET", "test-session-secret")
     monkeypatch.setenv("HOSTED_INVITE_SECRET", "test-invite-secret")
@@ -63,7 +63,7 @@ def _bygg_klient(monkeypatch, *, reportees: bool):
 
 @pytest.fixture
 def klient(monkeypatch):
-    """ID-porten PÅ med altinn:reportees-scopet (selskapslista hentes fra Altinn)."""
+    """ID-porten PÅ med altinn:accessmanagement/authorizedparties-scopet (selskapslista hentes fra Altinn)."""
     from hosted.api import config
 
     main_mod = _bygg_klient(monkeypatch, reportees=True)
@@ -74,7 +74,7 @@ def klient(monkeypatch):
 
 @pytest.fixture
 def klient_uten_reportees(monkeypatch):
-    """ID-porten PÅ men UTEN altinn:reportees (scopet ikke tildelt): manuell orgnr-inntasting."""
+    """ID-porten PÅ men UTEN altinn:accessmanagement/authorizedparties (scopet ikke tildelt): manuell orgnr-inntasting."""
     from hosted.api import config
 
     main_mod = _bygg_klient(monkeypatch, reportees=False)
@@ -83,7 +83,7 @@ def klient_uten_reportees(monkeypatch):
     config.settings.cache_clear()
 
 
-def _login(klient, *, scope: str = "openid profile altinn:reportees") -> str:
+def _login(klient, *, scope: str = "openid profile altinn:accessmanagement/authorizedparties") -> str:
     """Start innlogging og returner state-en (uten å følge redirecten til ID-porten)."""
     r = klient.get("/api/auth/idporten/login", follow_redirects=False)
     assert r.status_code in (302, 307)
@@ -97,7 +97,7 @@ def _login(klient, *, scope: str = "openid profile altinn:reportees") -> str:
 
 def _logg_inn(
     klient, monkeypatch, navn="Ole Fredrik Lie", access_token="fake-access-token",
-    scope="openid profile altinn:reportees",
+    scope="openid profile altinn:accessmanagement/authorizedparties",
 ):
     """Fullfør login + callback med mocket token og id_token-validering."""
     state = _login(klient, scope=scope)
@@ -194,7 +194,7 @@ def test_login_bygger_pkce_redirect(klient):
 
 def test_login_uten_reportees_ber_kun_om_openid_profile(klient_uten_reportees):
     """
-    Uten altinn:reportees-scopet (ikke tildelt klienten) ber innloggingen kun om openid+profile,
+    Uten altinn:accessmanagement/authorizedparties-scopet (ikke tildelt klienten) ber innloggingen kun om openid+profile,
     så ID-porten ikke avviser autorisasjonsforespørselen (invalid_scope). Regresjonsvern: scopet
     skal aldri snike seg inn i forespørselen før operatøren har skrudd det på.
     """


### PR DESCRIPTION
Etter ID-porten-innlogging i hostet Wenche kan brukeren nå velge selskap fra en liste over selskapene brukeren kan representere, hentet fra Altinn autoriserte parter, i stedet for å taste organisasjonsnummeret manuelt. Manuell inntasting beholdes som fallback. Selve listevalget ble lagt inn i 0.34.0 (bak flagget `HOSTED_IDPORTEN_REPORTEES`), men har aldri fungert fordi det krevde et Altinn-scope som ikke var tildelt. Denne endringen er det som gjør funksjonen reell.

Bakgrunn: for å hente lista må ID-porten-tokenet bære et `altinn:`-scope (token-vekslingen `exchange/id-porten` krever det), og oppslaget skjer mot `accessmanagement/api/v1/authorizedparties`. Opprinnelig ba vi om `altinn:reportees`, men det er et Altinn II-scope som forsvinner når Altinn II skrus av. Altinn servicedesk har nå tildelt operatør-org 922020523 Altinn III-scopet `altinn:accessmanagement/authorizedparties` i test og produksjon, og denne PR-en bytter til det. Det interne flagget og feltet heter fortsatt `reportees`, og `HOSTED_IDPORTEN_REPORTEES` er uendret.

Et oppsettspoeng kom frem underveis: scopet kan bare ligge på en ID-porten-klient av typen API-klient (eksterne scope = Ja), ikke en ren innloggings-klient, og nøkler registreres per klient. Operatør-dokumentasjonen i hosted/README er oppdatert med dette, og sluttbrukerflyten i README og docs/hostet beskriver nå listevalget med manuell orgnr som fallback.

Verifisert ende-til-ende i produksjon med ekte BankID: innlogging, ID-porten-samtykke, automatisk henting av selskapslista og valg av selskap. Funksjonen styres per miljø via Fly-secret. Hosted-only, så wheelen er funksjonelt uendret. Versjon bumpet til 0.35.0. 487 tester grønne.