### PR TITLE
docs: legg til sikkerhetspolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ Alle vesentlige endringer i Wenche dokumenteres her. Formatet bygger på
 [Keep a Changelog](https://keepachangelog.com/no/), og prosjektet følger
 [semantisk versjonering](https://semver.org/lang/no/).
 
+## [1.1.1] - 2026-07-29
+
+Ingen funksjonelle endringer. Utgivelsen finnes for at rettelsene under skal bli synlige på
+PyPI, siden README-en er pakkebeskrivelsen der.
+
+### Lagt til
+
+- Sikkerhetspolicy (`SECURITY.md`) som beskriver hvordan sårbarheter rapporteres privat, hva
+  som er i og utenfor scope, og hvilke regler som gjelder for testing. README lenker til den.
+
+### Rettet
+
+- Lenkene til `LICENSE` og `hosted/README.md` i README var relative, og virket derfor bare på
+  GitHub. På PyPI ga de 404. Nå er de absolutte.
+
 ## [1.1.0] - 2026-07-15
 
 ### Rettet

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ i Altinn, slik at den får rett til å sende inn på vegne av selskapet, og så 
 tallene og sender. Fødselsnummeret ditt lagres aldri, og dataene behandles kun i økten.
 Tjenesten bygger på nøyaktig samme åpne kildekode som denne self-hosted-versjonen.
 
-Drifts- og deploy-dokumentasjon for operatøren: [`hosted/README.md`](hosted/README.md).
+Drifts- og deploy-dokumentasjon for operatøren: [`hosted/README.md`](https://github.com/olefredrik/Wenche/blob/main/hosted/README.md).
 
 ## Dokumentasjon
 
@@ -101,7 +101,7 @@ Har du funnet en sikkerhetssårbarhet, ikke bruk et offentlig issue. Se [SECURIT
 
 ## Lisens
 
-MIT, se [LICENSE](LICENSE).
+MIT, se [LICENSE](https://github.com/olefredrik/Wenche/blob/main/LICENSE).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,8 @@ Wenche er et hjelpeverktøy for enkle holdingselskaper og er i aktiv utvikling. 
 
 Bidrag er velkomne. Åpne gjerne en issue eller pull request.
 
+Har du funnet en sikkerhetssårbarhet, ikke bruk et offentlig issue. Se [SECURITY.md](https://github.com/olefredrik/Wenche/blob/main/SECURITY.md) for hvordan du rapporterer privat.
+
 ## Lisens
 
 MIT, se [LICENSE](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,131 @@
+# Sikkerhetspolicy
+
+Wenche sender årsregnskap, skattemelding og aksjonærregisteroppgave til norske myndigheter.
+Den håndterer derfor ting som må være i orden: private RSA-nøkler, Maskinporten- og
+ID-porten-tokener, organisasjonsnummer, fødselsnummer og regnskapstall. Finner du en
+sårbarhet, vil jeg gjerne høre om det.
+
+## Støttede versjoner
+
+Wenche er et soloprosjekt og følger [semantisk versjonering](https://semver.org/lang/no/).
+**Kun den nyeste utgitte versjonen støttes med sikkerhetsfikser.** Fikser kommer som en ny
+patch-versjon på nyeste minor, og backportes ikke til eldre versjoner.
+
+[![Støttet versjon](https://img.shields.io/pypi/v/wenche?label=st%C3%B8ttet%20versjon)](https://pypi.org/project/wenche/)
+
+Merket over hentes fra PyPI og viser alltid gjeldende støttede versjon. Er du på noe eldre,
+gjelder ikke policyen for din versjon før du har oppgradert. Alle utgivelser med
+endringsbeskrivelse ligger under [Releases](https://github.com/olefredrik/Wenche/releases) og i
+[CHANGELOG.md](CHANGELOG.md).
+
+Den hostede tjenesten på [wenche.cloud](https://wenche.cloud) kjører alltid nyeste versjon, og
+oppdateres av meg. Kjører du self-hosted, er det ditt ansvar å oppgradere:
+
+```bash
+pip install --upgrade wenche
+```
+
+## Rapportere en sårbarhet
+
+**Ikke opprett et vanlig issue for sikkerhetsfeil.** Issues er offentlige, og gir alle andre
+oppskriften før det finnes en fiks.
+
+Bruk i stedet GitHubs private rapportering:
+
+**[Rapporter en sårbarhet](https://github.com/olefredrik/Wenche/security/advisories/new)**
+
+Får du ikke det til å fungere, send e-post til **hello@olefredrik.com** med «Wenche sikkerhet» i
+emnefeltet.
+
+### Ta med i rapporten
+
+- Hvilken versjon eller commit du testet mot
+- Om det gjelder self-hosted eller hostet ([wenche.cloud](https://wenche.cloud) eller
+  [demo.wenche.cloud](https://demo.wenche.cloud))
+- Hvilket miljø (`WENCHE_ENV=test` mot tt02, eller `prod`)
+- Stegene som reproduserer feilen, og hva du faktisk oppnådde med den
+- Gjerne et forslag til fiks, hvis du har et
+
+### Ikke ta med i rapporten
+
+Send aldri ekte hemmeligheter eller personopplysninger, verken egne eller andres:
+
+- Private nøkler (`*.pem`), tokener eller sesjonscookies. Beskriv at de lekket, ikke lim dem inn
+- Fødselsnumre, navn eller andre personopplysninger. Anonymiser eksemplene
+- `config.yaml` eller SAF-T-filer med reelle regnskapstall. Bruk oppdiktede tall
+
+Har du funnet en hemmelighet som ligger i git-historikken eller i et bygget artefakt, si det
+privat, så roterer jeg den før noe publiseres.
+
+## Hva du kan forvente
+
+Wenche er et soloprosjekt jeg driver på fritiden, gratis. Jeg setter derfor ingen svarfrister jeg
+ikke kan garantere at jeg holder. Det jeg lover er dette:
+
+- **Jeg leser og svarer på alle rapporter.** Du blir ikke ignorert, og en rapport i god tro blir
+  aldri møtt med juridiske trusler. Vanligvis svarer jeg innen noen dager, men det kan gå lenger i
+  travle perioder
+- Blir rapporten **akseptert**, fikser jeg den og slipper en patch-versjon til PyPI, deployer
+  hostet, og publiserer en GitHub Security Advisory med kreditering til deg (si fra hvis du vil
+  være anonym). Fiksen beskrives også i [CHANGELOG.md](CHANGELOG.md). Alvorlige funn i den
+  hostede tjenesten prioriteres foran alt annet
+- Blir rapporten **avvist**, får du en begrunnelse. Er vi uenige, si det gjerne, jeg vurderer på
+  nytt
+- **Hold funnet privat mens jeg jobber med det**, gjerne til fiksen er ute. Hører du ingenting fra
+  meg på 30 dager, står du fritt til å offentliggjøre. Blir jeg forsinket, sier jeg det til deg i
+  stedet for å bli stille
+- Det finnes **ingen bug bounty**. Jeg kan ikke betale for funn. Kreditering og en oppriktig takk
+  er det jeg har å gi
+
+## Hva som er i scope
+
+Kode i dette repoet, og tjenestene jeg selv drifter:
+
+- Python-kjernen og CLI-en (`wenche/`): autentisering, token- og nøkkelhåndtering, XML-bygging,
+  innsending
+- Det self-hostede webgrensesnittet (`wenche/web/`) og den lokale serveren `wenche` starter
+- Den hostede tjenesten (`hosted/`), inkludert `app.wenche.cloud` og `demo.wenche.cloud`
+- Det delte designsystemet (`packages/ui/`)
+
+Typiske funn jeg vil vite om: lekkasje av nøkler eller tokener (til disk, logg, nettverk eller
+nettleser), svakheter i sesjonsbinding eller cookie-signering, forfalskning av invitasjonstokener,
+at én bruker kan nå en annen brukers økt eller sende inn for et selskap de ikke representerer,
+injeksjon, XSS, path traversal, og avhengigheter med kjente sårbarheter som faktisk er utnyttbare
+i Wenche.
+
+## Hva som ikke er i scope
+
+- **Myndighetenes egne API-er og tjenester.** Altinn, Skatteetaten, Brønnøysundregistrene,
+  ID-porten og Maskinporten er ikke mine systemer, Wenche er bare en klient mot dem. Funn der
+  meldes til [servicedesk@altinn.no](mailto:servicedesk@altinn.no) eller
+  [Skatteetatens brukerstøtteportal](https://eksternjira.sits.no/plugins/servlet/desk/site/global)
+- **Manglende herding uten demonstrert effekt**, for eksempel savnede sikkerhetsheadere,
+  TLS-karakterer eller rå skannerrapporter, når det ikke følger et konkret angrep med det
+- **Tjenestenekt og lastgenerering.** Ikke kjør last- eller stresstesting mot
+  `app.wenche.cloud` eller `demo.wenche.cloud`, og aldri mot myndighets-API-er, verken tt02 eller
+  prod. Dette er én liten maskin per app, og misbruk av testmiljøene rammer alle som bruker dem
+- **Sosial manipulering, phishing og fysisk tilgang**
+- **Din egen maskin og dine egne nøkler i self-hosted bruk.** At noen med tilgang til din
+  brukerkonto kan lese `~/.wenche/token.json` eller din `config.yaml` er forventet, det er derfor
+  fila har rettigheter begrenset til din bruker
+
+## Regler for testing
+
+Test mot din egen installasjon, med `WENCHE_ENV=test` slik at du treffer Skatteetatens testmiljø
+tt02 og aldri ekte myndigheter. Bruk aldri andres fødselsnummer eller organisasjonsnummer.
+Tester du på `demo.wenche.cloud`, hold deg til demo-selskapet og din egen økt, og ikke prøv å nå
+andre brukeres data. Stopp og rapporter i stedet for å grave videre om du kommer over noe som ser
+ut som en annen brukers opplysninger.
+
+## Kjente forutsetninger
+
+- Wenche sender data kun til Maskinporten, ID-porten, Altinn, Skatteetaten og
+  Brønnøysundregistrene
+- `.env`, `config.yaml` og `*.pem` er gitignored, og skal aldri i git
+- Den hostede tjenesten er session-only: opplysninger behandles i økten og lagres ikke i noen
+  database. Fødselsnummer brukes kun til innlogging og lagres ikke
+- Demo og prod er separate Fly-apper med separate credentials, slik at en demo aldri kan røre
+  prod
+
+Wenche er lisensiert under [MIT](LICENSE) og leveres uten garantier. Denne policyen er et løfte om
+å ta sikkerhetsrapporter på alvor og svare på dem, ikke en garanti for at koden er feilfri.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "1.1.0"
+version = "1.1.1"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for små selskaper uten ordinær drift"
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Sammendrag

Wenche håndterer private nøkler, tokener, fødselsnummer og regnskapstall, men har ikke hatt noen dokumentert vei for å rapportere sårbarheter. Uten en slik vei er et offentlig issue det nærmeste en rapportør kommer.

## Endringer

- Ny `SECURITY.md`: privat GitHub-advisory som rapporteringsvei (e-post som fallback), hva som er i og utenfor scope, regler for testing, og hva en rapportør kan forvente.
- README lenker til policyen fra «Bidra», altså der noen står rett før de åpner et offentlig issue.
- Sidefiks: gjorde de relative README-lenkene til `LICENSE` og `hosted/README.md` absolutte. De virket på GitHub, men 404-et på PyPI, som ikke løser relative lenker.

Begrunnelsen for de større valgene (ingen svarfrister, ingen hardkodet versjonstabell) ligger i commit-meldingene.

## Test plan

- [x] `SECURITY.md` rendrer riktig, og «Report a vulnerability»-lenken åpner advisory-skjemaet
- [x] Sikkerhetsfanen viser policyen som aktiv
- [x] Ingen døde lenker, og README-lenkene løses fra både GitHub og PyPI
- [x] Kun `SECURITY.md` og `README.md` er med i diffen
