### PR TITLE
docs: presiser at BankID trengs i Altinn til tilkobling og signering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,9 @@ og rekkverk for bidragsytere og agenter.
 
 Wenche er et innsendingsverktøy for **passive holdingselskaper og småaksjeselskaper**: det
 bygger og sender årsregnskap, skattemelding/næringsspesifikasjon og aksjonærregisteroppgave
-til norske myndigheter (Altinn, Skatteetaten, Brønnøysund). Autentisering via Maskinporten
-med et selvgenerert RSA-nøkkelpar, ingen virksomhetssertifikat eller BankID.
+til norske myndigheter (Altinn, Skatteetaten, Brønnøysund). API-autentisering via Maskinporten
+med et selvgenerert RSA-nøkkelpar (ingen virksomhetssertifikat); BankID brukes fortsatt i Altinn
+til å godkjenne systembruker-tilkoblingen og signere innsendingene (lovpålagt, ikke maskinelt).
 
 ## Arkitektur
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Wenche er et verktøy for holdingselskaper og småaksjeselskaper som må levere 
 
 Etter installasjon kjører du `wenche` for å åpne et grafisk webgrensesnitt i nettleseren der du fyller ut og sender inn alt.
 
-Autentisering skjer via Maskinporten med et selvgenerert RSA-nøkkelpar, ingen virksomhetssertifikat eller BankID-innlogging nødvendig.
+Wenche autentiserer seg mot API-ene via Maskinporten med et selvgenerert RSA-nøkkelpar, så du slipper virksomhetssertifikat. Du logger fortsatt inn med BankID i Altinn for å koble til selskapet (én gang) og for å signere innsendingene, det er lovpålagt og kan ikke gjøres maskinelt.
 
 ## Hva er støttet?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ Wenche er et verktøy for holdingselskaper og småaksjeselskaper som må levere 
 
 Du fyller ut selskapsinformasjon, regnskapstall og aksjonærdata i et grafisk webgrensesnitt, og Wenche håndterer innsendingen til riktig myndighet.
 
-Autentisering skjer via Maskinporten med et selvgenerert RSA-nøkkelpar. Ingen virksomhetssertifikat eller BankID-innlogging nødvendig.
+Wenche autentiserer seg mot API-ene via Maskinporten med et selvgenerert RSA-nøkkelpar, så du slipper virksomhetssertifikat. Du logger fortsatt inn med BankID i Altinn for å koble til selskapet (én gang) og for å signere innsendingene, det er lovpålagt og kan ikke gjøres maskinelt.
 
 ## Hva hjelper Wenche med?
 


### PR DESCRIPTION
Oppsummeringslinjene i README og docs/index hevdet «ingen virksomhetssertifikat eller BankID-innlogging nødvendig». Første ledd stemmer, men andre ledd er upresist: BankID trengs faktisk i Altinn både for å godkjenne systembruker-tilkoblingen (én gang) og for å signere eller bekrefte innsendingene (årsregnskap signeres av daglig leder/styreleder, skattemelding bekreftes via ID-porten). Det er lovpålagt og kan ikke gjøres maskinelt.

Skiller nå de to tingene fra hverandre: API-autentiseringen er maskin-til-maskin via Maskinporten med et selvgenerert RSA-nøkkelpar (og uten virksomhetssertifikat, som er den reelle distinksjonen), mens innlogging og signering i Altinn fortsatt skjer med BankID.

Resten av dokumentasjonen (bruk, tutorial, oppsett) var allerede presis på dette. Denne PR-en retter kun de to oppsummeringslinjene i README.md og docs/index.md, pluss den korte agent-rettede varianten i CLAUDE.md, så de tre stedene ikke spriker. Ren dokumentasjonsendring, ingen kode berørt.