### PR TITLE
fix(systembruker): følg paginering ved henting av systembrukere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ Alle vesentlige endringer i Wenche dokumenteres her. Formatet bygger på
 [Keep a Changelog](https://keepachangelog.com/no/), og prosjektet følger
 [semantisk versjonering](https://semver.org/lang/no/).
 
+## [1.0.2] - 2026-07-07
+
+### Rettet
+
+- `hent_systembrukere` følger nå pagineringen fra Altinn (`links.next`) og henter alle
+  sidene. Tidligere ble bare de første 50 systembrukerne hentet, så kunde nr. 51 og utover
+  ble usynlig for gjenkjennings-sjekken ved ny tilkobling. Resultatet var at en kunde som
+  allerede hadde godkjent Wenche med BankID fikk «HTTP 500» (AUTH-00004 fra Altinn) i stedet
+  for å bli koblet til. Rammet både den hostede tjenesten og self-hosted-oppsettet.
+
 ## [1.0.1] - 2026-07-01
 
 ### Endret

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "1.0.1"
+version = "1.0.2"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for små selskaper uten ordinær drift"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_systembruker.py
+++ b/tests/test_systembruker.py
@@ -1,0 +1,60 @@
+"""
+Enhetstester for wenche.systembruker på HTTP-nivå (Altinn mocket via httpx.get).
+
+Hovedpoeng: hent_systembrukere må følge pagineringen (`links.next`). Uten det ble bare de
+første 50 systembrukerne sett, så kunde nr. 51+ ble usynlig for AlreadyApproved-sjekken og
+fikk AUTH-00004 ved ny tilkobling (regresjonen som traff org 917576661).
+"""
+from unittest.mock import MagicMock, patch
+
+import httpx
+
+from wenche import systembruker as sb
+
+
+def _resp(json_data):
+    resp = MagicMock(spec=httpx.Response)
+    resp.raise_for_status.return_value = None
+    resp.json.return_value = json_data
+    return resp
+
+
+@patch("wenche.systembruker.httpx.get")
+def test_hent_systembrukere_foelger_paginering(mock_get):
+    """To sider (50 + 4) via links.next slås sammen til alle 54."""
+    side1 = {
+        "data": [{"reporteeOrgNo": f"{i:09d}"} for i in range(50)],
+        "links": {"next": "https://platform.altinn.no/.../bysystem/x?token=SIDE2"},
+    }
+    side2 = {
+        "data": [{"reporteeOrgNo": "917576661"}] + [{"reporteeOrgNo": f"{i:09d}"} for i in range(3)],
+        "links": {},
+    }
+    mock_get.side_effect = [_resp(side1), _resp(side2)]
+
+    brukere = sb.hent_systembrukere("token", "922020523")
+
+    assert len(brukere) == 54
+    assert any(b["reporteeOrgNo"] == "917576661" for b in brukere)
+    # Side 2 ble hentet fra den absolutte next-lenken, ikke det opprinnelige endepunktet.
+    assert mock_get.call_count == 2
+    assert mock_get.call_args_list[1].args[0].endswith("token=SIDE2")
+
+
+@patch("wenche.systembruker.httpx.get")
+def test_hent_systembrukere_enkelt_side_uten_next(mock_get):
+    """Én side (tom links) gir bare den siden, uten ekstra kall."""
+    mock_get.return_value = _resp({"data": [{"reporteeOrgNo": "314273818"}], "links": {}})
+
+    brukere = sb.hent_systembrukere("token", "922020523")
+
+    assert brukere == [{"reporteeOrgNo": "314273818"}]
+    assert mock_get.call_count == 1
+
+
+@patch("wenche.systembruker.httpx.get")
+def test_hent_systembrukere_flat_liste_uten_wrapper(mock_get):
+    """Defensivt: et uventet flatt liste-svar returneres som det er."""
+    mock_get.return_value = _resp([{"reporteeOrgNo": "314273818"}])
+
+    assert sb.hent_systembrukere("token", "922020523") == [{"reporteeOrgNo": "314273818"}]

--- a/wenche/systembruker.py
+++ b/wenche/systembruker.py
@@ -216,16 +216,25 @@ def hent_systembrukere(maskinporten_token: str, vendor_orgnr: str) -> list[dict]
     """
     Henter alle godkjente systembrukere for Wenche-systemet.
 
-    Returnerer en liste med systembruker-objekter fra Altinn.
+    Returnerer en liste med systembruker-objekter fra Altinn. Endepunktet er paginert
+    (50 per side, med `links.next` til neste side); vi følger lenkene til alle sidene er
+    hentet. Uten dette ble bare de første 50 sett, så kunde nr. 51+ ble usynlig for
+    gjenkjennings-sjekken og fikk AUTH-00004 («existing SystemUser tied to System-Id») ved
+    ny tilkobling.
     """
     sid = system_id(vendor_orgnr)
-    resp = httpx.get(
-        f"{_base()}/authentication/api/v1/systemuser/vendor/bysystem/{sid}",
-        headers={"Authorization": f"Bearer {maskinporten_token}"},
-        timeout=15,
-    )
-    resp.raise_for_status()
-    data = resp.json()
-    return data.get("data", data) if isinstance(data, dict) else data
+    url = f"{_base()}/authentication/api/v1/systemuser/vendor/bysystem/{sid}"
+    headers = {"Authorization": f"Bearer {maskinporten_token}"}
+    alle: list[dict] = []
+    while url:
+        resp = httpx.get(url, headers=headers, timeout=15)
+        resp.raise_for_status()
+        data = resp.json()
+        if not isinstance(data, dict):
+            # Uventet flat liste (ingen paginerings-wrapper): returner som den er.
+            return data
+        alle.extend(data.get("data", []))
+        url = (data.get("links") or {}).get("next")
+    return alle
 
 


### PR DESCRIPTION
## Bakgrunn

En kunde fikk «HTTP 500» ved innlogging i den hostede tjenesten, selv om selskapet allerede hadde godkjent Wenche med BankID i Altinn. Prod-loggen viste AUTH-00004 fra Altinn («existing SystemUser tied to the given System-Id») på `opprett_forespørsel`.

Årsaken er paginering: Altinns `systemuser/vendor/bysystem`-endepunkt returnerer 50 systembrukere per side med en `links.next`-lenke til neste side. `hent_systembrukere` hentet bare første side. Da operatøren passerte 50 systembrukere, ble kunde nr. 51 og utover usynlig for AlreadyApproved-sjekken, appen forsøkte å opprette en ny forespørsel oppå den godkjente, og Altinn avviste med AUTH-00004.

## Endringer

- `hent_systembrukere` følger nå `links.next` til alle sidene er hentet.
- La til tre enhetstester for pagineringen (flere sider, én side, defensivt flatt svar).
- Bumpet versjon til 1.0.2 og logget fikset i CHANGELOG.

Gjelder både den hostede tjenesten og self-hosted, som deler denne koden.

## Test plan

- [x] `pytest` grønn (503 tester)
- [x] Verifisert mot prod (skrivebeskyttet) at endepunktet gir 54 systembrukere over to sider, og at det berørte org-et ligger på side 2
- [ ] Etter deploy: berørt kunde klikker «Koble systembruker» og bindes direkte (AlreadyApproved), uten ny 500
