### PR TITLE
feat(skjema): tusenskille i tallfelt og blanke felt som kan tømmes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Alle vesentlige endringer i Wenche dokumenteres her. Formatet bygger på
 [Keep a Changelog](https://keepachangelog.com/no/), og prosjektet følger
 [semantisk versjonering](https://semver.org/lang/no/).
 
+## [1.1.0] - 2026-07-15
+
+### Rettet
+
+- Tallfeltene i skjemaet starter nå blanke i stedet for å være forhåndsutfylt med `0`, og du
+  kan tømme et felt helt uten at nullen spretter tilbake. Lagrede verdier (også et bevisst `0`)
+  vises som før. Ved innsending fylles blanke påkrevde felt til `0`, så payloaden til
+  myndighetene er uendret.
+
+### Endret
+
+- Beløps- og tallfelt viser tusenskille (`1 000 000`) når feltet ikke er i fokus, så det er
+  lettere å lese av at tallet er riktig. Formateringen er kun visning; SAF-T-/Bodil-import,
+  skjembygging og innsending bruker samme rene tall som før.
+
 ## [1.0.3] - 2026-07-07
 
 ### Rettet

--- a/packages/ui/src/komponenter.tsx
+++ b/packages/ui/src/komponenter.tsx
@@ -1,4 +1,5 @@
 // Delte UI-primitiver for Wenche (hostet + self-hosted).
+import { useState } from "react";
 import { monoLabel, input } from "./styles";
 
 export function Kort({
@@ -73,6 +74,93 @@ export function Inn({
         value={value}
         onChange={(e) => onChange(e.target.value)}
       />
+    </label>
+  );
+}
+
+// Grupperer heltallsdelen med hardt mellomrom (nb-NO-stil), bevarer fortegn og desimaler.
+// 1000 -> "1\u00A0000", 1000000 -> "1\u00A0000\u00A0000", -2500.5 -> "-2\u00A0500,5". Ren visning;
+// tallet i config r\u00f8res ikke. Hardt mellomrom (\u00A0) matcher kr()/toLocaleString("nb-NO").
+export function grupperTusen(n: number): string {
+  if (!Number.isFinite(n)) return "";
+  const neg = n < 0;
+  const [heltall, desimal] = String(Math.abs(n)).split(".");
+  const gruppert = heltall.replace(/\B(?=(\d{3})+(?!\d))/g, "\u00A0");
+  return (neg ? "-" : "") + gruppert + (desimal ? "," + desimal : "");
+}
+
+// Tolker en skrevet streng (mellomrom og komma tillatt) til number | "". Tomt/ufullstendig
+// ("", "-", ".") og ugyldig blir "", s\u00e5 feltet kan st\u00e5 tomt under redigering.
+export function tolkTall(s: string): number | "" {
+  const r = s.replace(/[\s\u00A0]/g, "").replace(",", ".");
+  if (r === "" || r === "-" || r === "." || r === "-.") return "";
+  const n = Number(r);
+  return Number.isNaN(n) ? "" : n;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function formaterVerdi(v: any): string {
+  if (v === "" || v == null) return "";
+  const n = typeof v === "number" ? v : Number(String(v).replace(/[\s\u00A0]/g, "").replace(",", "."));
+  return Number.isFinite(n) ? grupperTusen(n) : "";
+}
+
+// Tallfelt med tusenskille i visningen. Lagrer alltid et rent number (eller "" når tomt) via
+// onChange, så SAF-T/Bodil-import, skjembygging og innsending ser samme verdier som før.
+// Formaterer først når feltet mister fokus; viser rene sifre mens du skriver (ingen markør-hopp).
+export function TallInput({
+  value,
+  onChange,
+  className = input,
+  disabled,
+  title,
+}: {
+  value: number | "";
+  onChange: (v: number | "") => void;
+  className?: string;
+  disabled?: boolean;
+  title?: string;
+}) {
+  const [fokus, setFokus] = useState(false);
+  const [tekst, setTekst] = useState("");
+  const vis = fokus ? tekst : formaterVerdi(value);
+  return (
+    <input
+      className={className}
+      type="text"
+      inputMode="decimal"
+      value={vis}
+      disabled={disabled}
+      title={title}
+      onFocus={() => {
+        setTekst(value === "" || value == null ? "" : String(value));
+        setFokus(true);
+      }}
+      onChange={(e) => {
+        // Behold bare sifre, mellomrom, komma/punktum og minus mens brukeren skriver.
+        const rå = e.target.value.replace(/[^\d\s.,-]/g, "");
+        setTekst(rå);
+        onChange(tolkTall(rå));
+      }}
+      onBlur={() => setFokus(false)}
+    />
+  );
+}
+
+// Etikettert tallfelt (samme oppsett som Inn), for aksjonær-tallene o.l.
+export function TallFelt({
+  label,
+  value,
+  onChange,
+}: {
+  label: string;
+  value: number | "";
+  onChange: (v: number | "") => void;
+}) {
+  return (
+    <label className="block">
+      <span className="mb-1 block text-xs text-muted-foreground">{label}</span>
+      <TallInput value={value} onChange={onChange} />
     </label>
   );
 }

--- a/packages/ui/src/skjema.tsx
+++ b/packages/ui/src/skjema.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import yaml from "js-yaml";
 import { monoLabel, input, btnPrimar, btnOutlineLett as btnOutline } from "./styles";
-import { Inn } from "./komponenter";
+import { Inn, TallInput, TallFelt } from "./komponenter";
 
 // Skjema-drevet datainntasting. Feltstrukturen er data; én generisk renderer bygger
 // config-objektet (samme form som config.yaml) som sendes til backenden.
@@ -105,20 +105,28 @@ const BALANSE_EK_GJELD = BALANSE_FELTER.filter((f) => f.key.includes(".egenkapit
 interface Aksjonaer {
   navn: string;
   fodselsnummer: string;
-  antall_aksjer: number;
+  // Tallfeltene kan stå tomme ("") under redigering, så brukeren slipper å slette en ledende 0.
+  // Normaliseres til tall ved lagring (se normaliserForLagring).
+  antall_aksjer: number | "";
   aksjeklasse: string;
-  utbytte_utbetalt: number;
-  innbetalt_kapital_per_aksje: number;
+  utbytte_utbetalt: number | "";
+  innbetalt_kapital_per_aksje: number | "";
 }
+
+const AKSJONAER_TALLFELT = [
+  "antall_aksjer",
+  "utbytte_utbetalt",
+  "innbetalt_kapital_per_aksje",
+] as const;
 
 function tomAksjonaer(): Aksjonaer {
   return {
     navn: "",
     fodselsnummer: "",
-    antall_aksjer: 0,
+    antall_aksjer: "",
     aksjeklasse: "ordinære",
-    utbytte_utbetalt: 0,
-    innbetalt_kapital_per_aksje: 0,
+    utbytte_utbetalt: "",
+    innbetalt_kapital_per_aksje: "",
   };
 }
 
@@ -139,14 +147,43 @@ function sett(obj: any, path: string, value: any): any {
   return ny;
 }
 
+// Alle ikke-valgfrie tallfelt (kostnader, balanse, årstall, aksjekapital osv.). Disse står
+// tomme under redigering, men må være tall i payloaden: flere av dem leses med direkte
+// indeksering i kjernen (selskap.stiftelsesaar/aksjekapital, regnskapsaar) og krasjer på "".
+const PAAKREVDE_TALLFELT: string[] = SEKSJONER.flatMap((s) =>
+  s.felter.filter((f) => f.type === "number" && !f.valgfri).map((f) => f.key),
+);
+
+// Tomt tallfelt ("", null, NaN) → true. Valgfrie felt får stå tomme (kjernen tolererer dem),
+// men påkrevde felt og aksjonær-tall må gjøres om til 0 før innsending.
+function erTomtTall(v: unknown): boolean {
+  return v === "" || v == null || (typeof v === "number" && Number.isNaN(v));
+}
+
+// Gjør blanke påkrevde tallfelt om til 0 rett før lagring/innsending, slik at payloaden er
+// identisk med den gamle (der feltene alltid var 0). Rører ikke valgfrie felt eller tekst.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function normaliserForLagring(config: any): any {
+  let c = config;
+  for (const key of PAAKREVDE_TALLFELT) if (erTomtTall(hent(c, key))) c = sett(c, key, 0);
+  const aksjonaerer = (config?.aksjonaerer ?? []).map((a: Aksjonaer) => {
+    const na = { ...a };
+    for (const f of AKSJONAER_TALLFELT) if (erTomtTall(na[f])) na[f] = 0;
+    return na;
+  });
+  return { ...c, aksjonaerer };
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function grunnConfig(): any {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let c: any = {};
+  // Tallfelt starter tomme ("") slik at brukeren slipper å slette en ledende 0.
+  // De normaliseres tilbake til tall ved lagring (normaliserForLagring).
   for (const s of SEKSJONER)
     for (const f of s.felter)
       if (!f.valgfri)
-        c = sett(c, f.key, f.type === "checkbox" ? false : f.type === "text" ? "" : 0);
+        c = sett(c, f.key, f.type === "checkbox" ? false : "");
   c.aksjonaerer = [tomAksjonaer()];
   return c;
 }
@@ -303,16 +340,25 @@ function Feltrutenett({
               {f.label}
               {f.help ? ` (${f.help})` : ""}
             </span>
-            <input
-              className={`${input} ${laast ? "cursor-not-allowed opacity-60" : ""}`}
-              type={f.type === "number" ? "number" : "text"}
-              value={hent(config, f.key) ?? ""}
-              disabled={laast}
-              title={laast ? "Låst til selskapet i invitasjonen" : undefined}
-              onChange={(e) =>
-                oppdater(f.key, f.type === "number" ? Number(e.target.value) || 0 : e.target.value)
-              }
-            />
+            {f.type === "number" ? (
+              // Tallfelt: tusenskille i visningen, rent number i config (se TallInput).
+              <TallInput
+                className={`${input} ${laast ? "cursor-not-allowed opacity-60" : ""}`}
+                value={hent(config, f.key) ?? ""}
+                disabled={laast}
+                title={laast ? "Låst til selskapet i invitasjonen" : undefined}
+                onChange={(v) => oppdater(f.key, v)}
+              />
+            ) : (
+              <input
+                className={`${input} ${laast ? "cursor-not-allowed opacity-60" : ""}`}
+                type="text"
+                value={hent(config, f.key) ?? ""}
+                disabled={laast}
+                title={laast ? "Låst til selskapet i invitasjonen" : undefined}
+                onChange={(e) => oppdater(f.key, e.target.value)}
+              />
+            )}
           </label>
         );
       })}
@@ -452,7 +498,7 @@ export function DataSkjema({
   const lagre = async () => {
     setLagrer(true);
     try {
-      await onLagre(config);
+      await onLagre(normaliserForLagring(config));
       // Etter vellykket lagring er gjeldende innhold den nye baselinen.
       pristine.current = JSON.stringify(configRef.current);
     } finally {
@@ -790,10 +836,10 @@ export function DataSkjema({
               <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
                 <Inn label="Navn" value={a.navn} onChange={(v) => settAksj(i, "navn", v)} />
                 <Inn label="Fødselsnummer" value={a.fodselsnummer} onChange={(v) => settAksj(i, "fodselsnummer", v)} />
-                <Inn label="Antall aksjer" type="number" value={a.antall_aksjer} onChange={(v) => settAksj(i, "antall_aksjer", Number(v) || 0)} />
+                <TallFelt label="Antall aksjer" value={a.antall_aksjer} onChange={(v) => settAksj(i, "antall_aksjer", v)} />
                 <Inn label="Aksjeklasse" value={a.aksjeklasse} onChange={(v) => settAksj(i, "aksjeklasse", v)} />
-                <Inn label="Utbytte utbetalt (kr)" type="number" value={a.utbytte_utbetalt} onChange={(v) => settAksj(i, "utbytte_utbetalt", Number(v) || 0)} />
-                <Inn label="Innbetalt kapital per aksje (kr)" type="number" value={a.innbetalt_kapital_per_aksje} onChange={(v) => settAksj(i, "innbetalt_kapital_per_aksje", Number(v) || 0)} />
+                <TallFelt label="Utbytte utbetalt (kr)" value={a.utbytte_utbetalt} onChange={(v) => settAksj(i, "utbytte_utbetalt", v)} />
+                <TallFelt label="Innbetalt kapital per aksje (kr)" value={a.innbetalt_kapital_per_aksje} onChange={(v) => settAksj(i, "innbetalt_kapital_per_aksje", v)} />
               </div>
               {aksjonaerer.length > 1 && (
                 <button

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "1.0.3"
+version = "1.1.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for små selskaper uten ordinær drift"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Bakgrunn

En bruker meldte at tallfeltene i skjemaet var forhåndsutfylt med `0`, og at nullen la seg i veien: man måtte slette den før man kunne skrive, og et tomt felt spratt tilbake til `0`. Andre brukere har rapportert ønske om tusenskille så det er lettere å lese av at store beløp er riktige.

## Endringer

- Tallfeltene starter nå blanke i stedet for `0`, og kan tømmes helt uten at nullen spretter tilbake. Lagrede verdier (også et bevisst `0`) vises som før.
- Ny delt `TallInput`/`TallFelt` i `packages/ui` viser tusenskille (`1 000 000`) når feltet ikke er i fokus, og rene sifre mens man skriver (ingen markør-hopp). Hardt mellomrom, samme som `kr()`/oppsummeringslinjen.
- Blanke påkrevde felt normaliseres til `0` ved lagring, så payloaden til myndighetene er uendret.
- Versjonsbump til 1.1.0 og CHANGELOG-oppføring.

## Invariant som gjør det trygt

Formateringen finnes kun i visningen; config lagrer alltid et rent tall (eller tomt). SAF-T-/Bodil-import, skjembygging og innsending ser derfor nøyaktig samme verdier som før.

## Test plan

- [x] Begge SPA-er bygger og typechecker rent (`tsc && vite build`)
- [x] pytest: 505 passed (backend-kontrakten urørt)
- [x] Runtime-verifisert: formatering, parsing, tapsfri rundtur, import-tall uendret ved lagring, blankt til 0 (30 assertions)
- [ ] Manuelt lokalt: felt starter blanke, kan tømmes, tusenskille vises ved fokus-tap, SAF-T-/Bodil-importert tall vises formatert
