### PR TITLE
fix(deps): oppdater js-yaml og postcss for GHSA-varsler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,15 @@ Alle vesentlige endringer i Wenche dokumenteres her. Formatet bygger på
 
 ## [1.1.1] - 2026-07-29
 
-Ingen funksjonelle endringer. Utgivelsen finnes for at rettelsene under skal bli synlige på
-PyPI, siden README-en er pakkebeskrivelsen der.
+### Sikkerhet
+
+- Oppdatert `js-yaml` (4.2.0 til 4.3.0), som er bundlet i webgrensesnittet og leser
+  `config.yaml` når du importerer fra Bodil. Den gamle versjonen kunne bruke svært lang tid på
+  en fil med visse nøstede `<<`-referanser, slik at nettleserfanen ble hengende. Filen leses
+  kun i nettleseren din, så en slik fil kunne ikke påvirke andre brukere eller den hostede
+  tjenesten.
+- Oppdatert `postcss` (8.5.15 til 8.5.24), som kun brukes når prosjektet bygges, ikke av
+  ferdig installert Wenche.
 
 ### Lagt til
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1941,9 +1941,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
-      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
       "funding": [
         {
           "type": "github",
@@ -2301,9 +2301,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -2405,9 +2405,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.24",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.24.tgz",
+      "integrity": "sha512-8RyVklq0owXUTa4xlpzu4l9AaVKIdQvAcOHZWaMh98HgySsUtxRVf/chRe3dsSLqb6i40BzGRzEUddRaI+9TSw==",
       "dev": true,
       "funding": [
         {
@@ -2425,7 +2425,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },


### PR DESCRIPTION
## Sammendrag

Lukker de to åpne Dependabot-varslene. Erstatter #153, som løfter `js-yaml` til 5.2.2 og brekker byggingen: v5 fjernet default-eksporten, så `import yaml from "js-yaml"` i `packages/ui/src/skjema.tsx` feiler i rollup. Advisory-en er patchet fra 4.3.0, så majoren gir ingen sikkerhetsgevinst.

Endringene lå i `1.1.1`-branchen, men rakk ikke å bli med da #152 ble merget. Siden 1.1.1 ikke er publisert, foldes de inn i samme versjon, og changelogen for 1.1.1 rettes tilsvarende.

## Endringer

- `js-yaml` 4.2.0 til 4.3.0 (GHSA-52cp-r559-cp3m). Bundlet i webgrensesnittet via `packages/ui`, brukt på `yaml.load()` av en brukeropplastet `config.yaml` i Bodil-importen. Reell rekkevidde er begrenset: v4 `load` bruker safe-skjemaet, så ingen kodeeksekvering, og CPU-bruken treffer brukerens egen fane, ikke serveren (hostet parser YAML i Python).
- `postcss` 8.5.15 til 8.5.24 (GHSA-r28c-9q8g-f849). Transitiv under vite, kun dev.
- `### Sikkerhet`-seksjon i changelogen for 1.1.1, som samtidig fjerner den nå uriktige «ingen funksjonelle endringer».

Begge lå innenfor eksisterende `^`-spesifikasjoner, så kun lockfila endres. `packages/ui/package.json` er urørt.

## Test plan

- [x] `npm ci` fra lockfila gir js-yaml 4.3.0 og postcss 8.5.24
- [x] `npm audit` rapporterer 0 sårbarheter
- [x] Begge SPA-er bygger, og 505 tester passerer
- [x] docker-jobben passerer, der #153 feiler