### PR TITLE
chore(release): 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Endringslogg
+
+Alle vesentlige endringer i Wenche dokumenteres her. Formatet bygger på
+[Keep a Changelog](https://keepachangelog.com/no/), og prosjektet følger
+[semantisk versjonering](https://semver.org/lang/no/).
+
+## [1.0.0] - 2026-06-26
+
+Første stabile utgave. Wenche har sendt inn årsregnskap, skattemelding og
+aksjonærregisteroppgave i produksjon for flere selskaper, og kjernen ansees stabil.
+Tidligere 0.x-utgaver finnes i git-historikken og under [releases](https://github.com/olefredrik/Wenche/releases).
+
+### Støttet
+
+- **Aksjonærregisteroppgave** (RF-1086) til Skatteetaten.
+- **Skattemelding for AS** med næringsspesifikasjon, for inntektsår 2025 og senere.
+- **Årsregnskap** til Brønnøysundregistrene.
+- Maskinporten-autentisering med selvgenerert RSA-nøkkelpar, uten virksomhetssertifikat.
+- Self-hosted webgrensesnitt (kommandoen `wenche`) og en hostet variant på wenche.cloud.
+- Forhåndsfyll av tall fra [Bodil](https://github.com/olefredrik/Bodil) eller via SAF-T-import.
+
+### Målgruppe
+
+Enkle aksjeselskaper uten ordinær drift: passive holdingselskaper og hvilende
+småaksjeselskaper, det vil si selskaper uten ansatte, varelager, konsernregnskapsplikt
+eller revisorkrav. Wenche er et innsendingsverktøy, ikke en regnskapsfører, og forutsetter
+at tallene finnes fra før.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Wenche åpner `http://localhost:8080` i nettleseren, der du fyller ut oppsett og
 
 Før første innsending må du generere et RSA-nøkkelpar og registrere en Maskinporten-klient. Hele veiledningen for installasjon, oppsett og bruk finner du i dokumentasjonen.
 
-## Hostet variant (beta)
+## Hostet variant
 
 I tillegg til å kjøre Wenche selv, finnes en hostet versjon på
 **[wenche.cloud](https://wenche.cloud)**. Der er Maskinporten-/Altinn-oppsettet gjort én
@@ -62,8 +62,7 @@ ID-porten og kobler økten til selskapet du representerer. Har operatøren delt 
 invitasjonslenke med deg, kommer du rett inn via den i stedet. Deretter godkjenner du Wenche
 i Altinn, slik at den får rett til å sende inn på vegne av selskapet, og så fyller du inn
 tallene og sender. Fødselsnummeret ditt lagres aldri, og dataene behandles kun i økten.
-Tjenesten er fortsatt i beta, og bygger på nøyaktig samme åpne kildekode som denne
-self-hosted-versjonen.
+Tjenesten bygger på nøyaktig samme åpne kildekode som denne self-hosted-versjonen.
 
 Drifts- og deploy-dokumentasjon for operatøren: [`hosted/README.md`](hosted/README.md).
 

--- a/docs/hostet.md
+++ b/docs/hostet.md
@@ -10,7 +10,7 @@ eller bruke den hostede versjonen på **[wenche.cloud](https://wenche.cloud)**.
 | Oppsett | Du genererer RSA-nøkkel og registrerer en Maskinporten-klient | Gjort én gang av operatøren |
 | Innlogging | Kjører lokalt på din maskin | Logg inn med ID-porten (BankID), så godkjenning i Altinn |
 | Data | Blir på din maskin | Behandles kun i økten, ingenting lagres i database |
-| Tilgang | Åpen kildekode, gratis | Foreløpig en tidlig testfase |
+| Tilgang | Åpen kildekode, gratis | Gratis, ingen installasjon |
 
 Den hostede tjenesten er for deg som heller vil slippe det tekniske oppsettet. Det er
 nøyaktig samme åpne kildekode under panseret, så du kan når som helst velge å kjøre

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,8 +4,8 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "0.35.2"
-description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for holdingselskaper"
+version = "1.0.0"
+description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for små selskaper uten ordinær drift"
 readme = "README.md"
 license = { file = "LICENSE" }
 requires-python = ">=3.11"


### PR DESCRIPTION
Første stabile utgave av Wenche. Kjernen har sendt inn årsregnskap, skattemelding og aksjonærregisteroppgave i produksjon for flere selskaper, og ansees stabil. Denne PR-en markerer overgangen fra 0.x til 1.0.0.

## Endringer
Bumper versjonen i `pyproject.toml` fra 0.35.2 til 1.0.0. Utvider pakkebeskrivelsen fra «holdingselskaper» til «små selskaper uten ordinær drift», i tråd med at scopet dekker både passive holdingselskaper og hvilende småaksjeselskaper. Fjerner «beta»/«tidlig testfase»-omtalen av den hostede varianten i README og `docs/hostet.md`, konsistent med at beta-preget er fjernet på wenche.cloud. Legger til `CHANGELOG.md` med et 1.0.0-notat som oppsummerer støttede skjemaer og målgruppe.

## Test
`pytest` grønt (500 tester). Publisering til PyPI skjer automatisk via `publish.yml` når taggen `v1.0.0` pushes etter merge.

## Etter merge
Tag-kommandoene kjøres manuelt (se egen melding).