### PR TITLE
perf(hosted): dvale med suspend og fjern virkningsløs keep-alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ Alle vesentlige endringer i Wenche dokumenteres her. Formatet bygger på
 [Keep a Changelog](https://keepachangelog.com/no/), og prosjektet følger
 [semantisk versjonering](https://semver.org/lang/no/).
 
+## [1.0.1] - 2026-07-01
+
+### Endret
+
+- Den hostede tjenesten dvaler nå med `suspend` i stedet for `stop`. En maskin som har
+  sovet våkner da på under et sekund i stedet for rundt to sekunders kaldstart, så en
+  bruker som tar seg tid til å fylle ut skjemaet ikke merker pausen. Kostnadsprofilen er
+  praktisk talt uendret.
+
+### Fjernet
+
+- Fjernet en keep-alive-heartbeat i den hostede webappen. Den kunne uansett ikke hindre
+  Fly i å dvale og ga ingen reell effekt.
+
 ## [1.0.0] - 2026-06-26
 
 Første stabile utgave. Wenche har sendt inn årsregnskap, skattemelding og

--- a/fly.demo.toml
+++ b/fly.demo.toml
@@ -22,10 +22,11 @@ primary_region = "ams"         # Amsterdam, EØS (samme som prod). Flyttet fra "
 [http_service]
   internal_port = 8080
   force_https = true
-  # Scale-to-zero for minimal kostnad: maskinen sovner når ingen bruker den, og våkner
-  # automatisk på første request. SPA-ens keep-alive-heartbeat hindrer dvale midt i en økt.
-  # Kun én maskin (in-memory-sesjon må ikke spres mellom maskiner).
-  auto_stop_machines = "stop"
+  # Scale-to-zero for minimal kostnad: maskinen dvaler når ingen bruker den, og våkner
+  # automatisk på første request. "suspend" fryser VM-en med RAM intakt (sub-sekund vekking
+  # i stedet for ~2 s kaldstart); kostnad ~lik "stop". Kan sjelden falle tilbake til "stop",
+  # det er trygt. Kun én maskin (in-memory-sesjon må ikke spres mellom maskiner).
+  auto_stop_machines = "suspend"
   auto_start_machines = true
   min_machines_running = 0
 

--- a/fly.toml
+++ b/fly.toml
@@ -18,13 +18,14 @@ primary_region = "ams"         # Amsterdam, EØS. Flyttet fra "arn" (Stockholm) 
 [http_service]
   internal_port = 8080
   force_https = true
-  # SCALE-TO-ZERO for minimal kostnad (invite-only test): maskinen sovner når ingen
-  # bruker den, og våkner automatisk på første request. SPA-en kjører en keep-alive-
-  # heartbeat (App.tsx) så den ikke sovner MIDT i en økt og mister in-memory-tilstanden.
-  # Ikke skaler til flere maskiner (da ville sesjoner spostes mellom dem).
-  # Tips: bytt "stop" -> "suspend" for å bevare minnet over dvale (raskere vekking +
-  # in-memory-tilstand overlever), hvis Fly-planen din støtter det.
-  auto_stop_machines = "stop"
+  # SCALE-TO-ZERO for minimal kostnad (invite-only): maskinen dvaler når ingen bruker den
+  # og våkner automatisk på første request. "suspend" fryser VM-en med RAM intakt i stedet
+  # for å boote på nytt, så vekking er sub-sekund (ikke ~2 s kaldstart) og en bruker som
+  # tar seg tid til å fylle ut ikke merker pausen. Kostnadsprofilen er ~lik "stop" (ingen
+  # CPU/RAM-kost mens suspendert). Fly kan i sjeldne tilfeller falle tilbake til "stop";
+  # det er trygt (session-tilstand ligger i signert cookie, ingen kundedata i serverminnet).
+  # Ikke skaler til flere maskiner (da ville sesjoner spres mellom dem).
+  auto_stop_machines = "suspend"
   auto_start_machines = true
   min_machines_running = 0
 

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -748,27 +748,6 @@ export default function App() {
     }
   }, []);
 
-  // Keep-alive-heartbeat: holder Fly-maskinen våken mens appen er i AKTIV bruk, så scale-to-zero
-  // ikke sovner midt i en økt. Pinger kun når fanen er synlig og brukeren har vært aktiv siste
-  // 10 min, så en glemt åpen fane lar maskinen sove.
-  useEffect(() => {
-    let sisteAktivitet = Date.now();
-    const merkAktiv = () => {
-      sisteAktivitet = Date.now();
-    };
-    const hendelser = ["mousemove", "keydown", "click", "touchstart", "scroll"];
-    hendelser.forEach((e) => window.addEventListener(e, merkAktiv, { passive: true }));
-    const id = setInterval(() => {
-      const aktiv =
-        document.visibilityState === "visible" && Date.now() - sisteAktivitet < 10 * 60 * 1000;
-      if (aktiv) fetch("/api/health").catch(() => {});
-    }, 45000);
-    return () => {
-      clearInterval(id);
-      hendelser.forEach((e) => window.removeEventListener(e, merkAktiv));
-    };
-  }, []);
-
   const naviger = (id: string) => {
     setFane(id as FaneId);
     window.scrollTo({ top: 0 });

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "1.0.0"
+version = "1.0.1"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for små selskaper uten ordinær drift"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Bakgrunn

Server-loggene viste at den hostede maskinen autostoppet og bootet på nytt hvert ~10. minutt (Fly sin concurrency-baserte autostopp), med ~2 sekunders kaldstart hver gang. En bruker som tar seg tid til å fylle ut skjemaet kan dermed treffe en kaldstart-hikke midt i økten. Ingen data går tapt (session-tilstand ligger i signert cookie, ingen kundedata i serverminnet), men vekkingen er unødvendig treg.

## Endringer

- Bytt `auto_stop_machines` fra `stop` til `suspend` i prod (`fly.toml`) og demo (`fly.demo.toml`). Suspend fryser VM-en med RAM intakt, så vekking er sub-sekund i stedet for ~2 s kaldstart. Kostnadsprofilen er praktisk talt uendret (ingen CPU/RAM-kost mens suspendert), så scale-to-zero-økonomien beholdes.
- Fjern keep-alive-heartbeaten i `hosted/web/src/App.tsx`. Den kunne uansett ikke slå ut concurrency-basert autostopp (periodiske pings holder ikke samtidigheten over null), og var portet av når fanen var skjult eller uten aktivitet, altså nettopp under en utfyllingspause. Med suspend er den død kode.
- Versjonsbump 1.0.0 → 1.0.1 + CHANGELOG-oppføring.

## Test plan

- [x] `hosted/web` bygger (tsc + vite), ingen gjenværende referanser til heartbeaten
- [x] Demo (`wenche-demo`, tt02) deployet: `/api/health` svarer `1.0.1`, `env=test`
- [ ] Bekreft `STATE = suspended` på demo etter idle-periode (`flyctl status -a wenche-demo`)
- [ ] Deploy prod (`wenche-hosted`) og røyktest etter merge + release
