### PR TITLE
fix(hosted): navngi steget i innsendingsfeil og strip rå feilkropp

### DIFF
--- a/hosted/api/innsending.py
+++ b/hosted/api/innsending.py
@@ -48,26 +48,67 @@ def _sjekk_org(cfg: dict, kunde_org: str) -> None:
         )
 
 
+def _url_fra_feil(e: Exception) -> str:
+    """Hent oppstrøms-URL-en fra en httpx-feil, trygt. httpx' `.request` kaster RuntimeError
+    hvis den ikke er satt (RequestError uten request), så vi svelger det og gir tom streng."""
+    try:
+        return str(e.request.url)  # type: ignore[attr-defined]
+    except (RuntimeError, AttributeError):
+        return ""
+
+
+def _steg_av_url(url: str) -> str | None:
+    """Utled et lesbart navn på innsendingssteget fra oppstrøms-URL-en.
+
+    Forteller brukeren HVOR i kjeden det stoppet (henting, validering, opplasting ...) uten
+    å avsløre den rå feilkroppen. Rekkefølgen er bevisst: de mest spesifikke mønstrene først,
+    siden f.eks. valider- og data-URL-ene også inneholder de generiske bitene. Returnerer
+    None når URL-en ikke kjennes igjen, så meldingen faller tilbake på en generisk formulering.
+    """
+    u = (url or "").lower()
+    if "skattemelding/v2/valider" in u:
+        return "validering av skattemeldingen hos Skatteetaten"
+    if "skattemelding/v2" in u:
+        return "henting av forhåndsutfylt skattemelding fra Skatteetaten"
+    if "/process/next" in u:
+        return "fullføring av innsendingen i Altinn"
+    if "/instances" in u and "/data" in u:
+        return "opplasting av data til Altinn"
+    if "/instances" in u:
+        return "oppretting av innsending i Altinn"
+    if "altinn" in u:
+        return "kommunikasjon med Altinn"
+    if "skatteetaten" in u:
+        return "kommunikasjon med Skatteetaten"
+    return None
+
+
 def _tolk_http_feil(e: httpx.HTTPStatusError) -> HTTPException:
-    """Gjør en rå HTTP-feil fra Altinn/Skatteetaten om til en lesbar 502 (unngår 500 + stacktrace)."""
+    """Gjør en rå HTTP-feil fra Altinn/Skatteetaten om til en lesbar 502 (unngår 500 + stacktrace).
+
+    Meldingen navngir steget (utledet av URL-en) og statuskoden, men aldri den rå feilkroppen:
+    den kan inneholde interne detaljer og logges kun server-side i _utfor.
+    """
     kode = e.response.status_code
+    steg = _steg_av_url(_url_fra_feil(e))
+    hvor = f" under {steg}" if steg else ""
     if kode == 403:
         melding = (
-            "Altinn avslo tilgangen (HTTP 403). Vanligste årsak: systembrukeren er ikke lenger "
-            "godkjent for selskapet, eller tjenesten mangler nødvendig rettighet."
+            f"Tilgangen ble avslått (HTTP 403){hvor}. Vanligste årsak: systembrukeren er ikke "
+            "lenger godkjent for selskapet, eller tjenesten mangler nødvendig rettighet."
         )
     elif kode == 401:
-        melding = "Altinn avviste tokenet (HTTP 401). Prøv igjen, eller koble systembrukeren på nytt."
+        melding = (
+            f"Tokenet ble avvist (HTTP 401){hvor}. Prøv igjen, eller koble systembrukeren på nytt."
+        )
     elif kode >= 500:
         melding = (
-            f"Altinn/Skatteetaten svarte med en serverfeil (HTTP {kode}). Dette er som regel "
+            f"Altinn/Skatteetaten svarte med en serverfeil (HTTP {kode}){hvor}. Dette er som regel "
             "midlertidig hos myndighetene. Ingenting er sendt inn. Prøv igjen om litt."
         )
     else:
-        # Rå feilkropp fra oppstrøms-API-ene sendes ikke til klienten (kan inneholde interne
-        # detaljer); den logges server-side i _utfor slik at operatøren kan feilsøke.
         melding = (
-            f"Altinn/Skatteetaten avviste forespørselen (HTTP {kode}). Ingenting er sendt inn. "
+            f"Altinn/Skatteetaten avviste forespørselen (HTTP {kode}){hvor}. Ingenting er sendt inn. "
             "Detaljene er logget; prøv igjen eller ta kontakt."
         )
     return HTTPException(status_code=502, detail=melding)
@@ -103,22 +144,24 @@ def _utfor(fn, kunde_org: str | None = None):
         # Tidsavbrudd/tilkoblingsfeil (ikke et HTTP-svar). Søsken av HTTPStatusError, så den
         # må fanges eksplisitt — ellers blir den en naken 500. Skattemelding gjør flere
         # oppstrøms-kall enn aksjonær og er derfor mer utsatt for et forbigående avbrudd.
-        try:
-            url = str(e.request.url)  # httpx' .request kaster RuntimeError hvis den ikke er satt
-        except RuntimeError:
-            url = "ukjent URL"
+        url = _url_fra_feil(e) or "ukjent URL"
+        steg = _steg_av_url(url)
+        hvor = f" under {steg}" if steg else ""
         logger.warning("Innsending feilet for org %s: nettverksfeil mot %s: %s", kunde_org, url, e)
         raise HTTPException(
             status_code=502,
             detail=(
-                "Fikk ikke fullført forespørselen mot Altinn/Skatteetaten (nettverksfeil eller "
-                "tidsavbrudd). Det er som regel midlertidig. Sjekk i Altinn eller hos Skatteetaten "
-                "før du prøver på nytt, i tilfelle forespørselen likevel gikk gjennom."
+                f"Fikk ikke fullført forespørselen mot Altinn/Skatteetaten{hvor} (nettverksfeil "
+                "eller tidsavbrudd). Det er som regel midlertidig. Sjekk i Altinn eller hos "
+                "Skatteetaten før du prøver på nytt, i tilfelle forespørselen likevel gikk gjennom."
             ),
         )
     except RuntimeError as e:
         logger.warning("Innsending feilet for org %s: %s", kunde_org, e)
-        raise HTTPException(status_code=502, detail=str(e))
+        # SKD-klienten/token-hentingen pakker noen ganger den rå feilkroppen etter en linjeskift
+        # (f.eks. "Feil ved henting av forhåndsutfylt skattemelding: 400\n<xml fra SKD>"). Send
+        # bare første linje (steg + statuskode) til klienten; hele teksten er logget over.
+        raise HTTPException(status_code=502, detail=str(e).split("\n", 1)[0])
     except HTTPException:
         raise  # alt bevisst reist (f.eks. _sjekk_org 409) skal slippe gjennom uendret
     except Exception:

--- a/hosted/hent_forhandsutfylt.py
+++ b/hosted/hent_forhandsutfylt.py
@@ -1,0 +1,63 @@
+"""
+Hent den forhåndsutfylte skattemeldingen for én org og skriv ut det rå svaret fra
+Skatteetaten. Operatør-verktøy: kjøres lokalt og leser Maskinporten-credsene rett fra .env
+(MASKINPORTEN_*_PROD), samme nøkkelpar som prod, så svaret er autoritativt.
+
+Bakgrunn: den ekte skattemelding-innsendingen (dry_run=false) gjør som aller første steg
+en GET mot Skatteetatens forhåndsutfylt-API for å utlede partsnummer og
+dokumentreferanseTilGjeldendeDokument (se wenche/innsending.py send_skattemelding og
+wenche/skd_skattemelding_client.py hent_forhåndsutfylt_med_id). Feiler den GET-en, stopper
+innsendingen før tallene i det hele tatt brukes, og hostet-API-et pakker det som en HTTP 502
+med Skatteetatens statuskode i teksten («Feil ved henting av forhåndsutfylt skattemelding:
+400»). Dette skriptet gjør nøyaktig den GET-en og viser hele svaret, så vi ser den eksakte
+400-årsaken uten å vente på at brukeren melder fra.
+
+  WENCHE_ENV=prod ./.venv/bin/python hosted/hent_forhandsutfylt.py 999999999 2025
+
+Argumenter: <orgnr> [inntektsår].  Standard inntektsår: 2025.  Credsene leses fra .env
+(MASKINPORTEN_CLIENT_ID_PROD / _KID_PROD / MASKINPORTEN_PRIVAT_NOKKEL), valgt av WENCHE_ENV.
+
+Read-only: gjør kun en GET (henting/visning), sender ingenting inn og endrer ingenting hos
+Skatteetaten.
+"""
+import os
+import sys
+
+from wenche import auth as wauth
+from wenche.auth import SKD_SKATTEMELDING_SCOPE
+from wenche.skd_skattemelding_client import SkdSkattemeldingClient
+
+
+def main() -> None:
+    if len(sys.argv) < 2:
+        raise SystemExit("Bruk: hent_forhandsutfylt.py <orgnr> [inntektsår]")
+    org = sys.argv[1].strip()
+    inntektsaar = int(sys.argv[2]) if len(sys.argv) > 2 else 2025
+
+    env = os.getenv("WENCHE_ENV", "prod")
+    creds = wauth._les_cli_credentials(env)  # leser MASKINPORTEN_*_{ENV} fra .env
+    print(f"Miljø: {env}   org: {org}   inntektsår: {inntektsaar}\n")
+
+    # Maskinporten-token på vegne av kunde-orgen, akkurat slik innsendingsruten gjør.
+    token = wauth.hent_tokens_for(creds, org, SKD_SKATTEMELDING_SCOPE)["maskinporten_token"]
+
+    with SkdSkattemeldingClient(token, env=env) as skd:
+        url = f"{skd._base}/api/skattemelding/v2/{inntektsaar}/{org}"
+        print(f"GET {url}\n")
+        resp = skd._http.get(url, headers={"Accept": "application/xml"})
+        print(f"HTTP {resp.status_code}   Content-Type: {resp.headers.get('content-type', '?')}")
+        print("--- svar fra Skatteetaten ---")
+        print(resp.text or "(tom kropp)")
+        print("--- slutt ---")
+
+        if resp.is_success:
+            # Samme tolkning som hent_forhåndsutfylt_med_id, for å se om partsnummer finnes.
+            try:
+                _, dok_id = skd.hent_forhåndsutfylt_med_id(inntektsaar, org)
+                print(f"\nForhåndsutfylt hentet OK. dokument-id: {dok_id or '(ikke funnet)'}")
+            except Exception as e:  # noqa: BLE001
+                print(f"\nKunne ikke tolke forhåndsutfylt-svaret: {e}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.35.0"
+version = "0.35.1"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_hosted_innsending_feil.py
+++ b/tests/test_hosted_innsending_feil.py
@@ -10,7 +10,7 @@ import httpx
 import pytest
 from fastapi import HTTPException
 
-from hosted.api.innsending import _utfor
+from hosted.api.innsending import _steg_av_url, _utfor
 from wenche.innsending import InnsendingValideringsfeil
 from wenche.skd_skattemelding_client import SkattemeldingValideringsfeil
 
@@ -98,7 +98,7 @@ def test_bevisst_httpexception_slipper_gjennom_uendret():
 
 def test_upstream_feilkropp_lekker_ikke_til_klient():
     """Rå feilkropp fra Altinn/SKD skal logges server-side, aldri sendes til nettleseren."""
-    req = httpx.Request("POST", "https://skatt.skatteetaten.no/api/skattemelding/v2")
+    req = httpx.Request("POST", "https://skatt.skatteetaten.no/api/skattemelding/v2/2025/123456789")
     svar = httpx.Response(400, text="intern-altinn-detalj-xyz stacktrace", request=req)
     feil = httpx.HTTPStatusError("400", request=req, response=svar)
     with pytest.raises(HTTPException) as ei:
@@ -106,3 +106,76 @@ def test_upstream_feilkropp_lekker_ikke_til_klient():
     assert ei.value.status_code == 502
     assert "intern-altinn-detalj-xyz" not in str(ei.value.detail)
     assert "400" in str(ei.value.detail)  # statuskoden er fortsatt synlig for brukeren
+
+
+def test_feilmelding_navngir_steget_forhandsutfylt():
+    # Feiler GET-en av forhåndsutfylt, skal meldingen si nettopp det (utledet av URL-en),
+    # slik at et skjermbilde fra brukeren alene peker oss til riktig steg.
+    req = httpx.Request("GET", "https://api.skatteetaten.no/api/skattemelding/v2/2025/123456789")
+    feil = httpx.HTTPStatusError("400", request=req, response=httpx.Response(400, request=req))
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(feil))
+    assert "forhåndsutfylt" in str(ei.value.detail).lower()
+
+
+def test_feilmelding_navngir_steget_validering():
+    req = httpx.Request("POST", "https://api.skatteetaten.no/api/skattemelding/v2/valider/2025/123456789")
+    feil = httpx.HTTPStatusError("500", request=req, response=httpx.Response(500, request=req))
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(feil))
+    assert "validering" in str(ei.value.detail).lower()
+    assert "serverfeil" in str(ei.value.detail).lower()
+
+
+def test_feilmelding_navngir_steget_altinn_instans():
+    req = httpx.Request("POST", "https://999999999.apps.altinn.no/ttd/skattemelding/instances")
+    feil = httpx.HTTPStatusError("403", request=req, response=httpx.Response(403, request=req))
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(feil))
+    assert "altinn" in str(ei.value.detail).lower()
+
+
+def test_401_navngir_steg_og_beholder_koden():
+    req = httpx.Request("POST", "https://999999999.apps.altinn.no/ttd/skattemelding/instances")
+    feil = httpx.HTTPStatusError("401", request=req, response=httpx.Response(401, request=req))
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(feil))
+    assert ei.value.status_code == 502
+    assert "401" in str(ei.value.detail)
+    assert "altinn" in str(ei.value.detail).lower()
+
+
+@pytest.mark.parametrize(
+    "url, forventet",
+    [
+        ("https://api.skatteetaten.no/api/skattemelding/v2/valider/2025/123", "validering"),
+        ("https://api.skatteetaten.no/api/skattemelding/v2/2025/123", "forhåndsutfylt"),
+        ("https://999999999.apps.altinn.no/ttd/skattemelding/instances/abc/process/next", "fullføring"),
+        ("https://999999999.apps.altinn.no/ttd/skattemelding/instances/abc/data", "opplasting"),
+        ("https://999999999.apps.altinn.no/ttd/skattemelding/instances", "oppretting"),
+        ("https://platform.altinn.no/authentication/api/v1/exchange", "kommunikasjon med Altinn"),
+        ("https://api.skatteetaten.no/api/noe-annet", "kommunikasjon med Skatteetaten"),
+    ],
+)
+def test_steg_av_url_kartlegger_alle_kjente_steg(url, forventet):
+    assert forventet in _steg_av_url(url)
+
+
+def test_steg_av_url_ukjent_url_gir_none():
+    # Ukjent URL skal gi None, slik at meldingen faller tilbake på generisk formulering uten
+    # å henge på et villedende stegnavn.
+    assert _steg_av_url("https://eksempel.no/ukjent") is None
+    assert _steg_av_url("") is None
+
+
+def test_runtimeerror_med_kropp_etter_linjeskift_stripper_kroppen():
+    # SKD-klienten pakker statuskode + rå kropp i samme RuntimeError-streng. Klienten skal kun
+    # se første linje (steg + kode), ikke kroppen; hele teksten logges server-side.
+    feil = RuntimeError(
+        "Feil ved henting av forhåndsutfylt skattemelding: 400\n<feil>intern-kropp-hemmelig</feil>"
+    )
+    with pytest.raises(HTTPException) as ei:
+        _utfor(_hev(feil))
+    assert ei.value.status_code == 502
+    assert "intern-kropp-hemmelig" not in str(ei.value.detail)
+    assert "forhåndsutfylt skattemelding: 400" in str(ei.value.detail)


### PR DESCRIPTION
## Bakgrunn

En hostet bruker fikk gjentatte 502-feil under skattemelding-innsending, og meldingen («Feil ved henting av forhåndsutfylt skattemelding: 400» med rå XML-kropp etter) sa verken tydelig hvilket steg som feilet eller holdt oppstrøms-detaljer borte fra nettleseren. Fly har ingen logghistorikk, så vi trenger at brukerens eget skjermbilde bærer nok til å diagnostisere.

## Endringer

- `_utfor` utleder nå **steget** fra oppstrøms-URL-en (henting av forhåndsutfylt, validering, oppretting/opplasting/fullføring i Altinn) og veaver det inn i feilmeldingen sammen med statuskoden.
- Den rå feilkroppen lekker ikke lenger til klienten: HTTP-feil viser kun kode + steg, og RuntimeError-stien sender bare første linje. Hele teksten logges fortsatt server-side.
- 401/403-tekstene gjort kildenøytrale (steget sier nå hvor).
- Nytt read-only operatør-verktøy `hosted/hent_forhandsutfylt.py`: henter forhåndsutfylt skattemelding for en org direkte mot prod for å se eksakt oppstrøms-statuskode under feilsøking.
- Versjonsbump 0.35.0 → 0.35.1 (hostet-only).

## Vurdert og avslått

Vedvarende feillogging (Fly-volum / ekstern drain) for å overleve maskinrestart: droppet. Det koster mer enn det smaker og bryter med session-only/ingen-persistens-premisset. Selvdokumenterende feilmeldinger gjør skjermbildet til «loggen».

## Test plan

- [x] `pytest` grønn (500 tester), inkl. 12 tester for feilhåndteringen
- [x] Stegnavngivning dekket per steg via parametrisert test på `_steg_av_url` (validering, forhåndsutfylt, fullføring, opplasting, oppretting, Altinn-/Skatteetaten-fallback, ukjent → None)
- [x] Rå feilkropp lekker ikke, både på HTTP-feil- og RuntimeError-stien
- [x] CI kjører pytest på PR mot main
