### PR TITLE
fix(hosted): svar lesbart ved AUTH-00004 i systembruker-tilkobling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ Alle vesentlige endringer i Wenche dokumenteres her. Formatet bygger på
 [Keep a Changelog](https://keepachangelog.com/no/), og prosjektet følger
 [semantisk versjonering](https://semver.org/lang/no/).
 
+## [1.0.3] - 2026-07-07
+
+### Rettet
+
+- Systembruker-tilkoblingen svarer nå med en lesbar melding hvis Altinn avviser med AUTH-00004
+  («existing SystemUser tied to the given System-Id»), i stedet for en rå «HTTP 500». Selve
+  årsaken til at feilen oppsto ble fjernet i 1.0.2 (paginering); dette er et ekstra sikkerhetsnett
+  slik at en tilsvarende Altinn-avvisning fra en annen årsak gir brukeren en forståelig beskjed.
+
 ## [1.0.2] - 2026-07-07
 
 ### Rettet

--- a/hosted/api/systembruker.py
+++ b/hosted/api/systembruker.py
@@ -52,7 +52,22 @@ def request_systembruker(request: Request) -> dict:
         return {"status": "AlreadyApproved", "godkjent": True, "kunde_org": org}
     # Ny kunde: sikre at systemet er registrert (idempotent), så opprett forespørselen.
     wsb.registrer_system(token, vendor_orgnr, creds.client_id)
-    svar = wsb.opprett_forespørsel(token, vendor_orgnr, org)
+    try:
+        svar = wsb.opprett_forespørsel(token, vendor_orgnr, org)
+    except RuntimeError as e:
+        # AUTH-00004: Altinn har allerede en systembruker/forespørsel for dette org-et for
+        # systemet vårt. Godkjente systembrukere fanges normalt av AlreadyApproved-sjekken over;
+        # havner vi likevel her finnes det typisk en påbegynt (ikke godkjent) forespørsel. Svar
+        # lesbart i stedet for en naken 500. Andre feil propagerer uendret.
+        if "AUTH-00004" in str(e):
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Det finnes allerede en påbegynt eller godkjent tilkobling for dette "
+                    "selskapet. Last siden på nytt for å fortsette. Vedvarer det, ta kontakt."
+                ),
+            ) from e
+        raise
     request.session["request_id"] = svar.get("id")
     request.session["pending_org"] = org
     return {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "1.0.2"
+version = "1.0.3"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for små selskaper uten ordinær drift"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/test_hosted_systembruker.py
+++ b/tests/test_hosted_systembruker.py
@@ -95,3 +95,40 @@ def test_avvist_forespoersel_binder_ikke(klient, monkeypatch):
     data = klient.post("/api/systembruker/status").json()
     assert data["godkjent"] is False
     assert data["kunde_org"] is None
+
+
+def test_auth_00004_gir_lesbar_409_ikke_500(klient, monkeypatch):
+    """Altinn AUTH-00004 på opprett_forespørsel skal bli et lesbart 409, ikke en naken 500."""
+    _inviter(klient)
+    _stub_vendor(monkeypatch)
+    monkeypatch.setattr(sb.wsb, "hent_systembrukere", lambda token, vendor: [])
+    monkeypatch.setattr(sb.wsb, "registrer_system", lambda token, vendor, cid: {})
+
+    def kast_auth_00004(token, vendor, party):
+        raise RuntimeError(
+            '400 Bad Request:\n{"detail":"Failed to create new SystemUser, existing '
+            'SystemUser tied to the given System-Id.","code":"AUTH-00004"}'
+        )
+
+    monkeypatch.setattr(sb.wsb, "opprett_forespørsel", kast_auth_00004)
+
+    r = klient.post("/api/systembruker/request")
+    assert r.status_code == 409
+    assert "allerede" in r.json()["detail"].lower()
+    assert klient.get("/api/auth/me").json()["kunde_org"] is None
+
+
+def test_annen_runtimeerror_propagerer_uendret(klient, monkeypatch):
+    """Andre feil enn AUTH-00004 skal ikke fanges av 409-grenen (uendret oppførsel)."""
+    _inviter(klient)
+    _stub_vendor(monkeypatch)
+    monkeypatch.setattr(sb.wsb, "hent_systembrukere", lambda token, vendor: [])
+    monkeypatch.setattr(sb.wsb, "registrer_system", lambda token, vendor, cid: {})
+
+    def kast_annet(token, vendor, party):
+        raise RuntimeError("500 Internal Server Error:\nnoe helt annet")
+
+    monkeypatch.setattr(sb.wsb, "opprett_forespørsel", kast_annet)
+
+    with pytest.raises(RuntimeError):
+        klient.post("/api/systembruker/request")


### PR DESCRIPTION
## Bakgrunn

`request_systembruker` lot en `RuntimeError` fra `opprett_forespørsel` bli en naken HTTP 500. Da et selskap allerede hadde en tilkobling for systemet vårt, svarte Altinn med AUTH-00004 («existing SystemUser tied to the given System-Id»), og brukeren fikk en stacktrace-500 i stedet for en forståelig beskjed. Dette er et sikkerhetsnett oppå pagineringsfiksen i 1.0.2 (#149), som fjernet den konkrete årsaken til at feilen oppsto.

## Endringer

- Fanger AUTH-00004 fra `opprett_forespørsel` og svarer med et lesbart 409. Andre feil propagerer uendret, så ingen annen feilsti påvirkes.
- To nye tester: AUTH-00004 gir 409 med lesbar `detail` og binder ikke, og en annen `RuntimeError` propagerer som før.
- Bumpet versjon til 1.0.3 (hosted-only, lockstep) og logget i CHANGELOG.

## Test plan

- [x] `pytest` grønn (505 tester)
