### PR TITLE
fix(hosted): logg ID-porten-claim-nøkler når navnet er tomt

### DIFF
--- a/hosted/api/idporten.py
+++ b/hosted/api/idporten.py
@@ -272,7 +272,10 @@ def callback(
 
     navn = _navn_fra_claims(claims)
     if not navn:
-        # Uten et verifisert navn kan vi ikke gjøre rollesjekken mot Enhetsregisteret.
+        # Uten et verifisert navn kan vi ikke gjøre rollesjekken mot Enhetsregisteret. Logg hvilke
+        # claim-nøkler ID-porten faktisk sendte (kun nøklene, aldri verdiene: name/pid er
+        # personopplysninger) så et tomt navn er feilsøkbart uten logghistorikk på Fly.
+        _log.warning("Tomt navn fra ID-porten; claim-nøkler: %s", sorted(claims.keys()))
         return _tilbake("Fikk ikke navnet ditt fra ID-porten. Ta kontakt for manuell tilgang.")
 
     # Bind den verifiserte identiteten til økten. Fødselsnummeret (`pid`) lagres aldri; kun

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.35.1"
+version = "0.35.2"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Bakgrunn

En bruker fikk «Fikk ikke navnet ditt fra ID-porten» etter BankID-innlogging, men kom inn på nytt forsøk med samme (uendret) navn. Det utelukker en deterministisk encoding-feil og peker mot en forbigående tilstand der ID-porten ikke leverte navnefeltene. Problemet er at feilgrenen i dag returnerer uten å logge noe, og hostet kjører uten logghistorikk på Fly (kun live `fly logs`), så en slik hendelse er ikke feilsøkbar i ettertid.

## Endringer

Legger til en `warning`-logg i ID-porten-callbacken når det verifiserte navnet er tomt. Den logger hvilke claim-nøkler tokenet faktisk inneholdt, kun nøklene og aldri verdiene, siden `name` og `pid` er personopplysninger. Da viser en eventuell gjentakelse om `name`/`given_name`/`family_name` manglet helt (peker mot ID-porten/userinfo) eller om noe annet er på ferde.

Bumper versjon 0.35.1 -> 0.35.2 (hosted-only, wheel funksjonelt uendret).

## Test plan

- [x] `pytest` grønt (500 tester, inkludert de 21 ID-porten-testene)
- [ ] Etter deploy: bekreft i `fly logs` at en tom-navn-hendelse gir den nye warning-linja med claim-nøkler (kun nøkler, ingen verdier)
