### PR TITLE
fix: skattekostnad, riktig skattegrunnlag og forlenget første regnskapsår

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,64 @@ Alle vesentlige endringer i Wenche dokumenteres her. Formatet bygger på
 [Keep a Changelog](https://keepachangelog.com/no/), og prosjektet følger
 [semantisk versjonering](https://semver.org/lang/no/).
 
+## [1.2.0] - 2026-08-05
+
+### Rettet
+
+- Årsregnskapet manglet **skattekostnad som egen linje** før årsresultatet, slik
+  regnskapsloven § 6-1 krever. Modellen regnet resultat før skatt som årsresultat direkte,
+  altså implisitt skattekostnad 0. Det gikk bra for et selskap uten skattepliktig inntekt,
+  men et passivt holdingselskap med renteinntekt (eller 3 %-tillegget på fritatt utbytte) har
+  en reell skattekostnad. Årsresultatet ble da rapportert for høyt til både Brønnøysund og
+  Skatteetaten, og balansen hadde ingen riktig plass til skattegjelden.
+
+- Næringsspesifikasjonen tilbakefører nå skattekostnaden som permanent forskjell
+  (`positivSkattekostnad`). Skatteetaten utleder sitt eget skattemessige resultat fra
+  årsresultatet pluss permanente forskjeller, så uten tilbakeføringen ville et selskap med
+  skattekostnad fått «Ugyldig innsending» med avvik i næringsopplysningene. Verifisert mot
+  Skatteetatens testmiljø.
+- **Utbytte som er fritatt etter fritaksmetoden ble oppgitt som skattepliktig inntekt** i
+  næringsspesifikasjonen. Skattegrunnlaget var dermed brutto utbytte, selv om bare
+  3 %-sjablonen (eller ingenting, ved eierandel fra 90 %) faktisk er skattepliktig. Utbyttet
+  tilbakeføres nå som permanent forskjell, og den skattepliktige delen legges til igjen, slik
+  at skattegrunnlaget stemmer med skatteberegningen. Sammen med skattekostnad-linjen var dette
+  en innsending som påsto et skattegrunnlag som ikke stemte med sin egen skattekostnad.
+- Et selskap med regnskapsmessig overskudd men skattemessig underskudd (fritatt utbytte og
+  fradragsberettigede kostnader) mistet underskuddet til fremføring, fordi underskuddet ble
+  regnet av regnskapets resultat i stedet for det skattepliktige. Nå føres det riktig.
+- Skattemessig resultat oppgis nå også når det er 0, så lenge det er poster i
+  resultatregnskapet. Et holdingselskap med bare fritatt utbytte har legitimt 0 i
+  skattepliktig inntekt, og Skatteetaten savnet påstanden. Helt hvilende selskap er uendret.
+
+- **Regnskapsperioden var hardkodet til 1. januar til 31. desember.** Et selskap stiftet sent
+  på året kan ha et forlenget første regnskapsår på inntil 18 måneder (regnskapsloven § 1-7
+  andre ledd), og rapporterte da en periode som ikke var den faktiske, både til Brønnøysund og
+  Skatteetaten. Tallene var riktige, men periodeangivelsen er en del av det signerte
+  regnskapet. Perioden kan nå oppgis med `regnskapsstart` og `regnskapsslutt`; står de tomme,
+  er den fortsatt hele kalenderåret. Skatteetaten godtar en periode over 12 måneder, verifisert
+  mot testmiljøet.
+- Aksjonærregisteroppgaven oppgav 1. januar som stiftelsesdato for alle selskap, fordi
+  Enhetsregister-oppslaget kastet bort dag og måned. Den eksakte datoen brukes nå.
+
+### Endret
+
+- SAF-T-importen leser nå skattekostnaden (kontoserie 83xx) inn i den nye linjen. Den falt
+  tidligere ut av importen, slik at balansen ikke gikk opp for et selskap med skattepliktig
+  inntekt. Betalbar skatt (konto 2500 og 2510) havner nå på egen linje i balansen i stedet
+  for i skyldige offentlige avgifter. Summen av kortsiktig gjeld er uendret.
+
+### Lagt til
+
+- Feltet `skattekostnad` under `resultatregnskap` og `betalbar_skatt` under
+  `balanse.egenkapital_og_gjeld.kortsiktig_gjeld`. Begge er 0 som standard, så et regnskap
+  uten skattepliktig inntekt gir nøyaktig samme innsending som før.
+- Knappen «Foreslå skattekostnad» i Tall-steget regner ut 22 % av skattepliktig inntekt
+  (etter fritaksmetoden og fremført underskudd) og viser den som forslag. Forslaget føres
+  aldri automatisk: du fører selv tallet du signerer på.
+- Sammendraget for skattemeldingen kontrollerer ført skattekostnad mot beregningen, og sier
+  fra hvis skatten er beregnet men ikke ført, eller hvis de to spriker. Valideringen av
+  årsregnskapet varsler også hvis en ført skattekostnad ikke har en motpost i balansen.
+
 ## [1.1.1] - 2026-07-29
 
 ### Sikkerhet

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -12,6 +12,8 @@ selskap:
   styreleder: ""                    # Kan være samme person som daglig leder
   forretningsadresse: "Eksempelgata 1, 0001 Oslo"
   stiftelsesaar: 2022
+  # stiftelsesdato: 2018-03-14        # Valgfri, eksakt dato (ÅÅÅÅ-MM-DD). Hentes fra
+                                      # Enhetsregisteret. Brukes i aksjonærregisteroppgaven
   aksjekapital: 30000               # NOK — fra stiftelsesdokumentene
   kontakt_epost: ""                 # Påkrevd for aksjonærregisteroppgave (RF-1086)
 
@@ -35,6 +37,20 @@ resultatregnskap:
     andre_finansinntekter: 0          # Renteinntekter og andre finansinntekter
     rentekostnader: 0                 # Renter på lån
     andre_finanskostnader: 0          # Andre finanskostnader
+
+  # Skattekostnad på ordinært resultat (rskl. § 6-1). Egen linje før årsresultatet.
+  # 0 for et selskap uten skattepliktig inntekt; har selskapet f.eks. renteinntekt,
+  # føres skatten her (og som betalbar_skatt i balansen hvis den ikke er betalt).
+  skattekostnad: 0
+
+# --- Regnskapsperiode (valgfritt) ---
+# Normalt hele kalenderåret, og da skal begge stå urørt.
+# Oppgi dem bare ved forlenget første regnskapsår (rskl. § 1-7 andre ledd): et selskap
+# stiftet sent på året kan la det første regnskapsåret løpe i inntil 18 måneder, fram til
+# 31.12 året etter. Da skal regnskapsaar over være året perioden AVSLUTTES.
+#
+# regnskapsstart: 2025-11-20      # Stiftelsesdatoen
+# regnskapsslutt: 2026-12-31      # Alltid 31. desember
 
 # --- Balanse ---
 # Balansen skal gå opp: sum eiendeler = sum egenkapital og gjeld.
@@ -60,6 +76,8 @@ balanse:
       andre_langsiktige_laan: 0       # Banklån og andre lån med løpetid over 1 år
     kortsiktig_gjeld:
       leverandoergjeld: 0             # Ubetalte fakturaer per 31.12
+      betalbar_skatt: 0               # Skyldig selskapsskatt per 31.12 (konto 2500),
+                                      # motposten til skattekostnaden i resultatregnskapet
       skyldige_offentlige_avgifter: 0 # Skyldig mva, arbeidsgiveravgift o.l.
       annen_kortsiktig_gjeld: 0       # Annen gjeld med forfall innen 1 år
 
@@ -82,6 +100,7 @@ foregaaende_aar:
       andre_finansinntekter: 0
       rentekostnader: 0
       andre_finanskostnader: 0
+    skattekostnad: 0
   balanse:
     eiendeler:
       anleggsmidler:
@@ -101,6 +120,7 @@ foregaaende_aar:
         andre_langsiktige_laan: 0
       kortsiktig_gjeld:
         leverandoergjeld: 0
+        betalbar_skatt: 0
         skyldige_offentlige_avgifter: 0
         annen_kortsiktig_gjeld: 0
 

--- a/docs/bruk.md
+++ b/docs/bruk.md
@@ -61,7 +61,7 @@ Sammendraget inneholder:
 
 - Alle felt i næringsspesifikasjonen ferdig utfylt
 - Skatteberegning med fritaksmetoden der det er aktuelt
-- Beregnet skatt (22 %)
+- Beregnet skatt (22 %), og en kontroll mot skattekostnaden du har ført
 - Skattekostnad ført i resultatregnskapet
 - Fremførbart underskudd hvis selskapet gikk med tap
 - **Egenkapitalnote** (rskl. § 7-2b) med bevegelse per egenkapitalpost (inngående balanse, årsresultat, utbytte og utgående balanse)

--- a/docs/referanse.md
+++ b/docs/referanse.md
@@ -18,6 +18,7 @@ Alle beløp oppgis i hele kroner (NOK). Bruk `0` for poster som ikke er aktuelle
 | `styreleder` | tekst | ja | Fullt navn på styreleder (kan være samme som daglig leder) |
 | `forretningsadresse` | tekst | ja | Gateadresse, postnummer og poststed |
 | `stiftelsesaar` | heltall | ja | Året selskapet ble stiftet |
+| `stiftelsesdato` | dato | nei | Eksakt stiftelsesdato (ÅÅÅÅ-MM-DD). Hentes fra Enhetsregisteret. Brukes som stiftelsesdato i aksjonærregisteroppgaven, og som start på et forlenget første regnskapsår. Uten den brukes 1. januar i stiftelsesåret |
 | `aksjekapital` | heltall | ja | Innbetalt aksjekapital i NOK, fra stiftelsesdokumentene |
 
 ### `regnskapsaar`
@@ -51,6 +52,29 @@ Alle beløp oppgis i hele kroner (NOK). Bruk `0` for poster som ikke er aktuelle
 | `andre_finansinntekter` | heltall | Renteinntekter og andre finansinntekter |
 | `rentekostnader` | heltall | Renter på lån |
 | `andre_finanskostnader` | heltall | Andre finanskostnader |
+
+#### Regnskapsperiode
+
+Feltene ligger på toppnivå i `config.yaml`, ved siden av `regnskapsaar`. Begge er valgfrie.
+
+| Felt | Type | Beskrivelse |
+|---|---|---|
+| `regnskapsstart` | dato | Første dag i regnskapsperioden (ÅÅÅÅ-MM-DD). Tom = 1. januar i regnskapsåret |
+| `regnskapsslutt` | dato | Siste dag i regnskapsperioden. Tom = 31. desember i regnskapsåret |
+
+Regnskapsåret er normalt kalenderåret (regnskapsloven § 1-7 første ledd), og da skal begge stå tomme. De oppgis bare ved **forlenget første regnskapsår** etter § 1-7 andre ledd: et selskap stiftet sent på året kan la det første regnskapsåret løpe i inntil 18 måneder, fram til 31. desember året etter. Perioden starter da på stiftelsesdatoen, og `regnskapsaar` skal være året perioden avsluttes.
+
+Wenche stopper innsendingen hvis perioden ikke kan tolkes entydig: over 18 måneder, slutt som ikke er 31. desember, slutt før start, eller `regnskapsaar` som ikke er sluttåret. En periode over 12 måneder gir en advarsel som viser hvilket inntektsår den fastsettes i.
+
+#### Skattekostnad
+
+Feltet ligger direkte under `resultatregnskap`, ikke i en underseksjon.
+
+| Felt | Type | Beskrivelse |
+|---|---|---|
+| `skattekostnad` | heltall | Skattekostnad på ordinært resultat (rskl. § 6-1). Egen linje mellom resultat før skatt og årsresultat. 0 for et selskap uten skattepliktig inntekt |
+
+Årsresultatet utledes som resultat før skatt minus skattekostnad. Har selskapet skattepliktig inntekt (for eksempel renteinntekt, eller 3 %-tillegget på fritatt utbytte), skal skatten føres her, og som `betalbar_skatt` i balansen hvis den ikke er betalt ved årsslutt. Wenche kan foreslå tallet: knappen «Foreslå skattekostnad» i Tall-steget regner ut 22 % av skattepliktig inntekt. Forslaget føres aldri automatisk.
 
 ### `balanse`
 
@@ -89,7 +113,8 @@ Alle beløp oppgis i hele kroner (NOK). Bruk `0` for poster som ikke er aktuelle
 | Felt | Type | Beskrivelse |
 |---|---|---|
 | `leverandoergjeld` | heltall | Ubetalte fakturaer per 31.12 |
-| `skyldige_offentlige_avgifter` | heltall | Skyldig mva, arbeidsgiveravgift, skyldig skatt o.l. |
+| `betalbar_skatt` | heltall | Skyldig selskapsskatt per 31.12 (konto 2500), motposten til `skattekostnad` |
+| `skyldige_offentlige_avgifter` | heltall | Skyldig mva, arbeidsgiveravgift o.l. |
 | `annen_kortsiktig_gjeld` | heltall | Annen gjeld med forfall innen 1 år |
 
 ### `foregaaende_aar` (valgfritt)

--- a/hosted/api/dokumenter.py
+++ b/hosted/api/dokumenter.py
@@ -93,6 +93,23 @@ def dok_skattemelding(request: Request, config: dict[str, Any] = Body(...)) -> d
     return {"filer": [_fil(navn, tekst.encode("utf-8"), "text/plain; charset=utf-8")]}
 
 
+@router.post("/skatteberegning")
+def dok_skatteberegning(request: Request, config: dict[str, Any] = Body(...)) -> dict:
+    """Beregnet skatt fra tallene i skjemaet, som forslag til skattekostnad-feltet.
+
+    Beregner og returnerer, lagrer ingenting: brukeren avgjør selv om forslaget skal føres
+    (samme forhåndsfyll-prinsipp som SAF-T-importen). Gjenbruker skattemelding.beregn_skatt
+    så forslaget ikke kan drifte fra tallet visningen viser.
+    """
+    krev_invitert(request)
+    beregning, foert = sm.beregn_skatt_fra_config(config)
+    return {
+        "beregnet_skatt": round(beregning.beregnet_skatt),
+        "skattepliktig_inntekt": round(beregning.skattepliktig_inntekt_netto),
+        "foert_skattekostnad": round(foert),
+    }
+
+
 @router.post("/aarsregnskap")
 def dok_aarsregnskap(request: Request, config: dict[str, Any] = Body(...)) -> dict:
     krev_invitert(request)

--- a/hosted/api/selskap.py
+++ b/hosted/api/selskap.py
@@ -34,4 +34,7 @@ def hent_selskap(request: Request) -> dict:
         "daglig_leder": roller["daglig_leder"],
         "styreleder": roller["styreleder"],
         "stiftelsesaar": enhet["stiftelsesaar"],
+        # Eksakt dato, ikke bare årstall: aksjonærregisteroppgaven oppgir stiftelsesdato, og
+        # et forlenget første regnskapsår starter på den.
+        "stiftelsesdato": enhet["stiftelsesdato"],
     }

--- a/hosted/web/src/App.tsx
+++ b/hosted/web/src/App.tsx
@@ -625,6 +625,7 @@ function TallFane({
           laastOrg={org ?? undefined}
           importerSaft={api.importerSaft}
           prefillSelskap={api.selskap}
+          beregnSkatt={(c) => api.dokument("skatteberegning", c)}
           saftMerknad="SAF-T-filen behandles i minnet i EØS og lagres ikke."
           ekstraSeksjon={<NoterSeksjon noter={noter} setNoter={setNoter} />}
         />

--- a/packages/ui/src/skjema.tsx
+++ b/packages/ui/src/skjema.tsx
@@ -6,7 +6,7 @@ import { Inn, TallInput, TallFelt } from "./komponenter";
 // Skjema-drevet datainntasting. Feltstrukturen er data; én generisk renderer bygger
 // config-objektet (samme form som config.yaml) som sendes til backenden.
 
-type FeltType = "number" | "text" | "checkbox";
+type FeltType = "number" | "text" | "checkbox" | "date";
 interface Felt {
   key: string; // punkt-sti inn i config, f.eks. "selskap.navn"
   label: string;
@@ -71,10 +71,29 @@ const SEKSJONER: Seksjon[] = [
       { key: "selskap.styreleder", label: "Styreleder", type: "text" },
       { key: "selskap.forretningsadresse", label: "Forretningsadresse", type: "text" },
       { key: "selskap.stiftelsesaar", label: "Stiftelsesår", type: "number" },
+      {
+        key: "selskap.stiftelsesdato",
+        label: "Stiftelsesdato",
+        type: "date",
+        valgfri: true,
+        help: "Hentes fra Enhetsregisteret. Brukes i aksjonærregisteroppgaven",
       },
       { key: "selskap.aksjekapital", label: "Aksjekapital (kr)", type: "number" },
       { key: "selskap.kontakt_epost", label: "Kontakt-e-post", type: "text" },
       { key: "regnskapsaar", label: "Regnskapsår", type: "number" },
+      {
+        key: "regnskapsstart",
+        label: "Regnskapsperiode fra",
+        type: "date",
+        valgfri: true,
+        help: "Kun ved forlenget første regnskapsår. Tom = 1. januar",
+      },
+      {
+        key: "regnskapsslutt",
+        label: "Regnskapsperiode til",
+        type: "date",
+        valgfri: true,
+        help: "Kun ved forlenget første regnskapsår. Tom = 31. desember",
       },
     ],
   },
@@ -370,7 +389,7 @@ function Feltrutenett({
             ) : (
               <input
                 className={`${input} ${laast ? "cursor-not-allowed opacity-60" : ""}`}
-                type="text"
+                type={f.type === "date" ? "date" : "text"}
                 value={hent(config, f.key) ?? ""}
                 disabled={laast}
                 title={laast ? "Låst til selskapet i invitasjonen" : undefined}
@@ -488,6 +507,7 @@ export function DataSkjema({
               daglig_leder: String(s.daglig_leder ?? "").trim() || d.daglig_leder || "",
               styreleder: String(s.styreleder ?? "").trim() || d.styreleder || "",
               stiftelsesaar: Number(s.stiftelsesaar) || d.stiftelsesaar || 0,
+              stiftelsesdato: String(s.stiftelsesdato ?? "").trim() || d.stiftelsesdato || "",
             },
           };
           pristine.current = JSON.stringify(oppdatert);

--- a/packages/ui/src/skjema.tsx
+++ b/packages/ui/src/skjema.tsx
@@ -30,6 +30,12 @@ const RESULTAT_FELTER: Felt[] = [
   { key: "resultatregnskap.finansposter.andre_finansinntekter", label: "Andre finansinntekter", type: "number" },
   { key: "resultatregnskap.finansposter.rentekostnader", label: "Rentekostnader", type: "number" },
   { key: "resultatregnskap.finansposter.andre_finanskostnader", label: "Andre finanskostnader", type: "number" },
+  {
+    key: "resultatregnskap.skattekostnad",
+    label: "Skattekostnad",
+    type: "number",
+    help: "Egen linje før årsresultatet (rskl. § 6-1). 0 uten skattepliktig inntekt",
+  },
 ];
 
 const BALANSE_FELTER: Felt[] = [
@@ -44,6 +50,12 @@ const BALANSE_FELTER: Felt[] = [
   { key: "balanse.egenkapital_og_gjeld.langsiktig_gjeld.laan_fra_aksjonaer", label: "Lån fra aksjonær", type: "number" },
   { key: "balanse.egenkapital_og_gjeld.langsiktig_gjeld.andre_langsiktige_laan", label: "Andre langsiktige lån", type: "number" },
   { key: "balanse.egenkapital_og_gjeld.kortsiktig_gjeld.leverandoergjeld", label: "Leverandørgjeld", type: "number" },
+  {
+    key: "balanse.egenkapital_og_gjeld.kortsiktig_gjeld.betalbar_skatt",
+    label: "Betalbar skatt",
+    type: "number",
+    help: "Motposten til skattekostnaden (konto 2500), hvis skatten ikke er betalt ved årsslutt",
+  },
   { key: "balanse.egenkapital_og_gjeld.kortsiktig_gjeld.skyldige_offentlige_avgifter", label: "Skyldige offentlige avgifter", type: "number" },
   { key: "balanse.egenkapital_og_gjeld.kortsiktig_gjeld.annen_kortsiktig_gjeld", label: "Annen kortsiktig gjeld", type: "number" },
 ];
@@ -59,9 +71,11 @@ const SEKSJONER: Seksjon[] = [
       { key: "selskap.styreleder", label: "Styreleder", type: "text" },
       { key: "selskap.forretningsadresse", label: "Forretningsadresse", type: "text" },
       { key: "selskap.stiftelsesaar", label: "Stiftelsesår", type: "number" },
+      },
       { key: "selskap.aksjekapital", label: "Aksjekapital (kr)", type: "number" },
       { key: "selskap.kontakt_epost", label: "Kontakt-e-post", type: "text" },
       { key: "regnskapsaar", label: "Regnskapsår", type: "number" },
+      },
     ],
   },
   { id: "resultatregnskap", tittel: "Resultatregnskap", felter: RESULTAT_FELTER },
@@ -210,6 +224,7 @@ const EKSEMPEL: any = {
       rentekostnader: 0,
       andre_finanskostnader: 0,
     },
+    skattekostnad: 0,
   },
   balanse: {
     eiendeler: {
@@ -221,6 +236,7 @@ const EKSEMPEL: any = {
       langsiktig_gjeld: { laan_fra_aksjonaer: 0, andre_langsiktige_laan: 0 },
       kortsiktig_gjeld: {
         leverandoergjeld: 0,
+        betalbar_skatt: 0,
         skyldige_offentlige_avgifter: 0,
         annen_kortsiktig_gjeld: 0,
       },
@@ -239,6 +255,7 @@ const EKSEMPEL: any = {
         rentekostnader: 0,
         andre_finanskostnader: 0,
       },
+      skattekostnad: 0,
     },
     balanse: {
       eiendeler: {
@@ -250,6 +267,7 @@ const EKSEMPEL: any = {
         langsiktig_gjeld: { laan_fra_aksjonaer: 0, andre_langsiktige_laan: 0 },
         kortsiktig_gjeld: {
           leverandoergjeld: 0,
+          betalbar_skatt: 0,
           skyldige_offentlige_avgifter: 0,
           annen_kortsiktig_gjeld: 0,
         },
@@ -376,6 +394,7 @@ export function DataSkjema({
   importerSaft,
   saftMerknad,
   prefillSelskap,
+  beregnSkatt,
 }: {
   onLagre: (config: unknown) => Promise<void>;
   visEksempel?: boolean;
@@ -400,6 +419,11 @@ export function DataSkjema({
   // stiftelsesår) fra Enhetsregisteret. Hostet injiserer henteren; self-hosted lar den være.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   prefillSelskap?: () => Promise<any>;
+  // Valgfritt forslag til skattekostnad: kjernen beregner 22 % av skattepliktig inntekt fra
+  // tallene i skjemaet. Forslag, aldri auto-utfylling: brukeren fører selv tallet han signerer
+  // på. Uten denne vises ikke forslags-knappen.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  beregnSkatt?: (config: any) => Promise<any>;
 }) {
   const laasteFelter = laastOrg ? ["selskap.org_nummer"] : [];
   // Tving org til det låste selskapet (brukes ved start, Bodil-import og eksempeldata).
@@ -479,6 +503,25 @@ export function DataSkjema({
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const oppdater = (key: string, val: any) => setConfig((c: any) => sett(c, key, val));
+
+  // Forslag til skattekostnad. Hentes kun når brukeren ber om det, og settes kun inn ved et
+  // eksplisitt trykk: Wenche fastsetter ikke tallet, den regner det ut som hjelp.
+  const [skattForslag, setSkattForslag] = useState<number | null>(null);
+  const [skattLaster, setSkattLaster] = useState(false);
+  const [skattFeil, setSkattFeil] = useState<string | null>(null);
+  const hentSkattForslag = async () => {
+    if (!beregnSkatt) return;
+    setSkattLaster(true);
+    setSkattFeil(null);
+    try {
+      const d = await beregnSkatt(normaliserForLagring(config));
+      setSkattForslag(Number(d?.beregnet_skatt) || 0);
+    } catch (e) {
+      setSkattFeil(e instanceof Error ? e.message : "Klarte ikke å beregne skatten");
+    } finally {
+      setSkattLaster(false);
+    }
+  };
 
   const sumEiendeler = BALANSE_EIENDELER.reduce((s, k) => s + (Number(hent(config, k)) || 0), 0);
   const sumEkGjeld = BALANSE_EK_GJELD.reduce((s, k) => s + (Number(hent(config, k)) || 0), 0);
@@ -802,6 +845,37 @@ export function DataSkjema({
         <section key={s.tittel} id={s.id} className="scroll-mt-32">
           <h3 className="mb-4 font-display text-xl font-normal">{s.tittel}</h3>
           <Feltrutenett felter={s.felter} config={config} oppdater={oppdater} laasteFelter={laasteFelter} />
+          {s.id === "resultatregnskap" && beregnSkatt && (
+            <div className="mt-4 text-sm">
+              <div className="flex flex-wrap items-center gap-3">
+                <button className={btnOutline} onClick={hentSkattForslag} disabled={skattLaster}>
+                  {skattLaster ? "Beregner…" : "Foreslå skattekostnad"}
+                </button>
+                {skattForslag !== null && (
+                  <>
+                    <span className="text-muted-foreground">
+                      Beregnet skatt (22 %): {kr(skattForslag)}
+                    </span>
+                    <button
+                      className="text-spruce underline underline-offset-2"
+                      onClick={() => oppdater("resultatregnskap.skattekostnad", skattForslag)}
+                    >
+                      Sett inn
+                    </button>
+                  </>
+                )}
+              </div>
+              {skattFeil && <p className="mt-2 text-red-700">{skattFeil}</p>}
+              {skattForslag !== null && (
+                <p className="mt-2 text-xs leading-relaxed text-muted-foreground">
+                  Forslaget er 22 % av skattepliktig inntekt slik Wenche beregner den, etter
+                  fritaksmetoden og fremført underskudd. Det dekker ikke utsatt skatt eller andre
+                  permanente forskjeller, så kontroller tallet før du fører det. Husk «Betalbar
+                  skatt» under kortsiktig gjeld hvis skatten ikke er betalt ved årsslutt.
+                </p>
+              )}
+            </div>
+          )}
           {s.id === "balanse" && (
             <div className="mt-4 flex flex-wrap items-center gap-x-6 gap-y-1 text-sm">
               <span className="text-muted-foreground">Sum eiendeler: {kr(sumEiendeler)}</span>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "wenche"
-version = "1.1.1"
+version = "1.2.0"
 description = "Enkel innsending av årsregnskap, skattemelding og aksjonærregisteroppgave til Altinn for små selskaper uten ordinær drift"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,35 @@ def eksempel_regnskap(eksempel_selskap):
 
 
 @pytest.fixture
+def regnskap_med_skattekostnad(eksempel_selskap):
+    """
+    Passivt holdingselskap med renteinntekt, altså reell skattepliktig inntekt.
+
+    Resultat før skatt 50 000, skattekostnad 11 000 (22 %), årsresultat 39 000.
+    Skatten er ikke betalt ved årsslutt og står som betalbar skatt i balansen.
+    Balansen går opp: eiendeler = EK + gjeld = 189 000 kr.
+    """
+    return Aarsregnskap(
+        selskap=eksempel_selskap,
+        regnskapsaar=2025,
+        resultatregnskap=Resultatregnskap(
+            finansposter=Finansposter(andre_finansinntekter=50000),
+            skattekostnad=11000,
+        ),
+        balanse=Balanse(
+            eiendeler=Eiendeler(
+                anleggsmidler=Anleggsmidler(aksjer_i_datterselskap=100000),
+                omloepmidler=Omloepmidler(bankinnskudd=89000),
+            ),
+            egenkapital_og_gjeld=EgenkapitalOgGjeld(
+                egenkapital=Egenkapital(aksjekapital=30000, annen_egenkapital=148000),
+                kortsiktig_gjeld=KortsiktigGjeld(betalbar_skatt=11000),
+            ),
+        ),
+    )
+
+
+@pytest.fixture
 def regnskap_med_utbytte(eksempel_selskap):
     """Holdingselskap som har mottatt utbytte fra datterselskap."""
     return Aarsregnskap(

--- a/tests/test_brreg.py
+++ b/tests/test_brreg.py
@@ -7,6 +7,7 @@ org, manglende felt og transient nettverksfeil skal aldri kaste, bare gi tomme v
 from unittest.mock import MagicMock, patch
 
 import httpx
+import pytest
 
 from wenche import brreg
 
@@ -83,7 +84,12 @@ def test_parse_enhet_navn_adresse_og_stiftelsesaar():
 
 
 def test_parse_enhet_tomt_svar():
-    assert brreg.parse_enhet({}) == {"navn": "", "forretningsadresse": "", "stiftelsesaar": 0}
+    assert brreg.parse_enhet({}) == {
+        "navn": "",
+        "forretningsadresse": "",
+        "stiftelsesaar": 0,
+        "stiftelsesdato": "",
+    }
 
 
 def _resp(status_code: int = 200, json_data: dict | None = None):
@@ -125,4 +131,26 @@ def test_hent_enhet_ok(mock_get):
 @patch("wenche.brreg.httpx.get")
 def test_hent_enhet_5xx_failsoft(mock_get):
     mock_get.return_value = _resp(status_code=503)
-    assert brreg.hent_enhet("999999999") == {"navn": "", "forretningsadresse": "", "stiftelsesaar": 0}
+    assert brreg.hent_enhet("999999999") == {
+        "navn": "",
+        "forretningsadresse": "",
+        "stiftelsesaar": 0,
+        "stiftelsesdato": "",
+    }
+
+
+def test_parse_stiftelsesdato_beholder_dag_og_maaned():
+    # Regresjon: oppslaget kastet før bort dag og måned, så RF-1086 oppgav 1. januar og et
+    # forlenget første regnskapsår startet på feil dato.
+    assert brreg.parse_stiftelsesdato({"stiftelsesdato": "2025-11-20"}) == "2025-11-20"
+
+
+@pytest.mark.parametrize("verdi", [None, "", "  ", "2025-13-01", "tullball", "2025"])
+def test_parse_stiftelsesdato_ugyldig_gir_tom(verdi):
+    assert brreg.parse_stiftelsesdato({"stiftelsesdato": verdi}) == ""
+
+
+def test_parse_enhet_tar_med_stiftelsesdato():
+    e = brreg.parse_enhet({"navn": "TEST AS", "stiftelsesdato": "2025-11-20"})
+    assert e["stiftelsesdato"] == "2025-11-20"
+    assert e["stiftelsesaar"] == 2025

--- a/tests/test_hosted_dokumenter.py
+++ b/tests/test_hosted_dokumenter.py
@@ -131,3 +131,18 @@ def test_aksjonaer_genereres_uten_tall(klient):
     r = klient.post("/api/dokumenter/aksjonaer", json=cfg)
     assert r.status_code == 200, r.text
     assert r.json()["filer"]
+
+
+def test_skatteberegning_gir_forslag(klient):
+    # Forslaget til skattekostnad-feltet, beregnet av kjernen (samme tall som visningen).
+    _inviter(klient)
+    cfg = _gyldig_config()
+    cfg["resultatregnskap"]["finansposter"]["andre_finansinntekter"] = 50000
+    r = klient.post("/api/dokumenter/skatteberegning", json=cfg)
+    assert r.status_code == 200, r.text
+    assert r.json()["beregnet_skatt"] == 11000
+
+
+def test_skatteberegning_krever_invite(klient):
+    r = klient.post("/api/dokumenter/skatteberegning", json=_gyldig_config())
+    assert r.status_code in (401, 403), r.text

--- a/tests/test_hosted_selskap.py
+++ b/tests/test_hosted_selskap.py
@@ -44,7 +44,7 @@ def test_selskap_forhandsfyller_fra_brreg(klient, monkeypatch):
     monkeypatch.setattr(
         brreg, "hent_enhet",
         lambda org, **k: {"navn": "Test AS", "forretningsadresse": "Vei 1, 0001 OSLO",
-                          "stiftelsesaar": 2018},
+                          "stiftelsesaar": 2018, "stiftelsesdato": "2018-09-14"},
     )
 
     token = lag_invite_token("314273818")
@@ -53,6 +53,9 @@ def test_selskap_forhandsfyller_fra_brreg(klient, monkeypatch):
     data = klient.get("/api/selskap").json()
     # Org kommer fra den signerte invite-bindingen, ikke fra brukerinput.
     assert data["org_nummer"] == "314273818"
+    # Eksakt stiftelsesdato, ikke bare årstall: RF-1086 oppgir datoen, og et forlenget
+    # første regnskapsår starter på den.
+    assert data["stiftelsesdato"] == "2018-09-14"
     assert data["navn"] == "Test AS"
     assert data["forretningsadresse"] == "Vei 1, 0001 OSLO"
     assert data["daglig_leder"] == "Kari Nordmann"

--- a/tests/test_regnskapsperiode.py
+++ b/tests/test_regnskapsperiode.py
@@ -1,0 +1,285 @@
+"""
+Regnskapsperioden, inkludert forlenget første regnskapsår (rskl. § 1-7).
+
+Perioden var hardkodet til 1. januar til 31. desember i regnskapsåret. Et selskap stiftet sent
+på året kan etter § 1-7 andre ledd ha et forlenget første regnskapsår på inntil 18 måneder, og
+rapporterte da en periode som ikke var den faktiske, både til Brønnøysund og Skatteetaten.
+Tallene var riktige, men periodeangivelsen var feil, og den er en del av det signerte
+regnskapet.
+
+Testene dekker:
+  1. Standardoppførselen er uendret: uten oppgitt periode er den fortsatt hele kalenderåret.
+  2. En oppgitt periode kommer med i begge innsendingene.
+  3. Valideringen fanger perioder som ikke kan tolkes entydig av mottakerne.
+  4. Aksjonærregisteroppgaven bruker eksakt stiftelsesdato når den er kjent.
+"""
+
+from datetime import date
+from xml.etree.ElementTree import fromstring
+
+import pytest
+
+from wenche import aarsregnskap as ar
+from wenche.aksjonaerregister import generer_hovedskjema_xml
+from wenche.brg_xml import generer_hovedskjema
+from wenche.models import (
+    Aksjonaer,
+    Aksjonaerregisteroppgave,
+    Balanse,
+    Egenkapital,
+    EgenkapitalOgGjeld,
+    Eiendeler,
+    Omloepmidler,
+    Resultatregnskap,
+    Selskap,
+)
+from wenche.naeringsspesifikasjon_xml import generer_naeringsspesifikasjon
+
+_NS = "{urn:no:skatteetaten:fastsetting:formueinntekt:naeringsspesifikasjon:ekstern:v6}"
+_PARTSNUMMER = 123456789
+
+
+def _regnskap(eksempel_selskap, **kwargs):
+    from wenche.models import Aarsregnskap
+
+    return Aarsregnskap(
+        selskap=eksempel_selskap,
+        regnskapsaar=kwargs.pop("regnskapsaar", 2026),
+        resultatregnskap=Resultatregnskap(),
+        balanse=Balanse(
+            eiendeler=Eiendeler(omloepmidler=Omloepmidler(bankinnskudd=30000)),
+            egenkapital_og_gjeld=EgenkapitalOgGjeld(
+                egenkapital=Egenkapital(aksjekapital=30000)
+            ),
+        ),
+        **kwargs,
+    )
+
+
+class TestPeriodeEgenskaper:
+    def test_standard_er_hele_kalenderaaret(self, eksempel_selskap):
+        r = _regnskap(eksempel_selskap, regnskapsaar=2025)
+        assert r.periode_start == date(2025, 1, 1)
+        assert r.periode_slutt == date(2025, 12, 31)
+        assert r.periode_maaneder == 12
+
+    def test_forlenget_foerste_aar(self, eksempel_selskap):
+        r = _regnskap(
+            eksempel_selskap,
+            regnskapsaar=2026,
+            regnskapsstart=date(2025, 11, 20),
+            regnskapsslutt=date(2026, 12, 31),
+        )
+        assert r.periode_start == date(2025, 11, 20)
+        assert r.periode_maaneder == 14
+
+    def test_maks_18_maaneder_er_grensen(self, eksempel_selskap):
+        # 1. juli til 31. desember året etter er 18 måneder, altså på grensen.
+        r = _regnskap(
+            eksempel_selskap,
+            regnskapsstart=date(2025, 7, 1),
+            regnskapsslutt=date(2026, 12, 31),
+        )
+        assert r.periode_maaneder == 18
+        assert ar.valider(r) == []
+
+
+class TestConfigLesing:
+    def _config(self, **ekstra):
+        return {
+            "selskap": {
+                "navn": "Test AS",
+                "org_nummer": "123456789",
+                "daglig_leder": "D L",
+                "styreleder": "D L",
+                "forretningsadresse": "Vei 1, 0001 OSLO",
+                "stiftelsesaar": 2025,
+                "aksjekapital": 30000,
+                **ekstra.pop("selskap", {}),
+            },
+            "regnskapsaar": 2026,
+            "resultatregnskap": {},
+            "balanse": {},
+            **ekstra,
+        }
+
+    def test_leser_periode_fra_iso_streng(self):
+        # Skjemaet sender datoer som streng.
+        r = ar.les_config(
+            self._config(regnskapsstart="2025-11-20", regnskapsslutt="2026-12-31")
+        )
+        assert r.periode_start == date(2025, 11, 20)
+        assert r.periode_slutt == date(2026, 12, 31)
+
+    def test_leser_periode_fra_yaml_dato(self):
+        # YAML tolker en naken YYYY-MM-DD som date.
+        r = ar.les_config(
+            self._config(regnskapsstart=date(2025, 11, 20), regnskapsslutt=date(2026, 12, 31))
+        )
+        assert r.periode_start == date(2025, 11, 20)
+
+    def test_tomme_datofelt_gir_kalenderaaret(self):
+        r = ar.les_config(self._config(regnskapsstart="", regnskapsslutt=None))
+        assert r.periode_start == date(2026, 1, 1)
+        assert r.periode_slutt == date(2026, 12, 31)
+
+    def test_leser_stiftelsesdato(self):
+        r = ar.les_config(self._config(selskap={"stiftelsesdato": "2025-11-20"}))
+        assert r.selskap.stiftelsesdato == date(2025, 11, 20)
+
+    def test_ugyldig_dato_gir_lesbar_feil(self):
+        with pytest.raises(ValueError, match="ÅÅÅÅ-MM-DD"):
+            ar.les_config(self._config(regnskapsstart="20. november"))
+
+
+class TestValidering:
+    def test_snudd_periode_avvises(self, eksempel_selskap):
+        r = _regnskap(
+            eksempel_selskap,
+            regnskapsstart=date(2026, 12, 31),
+            regnskapsslutt=date(2026, 1, 1),
+        )
+        feil = ar.valider(r)
+        assert any("slutter før den starter" in f for f in feil)
+
+    def test_over_18_maaneder_avvises(self, eksempel_selskap):
+        r = _regnskap(
+            eksempel_selskap,
+            regnskapsstart=date(2025, 6, 1),
+            regnskapsslutt=date(2026, 12, 31),
+        )
+        feil = ar.valider(r)
+        assert any("18 måneder" in f and "19 måneder" in f for f in feil)
+
+    def test_slutt_maa_vaere_31_desember(self, eksempel_selskap):
+        r = _regnskap(
+            eksempel_selskap,
+            regnskapsstart=date(2026, 1, 1),
+            regnskapsslutt=date(2026, 6, 30),
+        )
+        assert any("31. desember" in f for f in ar.valider(r))
+
+    def test_regnskapsaar_maa_vaere_sluttaaret(self, eksempel_selskap):
+        r = _regnskap(
+            eksempel_selskap,
+            regnskapsaar=2025,
+            regnskapsstart=date(2025, 11, 20),
+            regnskapsslutt=date(2026, 12, 31),
+        )
+        assert any("året perioden avsluttes" in f for f in ar.valider(r))
+
+    def test_vanlig_aar_validerer_uten_periodefeil(self, eksempel_regnskap):
+        assert ar.valider(eksempel_regnskap) == []
+
+
+class TestAdvarsler:
+    def test_advarer_naar_start_avviker_fra_stiftelsesdato(self, eksempel_selskap):
+        eksempel_selskap.stiftelsesdato = date(2025, 11, 20)
+        r = _regnskap(
+            eksempel_selskap,
+            regnskapsstart=date(2025, 12, 1),
+            regnskapsslutt=date(2026, 12, 31),
+        )
+        assert any("ble stiftet" in a for a in ar.advarsler(r))
+
+    def test_advarer_om_forlenget_periode(self, eksempel_selskap):
+        # Perioden er lovlig og godtas av Skatteetaten (verifisert mot tt02), men den er
+        # sjelden nok at brukeren bør se hvilket inntektsår den fastsettes i.
+        eksempel_selskap.stiftelsesdato = date(2025, 11, 20)
+        r = _regnskap(
+            eksempel_selskap,
+            regnskapsstart=date(2025, 11, 20),
+            regnskapsslutt=date(2026, 12, 31),
+        )
+        adv = ar.advarsler(r)
+        assert any("forlenget første regnskapsår" in a for a in adv)
+        assert any("inntektsår 2026" in a for a in adv)
+
+    def test_ingen_periodeadvarsel_for_vanlig_aar(self, eksempel_regnskap):
+        adv = ar.advarsler(eksempel_regnskap)
+        assert not any("Regnskapsperioden" in a for a in adv)
+
+
+class TestXmlUtgang:
+    def test_brg_hovedskjema_bruker_perioden(self, eksempel_selskap):
+        r = _regnskap(
+            eksempel_selskap,
+            regnskapsstart=date(2025, 11, 20),
+            regnskapsslutt=date(2026, 12, 31),
+        )
+        xml = generer_hovedskjema(r).decode("utf-8")
+        assert '<regnskapsstart orid="17103">2025-11-20</regnskapsstart>' in xml
+        assert '<regnskapsslutt orid="17104">2026-12-31</regnskapsslutt>' in xml
+        assert '<regnskapsaar orid="17102">2026</regnskapsaar>' in xml
+
+    def test_brg_hovedskjema_uendret_for_vanlig_aar(self, eksempel_regnskap):
+        xml = generer_hovedskjema(eksempel_regnskap).decode("utf-8")
+        assert '<regnskapsstart orid="17103">2025-01-01</regnskapsstart>' in xml
+        assert '<regnskapsslutt orid="17104">2025-12-31</regnskapsslutt>' in xml
+
+    def test_naeringsspesifikasjon_bruker_perioden(self, eksempel_selskap):
+        r = _regnskap(
+            eksempel_selskap,
+            regnskapsstart=date(2025, 11, 20),
+            regnskapsslutt=date(2026, 12, 31),
+        )
+        root = fromstring(generer_naeringsspesifikasjon(r, _PARTSNUMMER).decode("utf-8"))
+        periode = root.find(f"{_NS}virksomhet/{_NS}regnskapsperiode")
+        assert periode.find(f"{_NS}start/{_NS}dato").text == "2025-11-20"
+        assert periode.find(f"{_NS}slutt/{_NS}dato").text == "2026-12-31"
+
+
+class TestAksjonaerregisterStiftelsesdato:
+    def _oppgave(self, selskap):
+        return Aksjonaerregisteroppgave(
+            selskap=selskap,
+            regnskapsaar=2025,
+            aksjonaerer=[
+                Aksjonaer(
+                    navn="Ola Nordmann",
+                    fodselsnummer="24847799354",
+                    antall_aksjer=300,
+                    aksjeklasse="ordinære",
+                    utbytte_utbetalt=0,
+                    innbetalt_kapital_per_aksje=100,
+                )
+            ],
+        )
+
+    def test_bruker_eksakt_stiftelsesdato(self, eksempel_selskap):
+        eksempel_selskap.stiftelsesaar = 2025
+        eksempel_selskap.stiftelsesdato = date(2025, 11, 20)
+        xml = generer_hovedskjema_xml(self._oppgave(eksempel_selskap)).decode("utf-8")
+        assert "2025-11-20T00:00:00" in xml
+        assert "2025-01-01T00:00:00" not in xml
+
+    def test_faller_tilbake_paa_1_januar_uten_dato(self, eksempel_selskap):
+        eksempel_selskap.stiftelsesaar = 2025
+        eksempel_selskap.stiftelsesdato = None
+        xml = generer_hovedskjema_xml(self._oppgave(eksempel_selskap)).decode("utf-8")
+        assert "2025-01-01T00:00:00" in xml
+
+
+class TestFjoraarsadvarselVedForlengetAar:
+    """
+    Et forlenget første regnskapsår har ikke noe fjorår, selv om stiftelsesåret er lavere
+    enn regnskapsåret. § 6-6-advarselen ba derfor om sammenligningstall som ikke finnes.
+    """
+
+    def test_ingen_fjoraarsadvarsel_naar_selskapet_er_stiftet_i_perioden(self, eksempel_selskap):
+        eksempel_selskap.stiftelsesaar = 2024
+        eksempel_selskap.stiftelsesdato = date(2024, 11, 20)
+        r = _regnskap(
+            eksempel_selskap,
+            regnskapsaar=2025,
+            regnskapsstart=date(2024, 11, 20),
+            regnskapsslutt=date(2025, 12, 31),
+        )
+        assert not any("sammenligningstall" in a for a in ar.advarsler(r))
+
+    def test_fjoraarsadvarsel_staar_for_et_vanlig_aar(self, eksempel_selskap):
+        # Kontroll: et etablert selskap uten fjorårstall skal fortsatt varsles.
+        eksempel_selskap.stiftelsesaar = 2020
+        eksempel_selskap.stiftelsesdato = date(2020, 3, 14)
+        r = _regnskap(eksempel_selskap, regnskapsaar=2025)
+        assert any("sammenligningstall" in a for a in ar.advarsler(r))

--- a/tests/test_saft.py
+++ b/tests/test_saft.py
@@ -165,3 +165,58 @@ def test_xml_med_entitetsdefinisjoner_avvises():
     ).encode("utf-8")
     with pytest.raises(ValueError):
         importer_bytes(ondsinnet)
+
+
+def test_skattekostnad_importeres():
+    # Skattekostnaden har egen kategori i SAF-T. Uten mapping falt den ut av importen, og
+    # balansen gikk ikke opp for et selskap med skattepliktig inntekt.
+    cfg = importer_bytes(
+        _saft_xml(
+            _konto("finansinntekt", "8050", ub_kredit=50000)
+            + _konto("skattekostnad", "8300", ub_debet=11000)
+        )
+    )
+    assert cfg["resultatregnskap"]["skattekostnad"] == 11000
+
+
+def test_skattekostnad_paa_kode_alene():
+    # Fallback: 83-serien er skatt uansett hva kategorien sier.
+    cfg = importer_bytes(_saft_xml(_konto("ukjentKategori", "8300", ub_debet=11000)))
+    assert cfg["resultatregnskap"]["skattekostnad"] == 11000
+
+
+def test_betalbar_skatt_egen_linje():
+    # 2500 lå tidligere i skyldige offentlige avgifter. Den er motposten til skattekostnaden,
+    # og har nå egen linje (rskl. § 6-2).
+    cfg = importer_bytes(
+        _saft_xml(
+            _konto("kortsiktigGjeld", "2500", ub_kredit=11000)
+            + _konto("kortsiktigGjeld", "2700", ub_kredit=3000)
+        )
+    )
+    kg = cfg["balanse"]["egenkapital_og_gjeld"]["kortsiktig_gjeld"]
+    assert kg["betalbar_skatt"] == 11000
+    assert kg["skyldige_offentlige_avgifter"] == 3000
+
+
+def test_saft_import_gir_balanse_som_gaar_opp_med_skatt():
+    # Ende-til-ende for caset i rapporten: renteinntekt, skattekostnad og skattegjeld.
+    cfg = importer_bytes(
+        _saft_xml(
+            _konto("finansinntekt", "8050", ub_kredit=50000)
+            + _konto("skattekostnad", "8300", ub_debet=11000)
+            + _konto("balanseverdiForOmloepsmiddel", "1920", ub_debet=189000)
+            + _konto("egenkapital", "2000", ub_kredit=30000)
+            + _konto("egenkapital", "2050", ub_kredit=148000)
+            + _konto("kortsiktigGjeld", "2500", ub_kredit=11000)
+        )
+    )
+    from wenche import aarsregnskap as ar
+
+    regnskap = ar.les_config(
+        {**cfg, "selskap": {**cfg["selskap"], "daglig_leder": "D L", "styreleder": "D L",
+                            "stiftelsesaar": 2020, "aksjekapital": 30000}}
+    )
+    assert regnskap.resultatregnskap.resultat_foer_skatt == 50000
+    assert regnskap.resultatregnskap.aarsresultat == 39000
+    assert ar.valider(regnskap) == []

--- a/tests/test_selfhosted_dokumenter.py
+++ b/tests/test_selfhosted_dokumenter.py
@@ -95,3 +95,27 @@ def test_health_og_update_check(klient, monkeypatch):
     data = klient.get("/api/update-check").json()
     assert data["siste"] == "99.0.0"
     assert data["nyere"] is True
+
+
+def test_skatteberegning_gir_forslag(klient):
+    # Forslaget til skattekostnad-feltet: 22 % av skattepliktig inntekt, beregnet av kjernen
+    # så SPA-en ikke må duplisere fritaksmetoden og underskuddsfremføringen i TypeScript.
+    cfg = _gyldig_config()
+    cfg["resultatregnskap"]["finansposter"]["andre_finansinntekter"] = 50000
+    r = klient.post("/api/dokumenter/skatteberegning", json=cfg)
+    assert r.status_code == 200, r.text
+    assert r.json() == {
+        "beregnet_skatt": 11000,
+        "skattepliktig_inntekt": 50000,
+        "foert_skattekostnad": 0,
+    }
+
+
+def test_skatteberegning_uten_selskapsopplysninger(klient):
+    # Forslaget hentes fra Tall-steget, der stiftelsesår og aksjekapital godt kan stå tomme.
+    r = klient.post(
+        "/api/dokumenter/skatteberegning",
+        json={"resultatregnskap": {"finansposter": {"andre_finansinntekter": 50000}}},
+    )
+    assert r.status_code == 200, r.text
+    assert r.json()["beregnet_skatt"] == 11000

--- a/tests/test_skattekostnad.py
+++ b/tests/test_skattekostnad.py
@@ -1,0 +1,520 @@
+"""
+Skattekostnad som egen linje i årsregnskapet (rskl. § 6-1 nr. 19).
+
+Før dette regnet modellen «resultat før skatt» som årsresultat direkte, altså implisitt
+skattekostnad 0. Det gikk bra så lenge selskapet hadde underskudd eller null skattepliktig
+resultat, men et passivt holdingselskap med renteinntekt har en reell skattekostnad. Da
+manglet oppstillingsplanen en påkrevd linje, og balansen hadde ingen riktig plass til
+skattegjelden.
+
+Testene dekker tre ting:
+  1. Ny linje kommer med i begge innsendingene, med riktige orid/koder og plassering.
+  2. Skattemessig resultat reduseres IKKE av skattekostnaden (den er ikke fradragsberettiget,
+     sktl. § 6-1), verken i næringsspesifikasjonen eller i underskuddsgrunnlaget.
+  3. Et regnskap uten skattekostnad gir uendret XML, så eksisterende brukere ikke berøres.
+"""
+
+from xml.etree.ElementTree import fromstring
+
+from wenche import aarsregnskap as ar
+from wenche import skattemelding as sm
+from wenche.brg_xml import generer_underskjema
+from wenche.models import (
+    KortsiktigGjeld,
+    Resultatregnskap,
+    Finansposter,
+    SkattemeldingKonfig,
+)
+from wenche.naeringsspesifikasjon_xml import generer_naeringsspesifikasjon
+from wenche.skattemelding_xml import generer_skattemelding_fra_konfig
+
+_NS = "{urn:no:skatteetaten:fastsetting:formueinntekt:naeringsspesifikasjon:ekstern:v6}"
+_SM_NS = "{urn:no:skatteetaten:fastsetting:formueinntekt:skattemelding:upersonlig:ekstern:v5}"
+_PARTSNUMMER = 123456789
+
+
+class TestModell:
+    def test_aarsresultat_er_etter_skatt(self):
+        r = Resultatregnskap(
+            finansposter=Finansposter(andre_finansinntekter=50000),
+            skattekostnad=11000,
+        )
+        assert r.resultat_foer_skatt == 50000
+        assert r.aarsresultat == 39000
+
+    def test_uten_skattekostnad_er_aarsresultat_lik_resultat_foer_skatt(self):
+        r = Resultatregnskap(finansposter=Finansposter(andre_finansinntekter=50000))
+        assert r.aarsresultat == r.resultat_foer_skatt == 50000
+
+    def test_betalbar_skatt_teller_i_kortsiktig_gjeld(self):
+        kg = KortsiktigGjeld(leverandoergjeld=2000, betalbar_skatt=11000)
+        assert kg.sum == 13000
+
+
+class TestConfigLesing:
+    def _config(self, **resultat_ekstra):
+        return {
+            "selskap": {
+                "navn": "Test AS",
+                "org_nummer": "123456789",
+                "daglig_leder": "D L",
+                "styreleder": "D L",
+                "forretningsadresse": "Vei 1, 0001 OSLO",
+                "stiftelsesaar": 2018,
+                "aksjekapital": 30000,
+            },
+            "regnskapsaar": 2025,
+            "resultatregnskap": {
+                "finansposter": {"andre_finansinntekter": 50000},
+                **resultat_ekstra,
+            },
+            "balanse": {
+                "egenkapital_og_gjeld": {
+                    "kortsiktig_gjeld": {"betalbar_skatt": 11000},
+                },
+            },
+        }
+
+    def test_leser_skattekostnad_og_betalbar_skatt(self):
+        regnskap = ar.les_config(self._config(skattekostnad=11000))
+        assert regnskap.resultatregnskap.skattekostnad == 11000
+        assert regnskap.resultatregnskap.aarsresultat == 39000
+        kg = regnskap.balanse.egenkapital_og_gjeld.kortsiktig_gjeld
+        assert kg.betalbar_skatt == 11000
+
+    def test_manglende_skattekostnad_blir_null(self):
+        regnskap = ar.les_config(self._config())
+        assert regnskap.resultatregnskap.skattekostnad == 0.0
+
+    def test_blank_skattekostnad_blir_null(self):
+        # Skjemaet sender tom streng for et blankt tallfelt.
+        regnskap = ar.les_config(self._config(skattekostnad=""))
+        assert regnskap.resultatregnskap.skattekostnad == 0.0
+
+
+class TestBrgUnderskjema:
+    def test_skattekostnad_linje_med_orid(self, regnskap_med_skattekostnad):
+        xml = generer_underskjema(regnskap_med_skattekostnad).decode("utf-8")
+        assert '<skattekostnad altinnRowId=' in xml
+        assert '<aarets orid="11835">11000</aarets>' in xml
+        assert '<fjoraarets orid="11836">0</fjoraarets>' in xml
+
+    def test_skattekostnad_staar_mellom_resultat_foer_skatt_og_aarsresultat(
+        self, regnskap_med_skattekostnad
+    ):
+        # XSD-sekvensen i Resultat er rekkefølge-bundet.
+        xml = generer_underskjema(regnskap_med_skattekostnad).decode("utf-8")
+        pos_foer = xml.index("<resultatFoerSkattekostnad>")
+        pos_skatt = xml.index("<skattekostnad altinnRowId=")
+        pos_aars = xml.index("<aarsresultat>")
+        assert pos_foer < pos_skatt < pos_aars
+
+    def test_aarsresultat_er_etter_skatt_i_xml(self, regnskap_med_skattekostnad):
+        xml = generer_underskjema(regnskap_med_skattekostnad).decode("utf-8")
+        assert '<aarets orid="167">50000</aarets>' in xml   # resultat før skatt
+        assert '<aarets orid="172">39000</aarets>' in xml   # årsresultat
+
+    def test_betalbar_skatt_i_kortsiktig_gjeld(self, regnskap_med_skattekostnad):
+        xml = generer_underskjema(regnskap_med_skattekostnad).decode("utf-8")
+        assert '<betalbarSkatt altinnRowId=' in xml
+        assert '<aarets orid="2483">11000</aarets>' in xml
+        assert '<aarets orid="85">11000</aarets>' in xml    # sum kortsiktig gjeld
+
+    def test_betalbar_skatt_staar_foer_skyldige_offentlige_avgifter(
+        self, regnskap_med_skattekostnad
+    ):
+        xml = generer_underskjema(regnskap_med_skattekostnad).decode("utf-8")
+        pos_lev = xml.index("<balanseKortsiktigGjeld>")
+        pos_skatt = xml.index("<betalbarSkatt altinnRowId=")
+        pos_sum = xml.index("<sumKortsiktigGjeld>")
+        assert pos_lev < pos_skatt < pos_sum
+
+    def test_uten_skattekostnad_ingen_linje(self, eksempel_regnskap):
+        # Baklengs-kompatibilitet: et holdingselskap uten skattepliktig inntekt skal få
+        # nøyaktig samme XML som før endringen.
+        xml = generer_underskjema(eksempel_regnskap).decode("utf-8")
+        assert "<skattekostnad" not in xml
+        assert "<betalbarSkatt" not in xml
+
+
+class TestNaeringsspesifikasjon:
+    def _root(self, regnskap):
+        return fromstring(
+            generer_naeringsspesifikasjon(regnskap, _PARTSNUMMER).decode("utf-8")
+        )
+
+    def _beloep(self, el):
+        """Beløp i et avledet sum-element (BeloepMedSkattemessigeEgenskaper)."""
+        return el.find(f"{_NS}beloep/{_NS}beloep").text
+
+    def _forekomst_beloep(self, el):
+        """Beløp i en linjeforekomst, som har ett innkapslingsnivå mer enn sum-elementene."""
+        return el.find(f"{_NS}beloep/{_NS}beloep/{_NS}beloep").text
+
+    def test_skattekostnad_forekomst_med_kode_8300(self, regnskap_med_skattekostnad):
+        root = self._root(regnskap_med_skattekostnad)
+        kostnad = root.find(f"{_NS}resultatregnskap/{_NS}skattekostnad/{_NS}kostnad")
+        assert kostnad is not None
+        assert kostnad.find(f"{_NS}id").text == "8300"
+        assert (
+            kostnad.find(
+                f"{_NS}type/{_NS}resultatOgBalanseregnskapstype"
+            ).text
+            == "8300"
+        )
+        assert self._forekomst_beloep(kostnad) == "11000.00"
+
+    def test_sum_skattekostnad_emitteres(self, regnskap_med_skattekostnad):
+        root = self._root(regnskap_med_skattekostnad)
+        sum_el = root.find(f"{_NS}resultatregnskap/{_NS}sumSkattekostnad")
+        assert sum_el is not None
+        assert self._beloep(sum_el) == "11000.00"
+
+    def test_aarsresultat_er_etter_skatt(self, regnskap_med_skattekostnad):
+        root = self._root(regnskap_med_skattekostnad)
+        aars = root.find(f"{_NS}resultatregnskap/{_NS}aarsresultat")
+        assert self._beloep(aars) == "39000.00"
+
+    def test_skattemessig_resultat_er_foer_skatt(self, regnskap_med_skattekostnad):
+        # Kjernen i fiksen: skattekostnaden er ikke fradragsberettiget, så det skattemessige
+        # resultatet skal være 50 000, ikke årsresultatet på 39 000. Ellers ville
+        # næringsspesifikasjonen oppgitt et grunnlag som var 22 % for lavt.
+        root = self._root(regnskap_med_skattekostnad)
+        bni = root.find(f"{_NS}beregnetNaeringsinntekt")
+        assert self._beloep(bni.find(f"{_NS}skattemessigResultat")) == "50000.00"
+        fordelt = bni.find(
+            f"{_NS}fordeltBeregnetNaeringsinntektForUpersonligSkattepliktig"
+        )
+        assert self._beloep(fordelt.find(f"{_NS}fordeltSkattemessigResultat")) == "50000.00"
+        assert (
+            self._beloep(fordelt.find(f"{_NS}fordeltSkattemessigResultatEtterKorreksjon"))
+            == "50000.00"
+        )
+
+    def test_betalbar_skatt_som_gjeld_med_kode_2500(self, regnskap_med_skattekostnad):
+        root = self._root(regnskap_med_skattekostnad)
+        gjeld = root.findall(
+            f"{_NS}balanseregnskap/{_NS}gjeldOgEgenkapital/{_NS}kortsiktigGjeld/{_NS}gjeld"
+        )
+        koder = {g.find(f"{_NS}id").text: self._forekomst_beloep(g) for g in gjeld}
+        assert koder == {"2500": "11000.00"}
+
+    def test_uten_skattekostnad_ingen_skattekostnad_element(self, regnskap_med_utbytte):
+        root = self._root(regnskap_med_utbytte)
+        assert root.find(f"{_NS}resultatregnskap/{_NS}skattekostnad") is None
+        assert root.find(f"{_NS}resultatregnskap/{_NS}sumSkattekostnad") is None
+
+
+class TestTilbakefoertSkattekostnad:
+    """
+    Skattekostnaden må tilbakeføres som permanent forskjell.
+
+    Skatteetaten utleder sitt eget skattemessige resultat fra ÅRSRESULTATET pluss
+    permanente forskjeller, ikke fra resultat før skatt. Uten tilbakeføringen regner SKD
+    22 % lavere enn påstanden vår og svarer validertMedFeil med avvikNaeringsopplysninger
+    og merknaden N_AVVIK_TILBAKEFØRT_SKATTEKOSTNAD. Verifisert mot tt02 2026-08-05: uten
+    denne seksjonen validertMedFeil, med den validertOK og SKDs beregnede inntekt lik vår.
+    """
+
+    def _root(self, regnskap, konfig=None):
+        return fromstring(
+            generer_naeringsspesifikasjon(regnskap, _PARTSNUMMER, konfig).decode("utf-8")
+        )
+
+    def _forskjell(self, root):
+        return root.find(f"{_NS}forskjellMellomRegnskapsmessigOgSkattemessigVerdi")
+
+    def test_permanent_forskjell_med_riktig_kode(self, regnskap_med_skattekostnad):
+        perm = self._forskjell(self._root(regnskap_med_skattekostnad)).find(
+            f"{_NS}permanentForskjell"
+        )
+        assert perm.find(f"{_NS}id").text == "positivSkattekostnad"
+        assert (
+            perm.find(f"{_NS}permanentForskjellstype/{_NS}permanentForskjellstype").text
+            == "positivSkattekostnad"
+        )
+        assert (
+            perm.find(f"{_NS}beloep/{_NS}beloep/{_NS}beloep").text == "11000.00"
+        )
+
+    def test_sum_tillegg_i_naeringsinntekt(self, regnskap_med_skattekostnad):
+        forskjell = self._forskjell(self._root(regnskap_med_skattekostnad))
+        sum_el = forskjell.find(f"{_NS}sumTilleggINaeringsinntekt")
+        assert sum_el.find(f"{_NS}beloep/{_NS}beloep").text == "11000.00"
+        assert forskjell.find(f"{_NS}sumFradragINaeringsinntekt") is None
+
+    def test_negativ_skattekostnad_gaar_til_fradrag(self, regnskap_med_skattekostnad):
+        # En negativ skattekostnad (skatteinntekt) løfter årsresultatet over resultat før
+        # skatt, og må da trekkes fra for å komme tilbake til det skattemessige resultatet.
+        regnskap_med_skattekostnad.resultatregnskap.skattekostnad = -4000
+        forskjell = self._forskjell(self._root(regnskap_med_skattekostnad))
+        perm = forskjell.find(f"{_NS}permanentForskjell")
+        assert perm.find(f"{_NS}id").text == "negativSkattekostnad"
+        assert perm.find(f"{_NS}beloep/{_NS}beloep/{_NS}beloep").text == "4000.00"
+        assert forskjell.find(f"{_NS}sumFradragINaeringsinntekt") is not None
+        assert forskjell.find(f"{_NS}sumTilleggINaeringsinntekt") is None
+
+    def test_tilbakefoering_stemmer_med_skattemessig_resultat(
+        self, regnskap_med_skattekostnad
+    ):
+        # Invarianten SKD kryssjekker: årsresultat + tilbakeført skattekostnad
+        # == skattemessig resultat.
+        root = self._root(regnskap_med_skattekostnad)
+        aars = float(
+            root.find(f"{_NS}resultatregnskap/{_NS}aarsresultat/{_NS}beloep/{_NS}beloep").text
+        )
+        tillegg = float(
+            self._forskjell(root)
+            .find(f"{_NS}sumTilleggINaeringsinntekt/{_NS}beloep/{_NS}beloep")
+            .text
+        )
+        skattemessig = float(
+            root.find(
+                f"{_NS}beregnetNaeringsinntekt/{_NS}skattemessigResultat"
+                f"/{_NS}beloep/{_NS}beloep"
+            ).text
+        )
+        assert aars + tillegg == skattemessig == 50000.0
+
+    def test_ingen_seksjon_uten_forskjeller(self, eksempel_regnskap):
+        # Bare driftskostnader: ingen skattekostnad og ingen fritatt utbytte, altså
+        # ingenting å forklare mellom regnskap og skattegrunnlag.
+        assert self._forskjell(self._root(eksempel_regnskap)) is None
+
+
+class TestFritaksmetoden:
+    """
+    Utbytte som er fritatt etter fritaksmetoden skal ikke stå som skattepliktig inntekt.
+
+    Før dette oppgav næringsspesifikasjonen brutto utbytte som skattemessig resultat, mens
+    Wenches egen skatteberegning bare skattla 3 %-sjablonen. Innsendingen var altså
+    internt inkonsistent: den påsto et skattegrunnlag som ikke stemte med skattekostnaden.
+    SKDs validering fanger det ikke, fordi den bare kryssjekker årsresultat + permanente
+    forskjeller mot skattemessig resultat.
+    """
+
+    def _root(self, regnskap, konfig):
+        return fromstring(
+            generer_naeringsspesifikasjon(regnskap, _PARTSNUMMER, konfig).decode("utf-8")
+        )
+
+    def _forskjeller(self, root):
+        """{kode: beløp} for alle permanente forskjeller."""
+        forskjell = root.find(f"{_NS}forskjellMellomRegnskapsmessigOgSkattemessigVerdi")
+        if forskjell is None:
+            return {}
+        return {
+            p.find(f"{_NS}id").text: float(
+                p.find(f"{_NS}beloep/{_NS}beloep/{_NS}beloep").text
+            )
+            for p in forskjell.findall(f"{_NS}permanentForskjell")
+        }
+
+    def _skattemessig(self, root):
+        el = root.find(
+            f"{_NS}beregnetNaeringsinntekt/{_NS}skattemessigResultat/{_NS}beloep/{_NS}beloep"
+        )
+        return float(el.text) if el is not None else 0.0
+
+    def _utbytteregnskap(self, eksempel_selskap, utbytte, skattekostnad):
+        from wenche.models import (
+            Aarsregnskap,
+            Balanse,
+            Egenkapital,
+            EgenkapitalOgGjeld,
+            Eiendeler,
+            Omloepmidler,
+        )
+
+        return Aarsregnskap(
+            selskap=eksempel_selskap,
+            regnskapsaar=2025,
+            resultatregnskap=Resultatregnskap(
+                finansposter=Finansposter(utbytte_fra_datterselskap=utbytte),
+                skattekostnad=skattekostnad,
+            ),
+            balanse=Balanse(
+                eiendeler=Eiendeler(omloepmidler=Omloepmidler(bankinnskudd=utbytte)),
+                egenkapital_og_gjeld=EgenkapitalOgGjeld(
+                    egenkapital=Egenkapital(annen_egenkapital=utbytte)
+                ),
+            ),
+        )
+
+    def test_helt_fritatt_utbytte_gir_null_skattepliktig(self, eksempel_selskap):
+        # Eierandel >= 90 %: hele utbyttet er fritatt, ingen skatt, ingen 3 %-sjablon.
+        regnskap = self._utbytteregnskap(eksempel_selskap, 1000000, 0)
+        konfig = SkattemeldingKonfig(anvend_fritaksmetoden=True, eierandel_for_fritaksmetoden=100)
+        root = self._root(regnskap, konfig)
+        forskjeller = self._forskjeller(root)
+        assert forskjeller == {"tilbakefoeringAvInntektsfoertUtbytte": 1000000.0}
+        assert self._skattemessig(root) == 0.0
+
+    def test_sjablonregelen_gir_tre_prosent_som_skattepliktig(self, eksempel_selskap):
+        # Eierandel < 90 %: 3 % av utbyttet er skattepliktig, resten fritatt.
+        regnskap = self._utbytteregnskap(eksempel_selskap, 1000000, 6600)
+        konfig = SkattemeldingKonfig(anvend_fritaksmetoden=True, eierandel_for_fritaksmetoden=80)
+        root = self._root(regnskap, konfig)
+        assert self._forskjeller(root) == {
+            "positivSkattekostnad": 6600.0,
+            "skattepliktigDelAvUtbytterOgUtdelinger": 30000.0,
+            "tilbakefoeringAvInntektsfoertUtbytte": 1000000.0,
+        }
+        assert self._skattemessig(root) == 30000.0
+
+    def test_uten_fritaksmetoden_er_utbyttet_fullt_skattepliktig(self, eksempel_selskap):
+        # Fritaksmetoden av: ingen tilbakeføring, hele utbyttet er skattepliktig.
+        regnskap = self._utbytteregnskap(eksempel_selskap, 1000000, 220000)
+        konfig = SkattemeldingKonfig(anvend_fritaksmetoden=False)
+        root = self._root(regnskap, konfig)
+        assert self._forskjeller(root) == {"positivSkattekostnad": 220000.0}
+        assert self._skattemessig(root) == 1000000.0
+
+    def test_invariant_aarsresultat_pluss_tillegg_minus_fradrag(self, eksempel_selskap):
+        # Invarianten SKD kryssjekker, for alle tre variantene.
+        for eierandel, fritak, skattekostnad in [(100, True, 0), (80, True, 6600), (0, False, 220000)]:
+            regnskap = self._utbytteregnskap(eksempel_selskap, 1000000, skattekostnad)
+            konfig = SkattemeldingKonfig(
+                anvend_fritaksmetoden=fritak, eierandel_for_fritaksmetoden=eierandel
+            )
+            root = self._root(regnskap, konfig)
+            forskjell = root.find(f"{_NS}forskjellMellomRegnskapsmessigOgSkattemessigVerdi")
+
+            def _sum(tag):
+                el = forskjell.find(f"{_NS}{tag}/{_NS}beloep/{_NS}beloep")
+                return float(el.text) if el is not None else 0.0
+
+            aars = float(
+                root.find(
+                    f"{_NS}resultatregnskap/{_NS}aarsresultat/{_NS}beloep/{_NS}beloep"
+                ).text
+            )
+            utledet = aars + _sum("sumTilleggINaeringsinntekt") - _sum("sumFradragINaeringsinntekt")
+            assert utledet == self._skattemessig(root), (
+                f"invarianten brytes for eierandel={eierandel}, fritak={fritak}"
+            )
+
+    def test_skattemessig_resultat_null_emitteres_ved_aktivitet(self, eksempel_selskap):
+        # Helt fritatt utbytte gir legitimt 0 i skattepliktig inntekt. Utelates påstanden,
+        # beregner SKD 0 selv og flagger manglerNaeringsopplysninger (verifisert mot tt02).
+        regnskap = self._utbytteregnskap(eksempel_selskap, 1000000, 0)
+        konfig = SkattemeldingKonfig(anvend_fritaksmetoden=True, eierandel_for_fritaksmetoden=100)
+        root = self._root(regnskap, konfig)
+        assert root.find(f"{_NS}beregnetNaeringsinntekt") is not None
+        assert self._skattemessig(root) == 0.0
+
+    def test_hvilende_selskap_utelater_seksjonen(self, eksempel_selskap):
+        # Ingen poster i resultatregnskapet: SKD forventer ikke seksjonen, og innsendingen
+        # er ren uten den. Skal ikke endres av at 0 nå emitteres ved aktivitet.
+        from wenche.models import Aarsregnskap, Balanse
+
+        regnskap = Aarsregnskap(
+            selskap=eksempel_selskap,
+            regnskapsaar=2025,
+            resultatregnskap=Resultatregnskap(),
+            balanse=Balanse(),
+        )
+        root = self._root(regnskap, SkattemeldingKonfig())
+        assert root.find(f"{_NS}beregnetNaeringsinntekt") is None
+
+    def test_fritatt_utbytte_med_kostnader_gir_skattemessig_underskudd(self, eksempel_selskap):
+        # Regnskapsmessig overskudd, skattemessig underskudd: utbyttet er fritatt, mens
+        # kostnadene er fradragsberettigede. Underskuddet skal føres til fremføring.
+        regnskap = self._utbytteregnskap(eksempel_selskap, 1000000, 0)
+        regnskap.resultatregnskap.driftskostnader.andre_driftskostnader = 50000
+        konfig = SkattemeldingKonfig(anvend_fritaksmetoden=True, eierandel_for_fritaksmetoden=100)
+        assert regnskap.resultatregnskap.aarsresultat == 950000  # regnskapsmessig overskudd
+        assert self._skattemessig(self._root(regnskap, konfig)) == -50000.0
+        xml = generer_skattemelding_fra_konfig(regnskap, konfig, _PARTSNUMMER).decode("utf-8")
+        samlet = fromstring(xml).find(
+            f"{_SM_NS}inntektOgUnderskudd/{_SM_NS}samletUnderskudd/{_SM_NS}beloep"
+            f"/{_SM_NS}beloepSomHeltall"
+        )
+        assert samlet.text == "50000"
+
+
+class TestUnderskuddsgrunnlag:
+    def test_aarets_underskudd_regnes_foer_skatt(self, eksempel_regnskap):
+        # Underskuddsår: resultat før skatt -5 500. En (kunstig) ført skattekostnad skal
+        # ikke øke det fremførbare underskuddet, siden den ikke er fradragsberettiget.
+        eksempel_regnskap.resultatregnskap.skattekostnad = 1000
+        konfig = SkattemeldingKonfig()
+        xml = generer_skattemelding_fra_konfig(
+            eksempel_regnskap, konfig, _PARTSNUMMER
+        ).decode("utf-8")
+        root = fromstring(xml)
+        samlet = root.find(
+            f"{_SM_NS}inntektOgUnderskudd/{_SM_NS}samletUnderskudd/{_SM_NS}beloep"
+            f"/{_SM_NS}beloepSomHeltall"
+        )
+        assert samlet.text == "5500"
+
+
+class TestVisning:
+    def test_viser_foert_skattekostnad_og_aarsresultat(self, regnskap_med_skattekostnad):
+        tekst = sm.generer(regnskap_med_skattekostnad, SkattemeldingKonfig())
+        assert "Skattekostnad" in tekst
+        assert "-11 000 kr" in tekst
+        assert "39 000 kr" in tekst
+
+    def test_varsler_naar_skatt_er_beregnet_men_ikke_foert(self, regnskap_med_skattekostnad):
+        regnskap_med_skattekostnad.resultatregnskap.skattekostnad = 0
+        tekst = sm.generer(regnskap_med_skattekostnad, SkattemeldingKonfig())
+        assert "ikke ført" in tekst
+        assert "§ 6-1" in tekst
+
+    def test_varsler_ved_avvik_mot_beregningen(self, regnskap_med_skattekostnad):
+        regnskap_med_skattekostnad.resultatregnskap.skattekostnad = 9000
+        tekst = sm.generer(regnskap_med_skattekostnad, SkattemeldingKonfig())
+        assert "avvik" in tekst
+
+    def test_ingen_advarsel_naar_foert_stemmer(self, regnskap_med_skattekostnad):
+        tekst = sm.generer(regnskap_med_skattekostnad, SkattemeldingKonfig())
+        assert "avvik" not in tekst
+        assert "ikke ført" not in tekst
+
+
+class TestBeregning:
+    def test_beregn_skatt_fra_config_uten_selskapsopplysninger(self):
+        # Forslaget hentes fra Tall-steget, der selskapsfeltene godt kan stå tomme.
+        beregning, foert = sm.beregn_skatt_fra_config(
+            {"resultatregnskap": {"finansposter": {"andre_finansinntekter": 50000}}}
+        )
+        assert beregning.beregnet_skatt == 11000
+        assert foert == 0.0
+
+    def test_forslag_tar_hensyn_til_sjablonregelen(self):
+        beregning, _ = sm.beregn_skatt_fra_config(
+            {
+                "resultatregnskap": {
+                    "finansposter": {"utbytte_fra_datterselskap": 1000000}
+                },
+                "skattemelding": {
+                    "anvend_fritaksmetoden": True,
+                    "eierandel_for_fritaksmetoden": 80,
+                },
+            }
+        )
+        # 3 % av 1 000 000 er skattepliktig, 22 % av 30 000 = 6 600.
+        assert beregning.skattepliktig_utbytte == 30000
+        assert beregning.beregnet_skatt == 6600
+
+    def test_foert_skattekostnad_returneres(self):
+        _, foert = sm.beregn_skatt_fra_config(
+            {"resultatregnskap": {"skattekostnad": 11000}}
+        )
+        assert foert == 11000
+
+
+class TestAdvarsler:
+    def test_advarer_naar_skattekostnad_mangler_motpost(self, regnskap_med_skattekostnad):
+        kg = regnskap_med_skattekostnad.balanse.egenkapital_og_gjeld.kortsiktig_gjeld
+        kg.betalbar_skatt = 0
+        # Hold balansen i orden, slik at det er motposten (ikke balansen) som varsles.
+        regnskap_med_skattekostnad.balanse.eiendeler.omloepmidler.bankinnskudd = 78000
+        adv = ar.advarsler(regnskap_med_skattekostnad)
+        assert any("betalbar skatt" in a.lower() for a in adv)
+
+    def test_ingen_advarsel_naar_motposten_er_paa_plass(self, regnskap_med_skattekostnad):
+        adv = ar.advarsler(regnskap_med_skattekostnad)
+        assert not any("betalbar skatt" in a.lower() for a in adv)

--- a/tests/test_xsd_validering.py
+++ b/tests/test_xsd_validering.py
@@ -90,6 +90,55 @@ class TestNaeringsspesifikasjonXsd:
             f"Feil rekkefølge i gjeldOgEgenkapital: {barn}"
         )
 
+    def test_validerer_med_skattekostnad(self, regnskap_med_skattekostnad):
+        # Skattekostnad (8300) og betalbar skatt (2500) er nye elementer i sekvensene
+        # Resultatregnskap og KortsiktigGjeld. XSD-en er fasit på plasseringen:
+        # sumSkattekostnad før finansinntekt, skattekostnad etter finanskostnad.
+        xml = generer_naeringsspesifikasjon(regnskap_med_skattekostnad, _PARTSNUMMER)
+        _valider(xml, "naeringsspesifikasjon_v6_ekstern.xsd")
+
+    def test_resultatregnskap_rekkefolge_med_skattekostnad(self, regnskap_med_skattekostnad):
+        xml = generer_naeringsspesifikasjon(regnskap_med_skattekostnad, _PARTSNUMMER)
+        root = etree.fromstring(xml)
+        res = root.find(f".//{_NS_NS}resultatregnskap")
+        barn = [c.tag.replace(_NS_NS, "") for c in res]
+        forventet = ["sumSkattekostnad", "finansinntekt", "skattekostnad", "aarsresultat"]
+        posisjoner = [barn.index(navn) for navn in forventet if navn in barn]
+        assert posisjoner == sorted(posisjoner), f"Feil rekkefølge i resultatregnskap: {barn}"
+        assert set(forventet) <= set(barn), f"Manglende elementer: {barn}"
+
+    def test_validerer_med_fritaksmetodens_forskjeller(self, regnskap_med_utbytte):
+        # Tre permanente forskjeller samtidig (skattekostnad, tilbakeført utbytte,
+        # 3 %-sjablonen) med begge de avledede summene. PermanentForskjell er unbounded,
+        # men rekkefølgen forskjeller-før-summer er bundet av XSD-sekvensen.
+        regnskap_med_utbytte.resultatregnskap.skattekostnad = 660
+        konfig = SkattemeldingKonfig(
+            anvend_fritaksmetoden=True, eierandel_for_fritaksmetoden=80
+        )
+        xml = generer_naeringsspesifikasjon(regnskap_med_utbytte, _PARTSNUMMER, konfig)
+        _valider(xml, "naeringsspesifikasjon_v6_ekstern.xsd")
+        root = etree.fromstring(xml)
+        forskjell = root.find(f".//{_NS_NS}forskjellMellomRegnskapsmessigOgSkattemessigVerdi")
+        barn = [c.tag.replace(_NS_NS, "") for c in forskjell]
+        assert barn.count("permanentForskjell") == 3, barn
+        assert barn.index("sumTilleggINaeringsinntekt") > max(
+            i for i, n in enumerate(barn) if n == "permanentForskjell"
+        ), barn
+
+    def test_rotsekvens_med_tilbakefoert_skattekostnad(self, regnskap_med_skattekostnad):
+        # forskjellMellomRegnskapsmessigOgSkattemessigVerdi står etter
+        # beregnetNaeringsinntekt og før virksomhet i rot-sekvensen.
+        xml = generer_naeringsspesifikasjon(regnskap_med_skattekostnad, _PARTSNUMMER)
+        root = etree.fromstring(xml)
+        barn = [c.tag.replace(_NS_NS, "") for c in root]
+        forventet = [
+            "beregnetNaeringsinntekt",
+            "forskjellMellomRegnskapsmessigOgSkattemessigVerdi",
+            "virksomhet",
+        ]
+        posisjoner = [barn.index(navn) for navn in forventet]
+        assert posisjoner == sorted(posisjoner), f"Feil rekkefølge i roten: {barn}"
+
     def test_id_er_lik_kode(self, regnskap_med_utbytte):
         # Skatteetaten krever at <id> på hver resultat-/balanseforekomst er lik
         # kodeverdien (resultatOgBalanseregnskapstype), ikke en tilfeldig UUID.

--- a/wenche/aarsregnskap.py
+++ b/wenche/aarsregnskap.py
@@ -58,6 +58,7 @@ def _les_resultat(r: dict) -> Resultatregnskap:
             rentekostnader=_tall(fp.get("rentekostnader")),
             andre_finanskostnader=_tall(fp.get("andre_finanskostnader")),
         ),
+        skattekostnad=_tall(r.get("skattekostnad")),
     )
 
 
@@ -93,6 +94,7 @@ def _les_balanse(b: dict) -> Balanse:
             ),
             kortsiktig_gjeld=KortsiktigGjeld(
                 leverandoergjeld=_tall(kg.get("leverandoergjeld")),
+                betalbar_skatt=_tall(kg.get("betalbar_skatt")),
                 skyldige_offentlige_avgifter=_tall(kg.get("skyldige_offentlige_avgifter")),
                 annen_kortsiktig_gjeld=_tall(kg.get("annen_kortsiktig_gjeld")),
             ),
@@ -185,6 +187,21 @@ def advarsler(regnskap: Aarsregnskap) -> list[str]:
             "NOK). Utbytte kan bare deles ut av fri egenkapital (aksjeloven § 8-1). "
             "Kontroller at utbetalingen faktisk er utbytte og ikke f.eks. lån til "
             "aksjonær eller tilbakebetaling av innbetalt kapital."
+        )
+
+    # Skattekostnaden i resultatregnskapet har en motpost i balansen: er skatten ikke
+    # betalt ved årsslutt (normaltilfellet, den forfaller året etter), skal den stå som
+    # betalbar skatt under kortsiktig gjeld. Er den ført som kostnad uten å stå noe sted i
+    # balansen, mangler enten gjelden eller en tilsvarende reduksjon i bankinnskuddet.
+    # (Ikke-blokkerende: skatten kan være betalt i året, og da er det bankinnskuddet som er
+    # redusert. Balansekontrollen i valider() fanger opp om totalene ikke går opp.)
+    kg = regnskap.balanse.egenkapital_og_gjeld.kortsiktig_gjeld
+    if regnskap.resultatregnskap.skattekostnad > 0.01 and kg.betalbar_skatt < 0.01:
+        adv.append(
+            f"Det er ført en skattekostnad "
+            f"({regnskap.resultatregnskap.skattekostnad:,.0f} NOK), men betalbar skatt "
+            "står ikke i balansen. Er skatten ikke betalt ved årsslutt, skal den føres "
+            "som «Betalbar skatt» under kortsiktig gjeld (konto 2500)."
         )
 
     # Sammenligningstall for fjoråret er påkrevd etter regnskapsloven § 6-6 for

--- a/wenche/aarsregnskap.py
+++ b/wenche/aarsregnskap.py
@@ -2,6 +2,8 @@
 Innsending av årsregnskap til Brønnøysundregistrene via Altinn 3.
 """
 
+from datetime import date
+
 import yaml
 
 from wenche.altinn_client import AltinnClient
@@ -34,6 +36,22 @@ def _tall(verdi) -> float:
     if verdi is None or (isinstance(verdi, str) and not verdi.strip()):
         return 0.0
     return float(verdi)
+
+
+def _dato(verdi) -> date | None:
+    """Tolererer tomme og manglende datofelt som None, ellers en date.
+
+    YAML tolker en naken YYYY-MM-DD som date, mens skjemaet sender streng. Begge godtas.
+    En ugyldig dato blir en lesbar feil, ikke en naken ValueError fra fromisoformat.
+    """
+    if verdi is None or (isinstance(verdi, str) and not verdi.strip()):
+        return None
+    if isinstance(verdi, date):
+        return verdi
+    try:
+        return date.fromisoformat(str(verdi).strip())
+    except ValueError:
+        raise ValueError(f"«{verdi}» er ikke en gyldig dato. Bruk formatet ÅÅÅÅ-MM-DD.")
 
 
 def _les_resultat(r: dict) -> Resultatregnskap:
@@ -119,6 +137,7 @@ def les_config(config_fil: str | dict) -> Aarsregnskap:
         forretningsadresse=s["forretningsadresse"],
         stiftelsesaar=s["stiftelsesaar"],
         aksjekapital=s["aksjekapital"],
+        stiftelsesdato=_dato(s.get("stiftelsesdato")),
     )
 
     resultat = _les_resultat(cfg["resultatregnskap"])
@@ -140,6 +159,8 @@ def les_config(config_fil: str | dict) -> Aarsregnskap:
         foregaaende_aar_resultat=foregaaende_resultat,
         foregaaende_aar_balanse=foregaaende_balanse,
         utbytte_utbetalt=utbytte_utbetalt,
+        regnskapsstart=_dato(cfg.get("regnskapsstart")),
+        regnskapsslutt=_dato(cfg.get("regnskapsslutt")),
     )
 
 
@@ -159,6 +180,49 @@ def valider(regnskap: Aarsregnskap) -> list[str]:
 
     if len(regnskap.selskap.org_nummer.replace(" ", "")) != 9:
         feil.append("Organisasjonsnummeret må være 9 siffer.")
+
+    feil.extend(_valider_periode(regnskap))
+
+    return feil
+
+
+def _valider_periode(regnskap: Aarsregnskap) -> list[str]:
+    """
+    Kontrollerer regnskapsperioden. Tom liste betyr OK.
+
+    Perioden er normalt kalenderåret (rskl. § 1-7 første ledd). Andre ledd åpner for et
+    forlenget første regnskapsår på inntil 18 måneder ved oppstart, og da må start- og
+    sluttdato oppgis. Reglene her er de som må holde for at både Brønnøysund og
+    Skatteetaten skal kunne tolke perioden entydig.
+    """
+    feil = []
+    start, slutt = regnskap.periode_start, regnskap.periode_slutt
+
+    if slutt < start:
+        feil.append(
+            f"Regnskapsperioden slutter før den starter ({start.isoformat()} til "
+            f"{slutt.isoformat()}). Kontroller regnskapsstart og regnskapsslutt."
+        )
+        return feil  # De øvrige kontrollene er meningsløse på en snudd periode.
+
+    if regnskap.periode_maaneder > 18:
+        feil.append(
+            f"Regnskapsperioden er {regnskap.periode_maaneder} måneder "
+            f"({start.isoformat()} til {slutt.isoformat()}). Regnskapsloven § 1-7 tillater "
+            "inntil 18 måneder, og bare for det første regnskapsåret."
+        )
+
+    if (slutt.month, slutt.day) != (12, 31):
+        feil.append(
+            f"Regnskapsperioden slutter {slutt.isoformat()}, ikke 31. desember. Wenche "
+            "støtter bare regnskapsår som avsluttes ved kalenderårets slutt."
+        )
+
+    if slutt.year != regnskap.regnskapsaar:
+        feil.append(
+            f"Regnskapsåret er oppgitt som {regnskap.regnskapsaar}, men perioden avsluttes i "
+            f"{slutt.year}. Regnskapsåret skal være året perioden avsluttes."
+        )
 
     return feil
 
@@ -204,15 +268,48 @@ def advarsler(regnskap: Aarsregnskap) -> list[str]:
             "som «Betalbar skatt» under kortsiktig gjeld (konto 2500)."
         )
 
+    # Et forlenget første regnskapsår skal starte på stiftelsesdatoen (rskl. § 1-7 andre
+    # ledd). Avviker de to, er sannsynligvis én av dem feil skrevet inn.
+    stiftet = regnskap.selskap.stiftelsesdato
+    if stiftet and regnskap.regnskapsstart and regnskap.regnskapsstart != stiftet:
+        adv.append(
+            f"Regnskapsperioden starter {regnskap.regnskapsstart.isoformat()}, men selskapet "
+            f"ble stiftet {stiftet.isoformat()}. Et forlenget første regnskapsår løper fra "
+            "stiftelsesdatoen. Kontroller datoene."
+        )
+
+    # En periode over 12 måneder er lovlig for det første regnskapsåret, og Skatteetaten
+    # godtar den (validertOK mot tt02 2026-08-05 for en 14-måneders periode, med inntektsår
+    # lik året perioden avsluttes). Advarselen står likevel: dette er et sjeldent tilfelle,
+    # og hele perioden fastsettes da i ett inntektsår.
+    if regnskap.periode_maaneder > 12:
+        adv.append(
+            f"Regnskapsperioden er {regnskap.periode_maaneder} måneder "
+            f"({regnskap.periode_start.isoformat()} til {regnskap.periode_slutt.isoformat()}), "
+            f"altså et forlenget første regnskapsår. Hele perioden fastsettes i inntektsår "
+            f"{regnskap.regnskapsaar}. Kontroller at det stemmer med det selskapet har avtalt "
+            "med Skatteetaten."
+        )
+
     # Sammenligningstall for fjoråret er påkrevd etter regnskapsloven § 6-6 for
     # selskaper som ikke er nystiftet. Et selskap stiftet før regnskapsåret skal
     # ha et fjorår å sammenligne med; er fjorårstallene helt tomme, mangler de
     # sannsynligvis. (Ikke-blokkerende: et genuint hvilende selskap kan ha hatt
     # reelt null i fjor, så dette er et varsku, ikke en hard feil.)
+    #
+    # Unntaket er et forlenget første regnskapsår: det spenner over to kalenderår, så
+    # stiftelsesåret er lavere enn regnskapsåret selv om dette ER det første regnskapsåret og
+    # det ikke finnes noe fjorår å sammenligne med. Uten unntaket ba Wenche om
+    # sammenligningstall som ikke eksisterer.
     stiftelsesaar = regnskap.selskap.stiftelsesaar
     fb = regnskap.foregaaende_aar_balanse
     fjoraar_tomt = abs(fb.eiendeler.sum) < 0.01 and abs(fb.egenkapital_og_gjeld.sum) < 0.01
-    if stiftelsesaar and stiftelsesaar < regnskap.regnskapsaar and fjoraar_tomt:
+    stiftet_i_perioden = bool(
+        regnskap.selskap.stiftelsesdato
+        and regnskap.periode_start <= regnskap.selskap.stiftelsesdato <= regnskap.periode_slutt
+    )
+    foerste_regnskapsaar = stiftelsesaar >= regnskap.regnskapsaar or stiftet_i_perioden
+    if stiftelsesaar and not foerste_regnskapsaar and fjoraar_tomt:
         adv.append(
             f"Selskapet ble stiftet i {stiftelsesaar}, men det er ikke oppgitt "
             f"sammenligningstall for fjoråret ({regnskap.regnskapsaar - 1}). "

--- a/wenche/aksjonaerregister.py
+++ b/wenche/aksjonaerregister.py
@@ -25,6 +25,19 @@ from wenche.skd_client import SkdAksjonaerClient
 _BRG_ENHET_URL = "https://data.brreg.no/enhetsregisteret/api/enheter"
 
 
+def _stiftelsestidspunkt(selskap: Selskap) -> str:
+    """
+    Stiftelsestidspunkt for RF-1086, som ISO-datetime.
+
+    Bruker den eksakte stiftelsesdatoen når den er kjent (Enhetsregisteret har den), og faller
+    ellers tilbake på 1. januar i stiftelsesåret. Fallbacket er en tilnærming: for et selskap
+    stiftet sent på året oppgav Wenche før 1. januar selv om registeret hadde riktig dato.
+    """
+    if selskap.stiftelsesdato:
+        return f"{selskap.stiftelsesdato.isoformat()}T00:00:00"
+    return f"{selskap.stiftelsesaar}-01-01T00:00:00"
+
+
 def _format_paalydende(verdi: float) -> str:
     """
     Formater pålydende per aksje for RF-1086-XMLen.
@@ -103,7 +116,7 @@ def generer_hovedskjema_xml(
         if totalt_aksjer > 0
         else "0"
     )
-    stiftelsesdato = f"{s.stiftelsesaar}-01-01T00:00:00"
+    stiftelsesdato = _stiftelsestidspunkt(s)
 
     # Fjorår-felter og stiftelsestransaksjon skal kun inkluderes i stiftelsesåret.
     # For påfølgende år er beholdningen uendret fra foregående år, og SKDs MTRA_004-regel
@@ -206,7 +219,7 @@ def generer_underskjema_xml(
     org = innsending_org or s.org_nummer
     aar = oppgave.regnskapsaar
     anskaffelsesverdi = round(aksjonaer.innbetalt_kapital_per_aksje * aksjonaer.antall_aksjer)
-    stiftelsesdato = f"{s.stiftelsesaar}-01-01T00:00:00"
+    stiftelsesdato = _stiftelsestidspunkt(s)
 
     # Transaksjoner skal kun inkluderes hvis stiftelsesåret er inntektsåret.
     # For påfølgende år er det ingen transaksjon — aksjonæren hadde samme beholdning

--- a/wenche/brg_xml.py
+++ b/wenche/brg_xml.py
@@ -129,8 +129,8 @@ def generer_hovedskjema(regnskap: Aarsregnskap) -> bytes:
   <Skjemainnhold>
     <regnskapsperiode>
       <regnskapsaar orid="17102">{aar}</regnskapsaar>
-      <regnskapsstart orid="17103">{aar}-01-01</regnskapsstart>
-      <regnskapsslutt orid="17104">{aar}-12-31</regnskapsslutt>
+      <regnskapsstart orid="17103">{regnskap.periode_start.isoformat()}</regnskapsstart>
+      <regnskapsslutt orid="17104">{regnskap.periode_slutt.isoformat()}</regnskapsslutt>
     </regnskapsperiode>
     <konsern>
       <morselskap orid="4168">{morselskap}</morselskap>

--- a/wenche/brg_xml.py
+++ b/wenche/brg_xml.py
@@ -299,6 +299,7 @@ def generer_underskjema(regnskap: Aarsregnskap) -> bytes:
           <aarets orid="167">{_i(r.resultat_foer_skatt)}</aarets>
           <fjoraarets orid="7042">{_i(fr.resultat_foer_skatt)}</fjoraarets>
         </resultatFoerSkattekostnad>
+        {linje("skattekostnad", r.skattekostnad, "Skattekostnad på ordinært resultat", "29013", "11835", "11836", fr.skattekostnad)}
         <aarsresultat>
           <aarets orid="172">{_i(r.aarsresultat)}</aarets>
           <fjoraarets orid="7054">{_i(fr.aarsresultat)}</fjoraarets>
@@ -408,6 +409,7 @@ def generer_underskjema(regnskap: Aarsregnskap) -> bytes:
         </balanseGjeldAvsetningerForpliktelserAnnenLangsiktigGjeld>
         <balanseKortsiktigGjeld>
           {linje_enkel("leverandoergjeld", kg.leverandoergjeld, "220", "7162", fkg.leverandoergjeld)}
+          {linje("betalbarSkatt", kg.betalbar_skatt, "Betalbar skatt", "29038", "2483", "10293", fkg.betalbar_skatt)}
           {linje("skyldigeOffentligeAvgifter", kg.skyldige_offentlige_avgifter, "Skyldige offentlige avgifter", "29039", "225", "7170", fkg.skyldige_offentlige_avgifter)}
           {linje("annenKortsiktigGjeld", kg.annen_kortsiktig_gjeld, "Annen kortsiktig gjeld", "29040", "236", "7182", fkg.annen_kortsiktig_gjeld)}
           <sumKortsiktigGjeld>

--- a/wenche/brreg.py
+++ b/wenche/brreg.py
@@ -9,6 +9,8 @@ sin selvbetjenings-navnematch, som beholder en strengere feilkontrakt (se hosted
 """
 from __future__ import annotations
 
+from datetime import date
+
 import httpx
 
 _BASE = "https://data.brreg.no/enhetsregisteret/api/enheter"
@@ -62,6 +64,21 @@ def parse_stiftelsesaar(data: dict) -> int:
         return 0
 
 
+def parse_stiftelsesdato(data: dict) -> str:
+    """
+    Hele `stiftelsesdato` (YYYY-MM-DD) fra et enhets-svar. Tom streng om ukjent eller ugyldig.
+
+    Årstallet alene er ikke nok: aksjonærregisteroppgaven oppgir stiftelsesdato, og et
+    forlenget første regnskapsår starter på stiftelsesdatoen. Begge ble før satt til 1. januar
+    fordi oppslaget kastet bort dag og måned.
+    """
+    stiftelsesdato = (data.get("stiftelsesdato") or "").strip()
+    try:
+        return date.fromisoformat(stiftelsesdato).isoformat()
+    except ValueError:
+        return ""
+
+
 def _format_adresse(adr: dict) -> str:
     """Sett sammen brregs strukturerte forretningsadresse til én linje, f.eks.
     «Kong Carls gate 29, 4010 STAVANGER». Tom streng om adressen mangler."""
@@ -78,6 +95,7 @@ def parse_enhet(data: dict) -> dict:
         "navn": data.get("navn") or "",
         "forretningsadresse": _format_adresse(data.get("forretningsadresse") or {}),
         "stiftelsesaar": parse_stiftelsesaar(data),
+        "stiftelsesdato": parse_stiftelsesdato(data),
     }
 
 
@@ -103,4 +121,6 @@ def hent_roller(orgnr: str, *, timeout: float = 5.0) -> dict:
 def hent_enhet(orgnr: str, *, timeout: float = 5.0) -> dict:
     """Navn, forretningsadresse og stiftelsesår for orgnr fra Enhetsregisteret. Fail-soft (tomt ved feil)."""
     data = _hent_json(f"{_BASE}/{orgnr}", timeout)
-    return parse_enhet(data) if data else {"navn": "", "forretningsadresse": "", "stiftelsesaar": 0}
+    if not data:
+        return {"navn": "", "forretningsadresse": "", "stiftelsesaar": 0, "stiftelsesdato": ""}
+    return parse_enhet(data)

--- a/wenche/cli.py
+++ b/wenche/cli.py
@@ -408,7 +408,7 @@ def send_skattemelding(config_fil: str, dry_run: bool):
         click.echo(f"Partsnummer: {partsnummer}")
 
         skattemelding_xml = generer_skattemelding_fra_konfig(regnskap, konfig, partsnummer)
-        naeringsspesifikasjon_xml = generer_naeringsspesifikasjon(regnskap, partsnummer)
+        naeringsspesifikasjon_xml = generer_naeringsspesifikasjon(regnskap, partsnummer, konfig)
 
         if dry_run:
             ut_fil = Path("skattemelding.xml")
@@ -497,7 +497,7 @@ def valider_skattemelding(config_fil: str):
         click.echo(f"Partsnummer: {partsnummer}")
 
         skattemelding_xml = generer_skattemelding_fra_konfig(regnskap, konfig, partsnummer)
-        naeringsspesifikasjon_xml = generer_naeringsspesifikasjon(regnskap, partsnummer)
+        naeringsspesifikasjon_xml = generer_naeringsspesifikasjon(regnskap, partsnummer, konfig)
         konvolutt = generer_konvolutt(
             skattemelding_xml=skattemelding_xml,
             inntektsaar=regnskap.regnskapsaar,

--- a/wenche/innsending.py
+++ b/wenche/innsending.py
@@ -121,7 +121,7 @@ def send_skattemelding(
                 "Skatteetaten ennå. Prøv igjen senere, eller ta kontakt."
             ) from e
     skattemelding_xml = generer_skattemelding_fra_konfig(regnskap, konfig, partsnummer)
-    naeringsspesifikasjon_xml = generer_naeringsspesifikasjon(regnskap, partsnummer)
+    naeringsspesifikasjon_xml = generer_naeringsspesifikasjon(regnskap, partsnummer, konfig)
     instans_id = skd_klient.send(
         inntektsaar=regnskap.regnskapsaar,
         orgnr=orgnr,

--- a/wenche/models.py
+++ b/wenche/models.py
@@ -73,6 +73,11 @@ class Resultatregnskap:
     driftsinntekter: Driftsinntekter = field(default_factory=Driftsinntekter)
     driftskostnader: Driftskostnader = field(default_factory=Driftskostnader)
     finansposter: Finansposter = field(default_factory=Finansposter)
+    # Skattekostnad på ordinært resultat, oppgitt som positiv kostnad (rskl. § 6-1 nr. 19).
+    # Egen linje fordi oppstillingsplanen krever den mellom resultat før skatt og årsresultat.
+    # 0 for et selskap uten skattepliktig inntekt (typisk holding med bare fritatt utbytte),
+    # men et selskap med renteinntekt har en reell skattekostnad som må stå her.
+    skattekostnad: float = 0.0
 
     @property
     def driftsresultat(self) -> float:
@@ -88,7 +93,7 @@ class Resultatregnskap:
 
     @property
     def aarsresultat(self) -> float:
-        return self.resultat_foer_skatt  # Skattekostnad = 0 for holdingselskap uten skattbar inntekt
+        return self.resultat_foer_skatt - self.skattekostnad
 
 
 # ---------------------------------------------------------------------------
@@ -150,6 +155,10 @@ class LangsiktigGjeld:
 @dataclass
 class KortsiktigGjeld:
     leverandoergjeld: float = 0.0
+    # Betalbar skatt, ikke fastsatt (konto 2500). Motposten til skattekostnaden i
+    # resultatregnskapet: uten denne linjen har et selskap med skattepliktig inntekt
+    # ingen riktig plass å føre skattegjelden, og balansen går ikke opp.
+    betalbar_skatt: float = 0.0
     skyldige_offentlige_avgifter: float = 0.0
     annen_kortsiktig_gjeld: float = 0.0
 
@@ -157,6 +166,7 @@ class KortsiktigGjeld:
     def sum(self) -> float:
         return (
             self.leverandoergjeld
+            + self.betalbar_skatt
             + self.skyldige_offentlige_avgifter
             + self.annen_kortsiktig_gjeld
         )

--- a/wenche/models.py
+++ b/wenche/models.py
@@ -25,6 +25,10 @@ class Selskap:
     stiftelsesaar: int
     aksjekapital: float
     kontakt_epost: str = ""     # Påkrevd for aksjonærregisteroppgave (RF-1086)
+    # Eksakt stiftelsesdato når den er kjent (hentes fra Enhetsregisteret). Årstallet alene
+    # holder ikke overalt: aksjonærregisteroppgaven oppgir stiftelsesdato, og et forlenget
+    # første regnskapsår starter på stiftelsesdatoen, ikke 1. januar.
+    stiftelsesdato: Optional[date] = None
 
 
 # ---------------------------------------------------------------------------
@@ -215,6 +219,28 @@ class Aarsregnskap:
     foregaaende_aar_resultat: Resultatregnskap = field(default_factory=Resultatregnskap)
     foregaaende_aar_balanse: Balanse = field(default_factory=Balanse)
     utbytte_utbetalt: float = 0.0              # Totalt utbytte utbetalt til aksjonærer i løpet av året
+    # Regnskapsperioden. Normalt hele kalenderåret (rskl. § 1-7 første ledd), og da kan begge
+    # stå tomme. Settes bare når perioden avviker, i praksis et forlenget første regnskapsår
+    # etter § 1-7 andre ledd: da starter perioden på stiftelsesdatoen og kan løpe i inntil
+    # 18 måneder, fram til 31.12 året etter.
+    regnskapsstart: Optional[date] = None
+    regnskapsslutt: Optional[date] = None
+
+    @property
+    def periode_start(self) -> date:
+        """Første dag i regnskapsperioden. 1. januar med mindre noe annet er oppgitt."""
+        return self.regnskapsstart or date(self.regnskapsaar, 1, 1)
+
+    @property
+    def periode_slutt(self) -> date:
+        """Siste dag i regnskapsperioden. 31. desember med mindre noe annet er oppgitt."""
+        return self.regnskapsslutt or date(self.regnskapsaar, 12, 31)
+
+    @property
+    def periode_maaneder(self) -> int:
+        """Antall kalendermåneder perioden berører. 12 for et vanlig regnskapsår."""
+        start, slutt = self.periode_start, self.periode_slutt
+        return (slutt.year * 12 + slutt.month) - (start.year * 12 + start.month) + 1
 
 
 # ---------------------------------------------------------------------------

--- a/wenche/naeringsspesifikasjon_xml.py
+++ b/wenche/naeringsspesifikasjon_xml.py
@@ -455,9 +455,9 @@ def generer_naeringsspesifikasjon(
 
     regnskapsperiode = SubElement(virksomhet, "regnskapsperiode")
     start = SubElement(regnskapsperiode, "start")
-    SubElement(start, "dato").text = f"{regnskap.regnskapsaar}-01-01"
+    SubElement(start, "dato").text = regnskap.periode_start.isoformat()
     slutt = SubElement(regnskapsperiode, "slutt")
-    SubElement(slutt, "dato").text = f"{regnskap.regnskapsaar}-12-31"
+    SubElement(slutt, "dato").text = regnskap.periode_slutt.isoformat()
 
     vt = SubElement(virksomhet, "virksomhetstype")
     SubElement(vt, "virksomhetstype").text = "oevrigSelskap"

--- a/wenche/naeringsspesifikasjon_xml.py
+++ b/wenche/naeringsspesifikasjon_xml.py
@@ -20,20 +20,23 @@ Implementasjonen dekker en typisk norsk holding AS med:
   - Lønnskostnader (5000), avskrivninger (6000), andre driftskostnader (6700)
   - Finansinntekter: utbytte fra datterselskap (8090), andre (8050)
   - Finanskostnader: rentekostnader (8150), andre (8160)
+  - Skattekostnad: betalbar skatt på ordinært resultat (8300), tilbakeført som
+    permanent forskjell (positivSkattekostnad, kodeliste 2025_permanentForskjellstype)
   - Anleggsmidler: aksjer i datterselskap (1313), andre aksjer (1350),
     langsiktige fordringer (1390)
   - Omløpsmidler: kortsiktige fordringer (1500), bankinnskudd (1920)
   - Egenkapital: aksjekapital (2000), overkurs (2020), annen (2050/2080)
   - Langsiktig gjeld: gjeld til eiere (2250), annen (2290)
-  - Kortsiktig gjeld: leverandørgjeld (2400), offentlige avgifter (2600),
-    annen (2990)
+  - Kortsiktig gjeld: leverandørgjeld (2400), betalbar skatt (2500),
+    offentlige avgifter (2600), annen (2990)
 """
 
 from __future__ import annotations
 
 from xml.etree.ElementTree import Element, SubElement, tostring
 
-from wenche.models import Aarsregnskap
+from wenche.models import Aarsregnskap, SkattemeldingKonfig
+from wenche.skatteberegning import beregn_skatt
 
 _NS = (
     "urn:no:skatteetaten:fastsetting:formueinntekt:"
@@ -116,6 +119,7 @@ def _balanseforekomst(
 def generer_naeringsspesifikasjon(
     regnskap: Aarsregnskap,
     partsnummer: int,
+    konfig: SkattemeldingKonfig | None = None,
 ) -> bytes:
     """
     Genererer naeringsspesifikasjon XML for innsending til Skatteetaten.
@@ -128,10 +132,17 @@ def generer_naeringsspesifikasjon(
     Args:
         regnskap:     Årsregnskap med resultatregnskap og balanse.
         partsnummer:  Skatteetatens interne partsnummer (fra forhåndsutfylt API).
+        konfig:       Skattemelding-konfigurasjonen. Nødvendig fordi det skattemessige
+                      resultatet avhenger av fritaksmetoden og eierandelen: uten den
+                      ville næringsspesifikasjonen oppgitt brutto utbytte som
+                      skattepliktig inntekt. Utelates den, brukes standardvalgene
+                      (fritaksmetoden på, 100 % eierandel).
 
     Returns:
         XML-bytes klar for innpakking i konvolutt via generer_konvolutt().
     """
+    konfig = konfig or SkattemeldingKonfig()
+    beregning = beregn_skatt(regnskap.resultatregnskap, konfig)
     root = Element("naeringsspesifikasjon", xmlns=_NS)
 
     SubElement(root, "partsreferanse").text = str(partsnummer)
@@ -185,6 +196,9 @@ def generer_naeringsspesifikasjon(
         _beloep_element(resultatregnskap, "sumFinansinntekt", fp.sum_inntekter)
     if fp.sum_kostnader:
         _beloep_element(resultatregnskap, "sumFinanskostnad", fp.sum_kostnader)
+    # sumSkattekostnad står etter sumFinanskostnad og før finansinntekt per XSD-sekvensen.
+    if res.skattekostnad:
+        _beloep_element(resultatregnskap, "sumSkattekostnad", res.skattekostnad)
 
     # Finansinntekter
     fi_poster = [
@@ -207,6 +221,11 @@ def generer_naeringsspesifikasjon(
         finanskostnad_el = SubElement(resultatregnskap, "finanskostnad")
         for beloep, kode in fk_poster:
             _resultatforekomst(finanskostnad_el, "kostnad", beloep, kode)
+
+    # Skattekostnad-forekomsten står etter finanskostnad per XSD-sekvensen.
+    if res.skattekostnad:
+        skattekostnad_el = SubElement(resultatregnskap, "skattekostnad")
+        _resultatforekomst(skattekostnad_el, "kostnad", res.skattekostnad, "8300")
 
     # aarsresultat står sist i Resultatregnskap-sekvensen.
     if res.aarsresultat:
@@ -286,6 +305,7 @@ def generer_naeringsspesifikasjon(
     # Kortsiktig gjeld
     kg_poster = [
         (kg.leverandoergjeld, "2400"),
+        (kg.betalbar_skatt, "2500"),
         (kg.skyldige_offentlige_avgifter, "2600"),
         (kg.annen_kortsiktig_gjeld, "2990"),
     ]
@@ -322,21 +342,108 @@ def generer_naeringsspesifikasjon(
     # -----------------------------------------------------------------------
     # BeregnetNaeringsinntekt (XSD-pos: etter balanseregnskap, før virksomhet)
     # For et upersonlig skattesubjekt (AS) fordeles skattemessig resultat på
-    # «forekomst 1» (én virksomhet). skattemessigResultat = aarsresultat for
-    # holdingselskap uten skattekostnad. SKD krysstillegger feltet mot
+    # «forekomst 1» (én virksomhet). SKD krysstillegger feltet mot
     # skattemeldingens inntektOgUnderskudd-poster.
+    #
+    # Grunnlaget er den skattepliktige inntekten slik skatteberegningen definerer den,
+    # ikke årsresultatet og ikke resultat før skatt. Forskjellen er reell for et
+    # holdingselskap: utbytte som er fritatt etter fritaksmetoden (sktl. § 2-38) er ikke
+    # skattepliktig inntekt, mens skattekostnaden ikke er fradragsberettiget (§ 6-1).
+    # Én kilde til tallet (skatteberegning.beregn_skatt) gjør at næringsspesifikasjonen
+    # og skatteberegningen ikke kan sprike.
+    #
+    # SKD utleder sitt eget skattemessige resultat som ÅRSRESULTAT + permanente
+    # forskjeller. Hver forskjell må derfor emitteres eksplisitt nedenfor, ellers
+    # svarer SKD validertMedFeil (avvikNaeringsopplysninger). Verifisert mot tt02
+    # 2026-08-05.
     # -----------------------------------------------------------------------
-    if res.aarsresultat:
+    skattemessig_resultat = beregning.skattepliktig_inntekt_brutto
+    # Emitteres også når resultatet er 0, så lenge det er aktivitet i resultatregnskapet.
+    # Et holdingselskap med bare fritatt utbytte har legitimt 0 i skattepliktig inntekt, og
+    # da savner SKD påstanden vår: de beregner 0 selv og flagger manglerNaeringsopplysninger
+    # (verifisert mot tt02 2026-08-05). Et helt hvilende selskap uten poster i det hele tatt
+    # skal derimot fortsatt utelate seksjonen, for der forventer ikke SKD den, og innsendingen
+    # er ren uten avvik i dag.
+    har_resultatposter = bool(
+        res.driftsinntekter.sum
+        or res.driftskostnader.sum
+        or res.finansposter.sum_inntekter
+        or res.finansposter.sum_kostnader
+        or res.skattekostnad
+    )
+    if skattemessig_resultat or har_resultatposter:
         bni_el = SubElement(root, "beregnetNaeringsinntekt")
         fordelt_el = SubElement(
             bni_el, "fordeltBeregnetNaeringsinntektForUpersonligSkattepliktig"
         )
         SubElement(fordelt_el, "id").text = "1"
-        _beloep_element(fordelt_el, "fordeltSkattemessigResultat", res.aarsresultat)
+        _beloep_element(fordelt_el, "fordeltSkattemessigResultat", skattemessig_resultat)
         _beloep_element(
-            fordelt_el, "fordeltSkattemessigResultatEtterKorreksjon", res.aarsresultat
+            fordelt_el,
+            "fordeltSkattemessigResultatEtterKorreksjon",
+            skattemessig_resultat,
         )
-        _beloep_element(bni_el, "skattemessigResultat", res.aarsresultat)
+        _beloep_element(bni_el, "skattemessigResultat", skattemessig_resultat)
+
+    # -----------------------------------------------------------------------
+    # ForskjellMellomRegnskapsmessigOgSkattemessigVerdi
+    # (XSD-pos: etter beregnetNaeringsinntekt, før virksomhet)
+    #
+    # Broen mellom regnskapet og skattegrunnlaget. SKD regner årsresultat + tillegg -
+    # fradrag og krysstjekker mot skattemessigResultat over, så denne seksjonen må
+    # forklare hele differansen. Kodene er hentet fra kodelisten
+    # 2025_permanentForskjellstype, og id settes lik koden (samme krav som for
+    # resultat- og balanseforekomstene, ellers avvik idAvvikerFraKrav).
+    #
+    # To forskjeller er aktuelle for et passivt holdingselskap:
+    #
+    #   Skattekostnaden er ikke fradragsberettiget (sktl. § 6-1) og legges tilbake.
+    #
+    #   Utbytte som er fritatt etter fritaksmetoden (sktl. § 2-38) er inntektsført i
+    #   regnskapet, men er ikke skattepliktig. Hele utbyttet tilbakeføres derfor, og
+    #   den skattepliktige delen legges til igjen: 0 ved eierandel >= 90 %, ellers
+    #   3 %-sjablonen (§ 2-38 sjette ledd). Uten dette paret oppgav
+    #   næringsspesifikasjonen brutto utbytte som skattepliktig inntekt.
+    #
+    # Regnestykket, med utbytte U, skattepliktig del S og skattekostnad K:
+    #   årsresultat + (K + S) - U == resultat før skatt - U + S == skattepliktig inntekt.
+    # -----------------------------------------------------------------------
+    tillegg: list[tuple[str, float]] = []
+    fradrag: list[tuple[str, float]] = []
+
+    if res.skattekostnad > 0:
+        tillegg.append(("positivSkattekostnad", res.skattekostnad))
+    elif res.skattekostnad < 0:
+        fradrag.append(("negativSkattekostnad", abs(res.skattekostnad)))
+
+    # Bare når fritaksmetoden faktisk er anvendt: er den av, er utbyttet skattepliktig i
+    # sin helhet, og et par som nullet hverandre ut ville bare vært støy i innsendingen.
+    utbytte = res.finansposter.utbytte_fra_datterselskap
+    if konfig.anvend_fritaksmetoden and utbytte > 0:
+        fradrag.append(("tilbakefoeringAvInntektsfoertUtbytte", utbytte))
+        if beregning.skattepliktig_utbytte > 0:
+            tillegg.append(
+                ("skattepliktigDelAvUtbytterOgUtdelinger", beregning.skattepliktig_utbytte)
+            )
+
+    if tillegg or fradrag:
+        forskjell_el = SubElement(root, "forskjellMellomRegnskapsmessigOgSkattemessigVerdi")
+        # Alle permanentForskjell-elementene først, så de avledede summene, per XSD-sekvensen.
+        for kode, beloep in tillegg + fradrag:
+            perm_el = SubElement(forskjell_el, "permanentForskjell")
+            SubElement(perm_el, "id").text = kode
+            type_el = SubElement(perm_el, "permanentForskjellstype")
+            SubElement(type_el, "permanentForskjellstype").text = kode
+            _beloep_element(perm_el, "beloep", beloep)
+        # Avledede summer, emitteres eksplisitt som de øvrige (jf. modulens docstring).
+        if tillegg:
+            _beloep_element(
+                forskjell_el, "sumTilleggINaeringsinntekt", sum(b for _, b in tillegg)
+            )
+        if fradrag:
+            _beloep_element(
+                forskjell_el, "sumFradragINaeringsinntekt", sum(b for _, b in fradrag)
+            )
 
     # -----------------------------------------------------------------------
     # Virksomhet (obligatorisk)

--- a/wenche/saft.py
+++ b/wenche/saft.py
@@ -54,14 +54,27 @@ def _aapning_netto(account: ET.Element) -> float:
     return _tall(account, "OpeningDebitBalance") - _tall(account, "OpeningCreditBalance")
 
 
+def _er_betalbar_skatt(code: str) -> bool:
+    """
+    True for GroupingCode som tilsvarer betalbar selskapsskatt: 2500 (ikke fastsatt) og
+    2510 (fastsatt), med underkontoer. Egen linje i balansen fordi den er motposten til
+    skattekostnaden i resultatregnskapet; tidligere havnet den i skyldige offentlige avgifter.
+    """
+    try:
+        return 2500 <= int(code) <= 2519
+    except ValueError:
+        return False
+
+
 def _er_offentlig_avgift(code: str) -> bool:
     """
     True for GroupingCode som tilsvarer skyldige offentlige avgifter:
-    2500–2599 (betalbar skatt, forskuddsskatt) og 2700–2799 (MVA, aga, skattetrekk).
+    2520–2599 (forskuddsskatt o.l.) og 2700–2799 (MVA, aga, skattetrekk).
+    Betalbar selskapsskatt (2500–2519) har egen linje, se _er_betalbar_skatt.
     """
     try:
         c = int(code)
-        return 2500 <= c <= 2599 or 2700 <= c <= 2799
+        return 2520 <= c <= 2599 or 2700 <= c <= 2799
     except ValueError:
         return False
 
@@ -77,6 +90,7 @@ def _tom_akkumulator() -> dict:
         "andre_finansinntekter": 0.0,
         "rentekostnader": 0.0,
         "andre_finanskostnader": 0.0,
+        "skattekostnad": 0.0,
         "aksjer_i_datterselskap": 0.0,
         "andre_aksjer": 0.0,
         "langsiktige_fordringer": 0.0,
@@ -88,6 +102,7 @@ def _tom_akkumulator() -> dict:
         "laan_fra_aksjonaer": 0.0,
         "andre_langsiktige_laan": 0.0,
         "leverandoergjeld": 0.0,
+        "betalbar_skatt": 0.0,
         "skyldige_offentlige_avgifter": 0.0,
         "annen_kortsiktig_gjeld": 0.0,
     }
@@ -167,10 +182,21 @@ def _akkumuler(acc: dict, account: ET.Element, netto: float) -> None:
     elif cat == "kortsiktigGjeld":
         if code == "2400":
             acc["leverandoergjeld"] += -netto
+        elif _er_betalbar_skatt(code):
+            acc["betalbar_skatt"] += -netto
         elif _er_offentlig_avgift(code):
             acc["skyldige_offentlige_avgifter"] += -netto
         else:
             acc["annen_kortsiktig_gjeld"] += -netto
+
+    # Skattekostnad: 8300 (betalbar skatt på ordinært resultat) og 8321–8324 (utsatt skatt,
+    # avvik fra tidligere år). Kategorinavnet følger næringsspesifikasjonens elementnavn, som
+    # de øvrige kategoriene her. 83-serien tas også på kode alene, siden hele serien i
+    # kodelisten er skatt: uten dette forsvant skattekostnaden stille i importen, og balansen
+    # gikk ikke opp for et selskap med skattepliktig inntekt. Står sist, så en eksplisitt
+    # kategori over alltid vinner.
+    elif cat == "skattekostnad" or code.startswith("83"):
+        acc["skattekostnad"] += netto
 
 
 def _bygg_resultat(acc: dict) -> dict:
@@ -190,6 +216,7 @@ def _bygg_resultat(acc: dict) -> dict:
             "rentekostnader": acc["rentekostnader"],
             "andre_finanskostnader": acc["andre_finanskostnader"],
         },
+        "skattekostnad": acc["skattekostnad"],
     }
 
 
@@ -218,6 +245,7 @@ def _bygg_balanse(acc: dict) -> dict:
             },
             "kortsiktig_gjeld": {
                 "leverandoergjeld": acc["leverandoergjeld"],
+                "betalbar_skatt": acc["betalbar_skatt"],
                 "skyldige_offentlige_avgifter": acc["skyldige_offentlige_avgifter"],
                 "annen_kortsiktig_gjeld": acc["annen_kortsiktig_gjeld"],
             },

--- a/wenche/skatteberegning.py
+++ b/wenche/skatteberegning.py
@@ -1,0 +1,112 @@
+"""
+Skatteberegning for AS (RF-1028).
+
+Egen modul fordi tallene trengs på tre steder som ellers ikke skal kjenne hverandre:
+visningen i skattemelding.py, næringsspesifikasjonens permanente forskjeller, og
+forslaget til skattekostnad-feltet i skjemaet. Én implementasjon, ellers ville de
+kunne drifte fra hverandre, og et sprik her gir en innsending Skatteetaten avviser.
+
+Modulen har bare modeller som avhengighet, aldri XML-generatorer eller lesere, slik at
+den kan importeres fra alle tre uten sykel.
+"""
+
+import math
+from dataclasses import dataclass
+
+from wenche.models import Resultatregnskap, SkattemeldingKonfig
+
+SKATTESATS = 0.22  # 22 % selskapsskatt
+
+
+@dataclass(frozen=True)
+class Skatteberegning:
+    """Resultatet av skatteberegningen (RF-1028). Alle beløp i kroner."""
+
+    utbytte: float                          # Utbytte fra datterselskap, før fritaksmetoden
+    fritatt_utbytte: float                  # Del av utbyttet som er skattefritt
+    skattepliktig_utbytte: float            # Del av utbyttet som er skattepliktig (3 %-sjablon)
+    skattepliktig_inntekt_brutto: float     # Før fradrag for fremført underskudd
+    fradrag_underskudd: float               # Anvendt fremført underskudd
+    skattepliktig_inntekt_netto: float      # Grunnlaget for skatten
+    nytt_underskudd: float                  # Underskudd til fremføring neste år
+    beregnet_skatt: float                   # 22 % av netto skattepliktig inntekt, avrundet opp
+
+
+def beregn_skatt(
+    r: Resultatregnskap, konfig: SkattemeldingKonfig
+) -> Skatteberegning:
+    """
+    Beregner selskapsskatten for inntektsåret (RF-1028).
+
+    Skilt ut fra generer() fordi tallet trengs på flere steder: i visningen, som
+    forslag til skattekostnad-feltet i skjemaet, og i kontrollen av at ført
+    skattekostnad stemmer med beregningen. Én implementasjon, ellers ville
+    forslaget og visningen kunne drifte fra hverandre.
+
+    Tar resultatregnskapet, ikke hele årsregnskapet, slik at forslaget kan hentes
+    fra et skjema der selskapsopplysningene ennå ikke er fylt ut.
+
+    Merk at beregningen ikke er skattekostnaden i regnskapsmessig forstand: den
+    modellerer ikke utsatt skatt, og skattekostnaden føres av brukeren (Wenche er
+    et innsendingsverktøy, ikke en regnskapsfører). Se skattekostnad-feltet i
+    Resultatregnskap.
+    """
+    # Fritaksmetoden (sktl. § 2-38): utbytte fra kvalifiserende selskaper er skattefritt.
+    # Ved eierandel < 90 % gjelder sjablonregelen (§ 2-38 sjette ledd): 3 % er skattepliktig.
+    # Ved eierandel ≥ 90 % er hele utbyttet fritatt (0 % skattepliktig).
+    # Merk: dette er basert på faglig vurdering — sjekk alltid mot gjeldende regelverk.
+    utbytte = r.finansposter.utbytte_fra_datterselskap
+    if konfig.anvend_fritaksmetoden and utbytte > 0:
+        if konfig.eierandel_for_fritaksmetoden >= 90:
+            skattepliktig_utbytte = 0
+            fritatt_utbytte = utbytte
+        else:
+            skattepliktig_utbytte = math.ceil(utbytte * 0.03)
+            fritatt_utbytte = utbytte - skattepliktig_utbytte
+    else:
+        skattepliktig_utbytte = utbytte
+        fritatt_utbytte = 0
+
+    # Skattepliktig inntekt før underskuddsfradrag. Grunnlaget er postene før
+    # skatt: skattekostnaden er ikke fradragsberettiget (sktl. § 6-1).
+    skattepliktig_inntekt_brutto = (
+        r.driftsresultat
+        + skattepliktig_utbytte
+        + r.finansposter.andre_finansinntekter
+        - r.finansposter.sum_kostnader
+    )
+
+    # Fradrag for fremførbart underskudd (kun hvis positiv inntekt)
+    if skattepliktig_inntekt_brutto > 0 and konfig.underskudd_til_fremfoering > 0:
+        fradrag_underskudd = min(
+            konfig.underskudd_til_fremfoering, skattepliktig_inntekt_brutto
+        )
+    else:
+        fradrag_underskudd = 0
+
+    skattepliktig_inntekt_netto = skattepliktig_inntekt_brutto - fradrag_underskudd
+
+    # Underskudd til fremføring neste år
+    if skattepliktig_inntekt_brutto < 0:
+        nytt_underskudd = konfig.underskudd_til_fremfoering + abs(
+            skattepliktig_inntekt_brutto
+        )
+    else:
+        nytt_underskudd = konfig.underskudd_til_fremfoering - fradrag_underskudd
+
+    # Beregnet skatt
+    if skattepliktig_inntekt_netto > 0:
+        beregnet_skatt = math.ceil(skattepliktig_inntekt_netto * SKATTESATS)
+    else:
+        beregnet_skatt = 0
+
+    return Skatteberegning(
+        utbytte=utbytte,
+        fritatt_utbytte=fritatt_utbytte,
+        skattepliktig_utbytte=skattepliktig_utbytte,
+        skattepliktig_inntekt_brutto=skattepliktig_inntekt_brutto,
+        fradrag_underskudd=fradrag_underskudd,
+        skattepliktig_inntekt_netto=skattepliktig_inntekt_netto,
+        nytt_underskudd=nytt_underskudd,
+        beregnet_skatt=beregnet_skatt,
+    )

--- a/wenche/skattemelding.py
+++ b/wenche/skattemelding.py
@@ -8,11 +8,12 @@ Innsending via API krever registrering som systemleverandør hos Skatteetaten.
 Se modulens docstring i skattemelding.py for detaljer.
 """
 
-import math
-
 import yaml
 
 from wenche.aarsregnskap import _les_resultat, _les_balanse, _tall as _belop
+# Re-eksporteres bevisst: kallsteder (endepunkter, tester, CLI) har brukt sm.beregn_skatt
+# og sm.SKATTESATS siden før beregningen fikk egen modul.
+from wenche.skatteberegning import SKATTESATS, Skatteberegning, beregn_skatt
 from wenche.models import (
     Aarsregnskap,
     Balanse,
@@ -30,8 +31,6 @@ from wenche.models import (
     LangsiktigGjeld,
     KortsiktigGjeld,
 )
-
-SKATTESATS = 0.22  # 22 % selskapsskatt
 
 
 # Selskapsfelt skattemeldingen krever (org-nr utledes på annet vis ved innsending). I motsetning
@@ -130,13 +129,20 @@ def les_config(config_fil: str | dict) -> tuple[Aarsregnskap, SkattemeldingKonfi
         utbytte_utbetalt=utbytte_utbetalt,
     )
 
-    # Blanke tallfelt sendes som "" fra skjemaet, så vi tolererer dem (som leserne over) i
-    # stedet for å la float("")/int("") bli en naken 500. Tomt eierandel = 100 % (helt
-    # skattefritt), tom samlet_verdi = ingen overstyring.
-    sm_raw = raw.get("skattemelding", {})
+    return regnskap, _les_skattekonfig(raw)
+
+
+def _les_skattekonfig(raw: dict) -> SkattemeldingKonfig:
+    """Leser skattemelding-seksjonen av config-en.
+
+    Blanke tallfelt sendes som "" fra skjemaet, så vi tolererer dem (som leserne over) i
+    stedet for å la float("")/int("") bli en naken 500. Tomt eierandel = 100 % (helt
+    skattefritt), tom samlet_verdi = ingen overstyring.
+    """
+    sm_raw = raw.get("skattemelding") or {}
     _eierandel = sm_raw.get("eierandel_for_fritaksmetoden")
     _verdi_override = sm_raw.get("samlet_verdi_bak_aksjene")
-    konfig = SkattemeldingKonfig(
+    return SkattemeldingKonfig(
         underskudd_til_fremfoering=_belop(sm_raw.get("underskudd_til_fremfoering")),
         anvend_fritaksmetoden=bool(sm_raw.get("anvend_fritaksmetoden", True)),
         eierandel_for_fritaksmetoden=100 if _er_tom(_eierandel) else int(float(_eierandel)),
@@ -144,8 +150,6 @@ def les_config(config_fil: str | dict) -> tuple[Aarsregnskap, SkattemeldingKonfi
         formuesverdi_aksjer=_belop(sm_raw.get("formuesverdi_aksjer")),
         samlet_verdi_bak_aksjene=None if _er_tom(_verdi_override) else float(_verdi_override),
     )
-
-    return regnskap, konfig
 
 
 def _nok(beloep: float) -> str:
@@ -156,6 +160,19 @@ def _nok(beloep: float) -> str:
 def _nok2(aarets: float, fjoraarets: float) -> str:
     """Formaterer to beløp side om side (inneværende og foregående år)."""
     return f"{round(aarets):>12,} kr   {round(fjoraarets):>12,} kr".replace(",", " ")
+
+
+def beregn_skatt_fra_config(config_fil: str | dict) -> tuple[Skatteberegning, float]:
+    """
+    Beregner skatten direkte fra en config, og returnerer (beregning, ført skattekostnad).
+
+    Leser bare resultatregnskapet og skattemelding-seksjonen, ikke selskapsopplysningene:
+    forslaget hentes fra Tall-steget, der stiftelsesår og aksjekapital godt kan stå tomme
+    ennå. les_config ville kastet på dem.
+    """
+    raw = _raw(config_fil)
+    resultat = _les_resultat(raw.get("resultatregnskap") or {})
+    return beregn_skatt(resultat, _les_skattekonfig(raw)), resultat.skattekostnad
 
 
 def generer(regnskap: Aarsregnskap, konfig: SkattemeldingKonfig) -> str:
@@ -183,54 +200,20 @@ def generer(regnskap: Aarsregnskap, konfig: SkattemeldingKonfig) -> str:
 
     # --- RF-1028: Skatteberegning ---
 
-    # Fritaksmetoden (sktl. § 2-38): utbytte fra kvalifiserende selskaper er skattefritt.
-    # Ved eierandel < 90 % gjelder sjablonregelen (§ 2-38 sjette ledd): 3 % er skattepliktig.
-    # Ved eierandel ≥ 90 % er hele utbyttet fritatt (0 % skattepliktig).
-    # Merk: dette er basert på faglig vurdering — sjekk alltid mot gjeldende regelverk.
-    utbytte = r.finansposter.utbytte_fra_datterselskap
-    if konfig.anvend_fritaksmetoden and utbytte > 0:
-        if konfig.eierandel_for_fritaksmetoden >= 90:
-            skattepliktig_utbytte = 0
-            fritatt_utbytte = utbytte
-        else:
-            skattepliktig_utbytte = math.ceil(utbytte * 0.03)
-            fritatt_utbytte = utbytte - skattepliktig_utbytte
-    else:
-        skattepliktig_utbytte = utbytte
-        fritatt_utbytte = 0
-
-    # Skattepliktig inntekt før underskuddsfradrag
+    beregning = beregn_skatt(r, konfig)
+    utbytte = beregning.utbytte
+    fritatt_utbytte = beregning.fritatt_utbytte
+    skattepliktig_utbytte = beregning.skattepliktig_utbytte
+    skattepliktig_inntekt_brutto = beregning.skattepliktig_inntekt_brutto
+    fradrag_underskudd = beregning.fradrag_underskudd
+    skattepliktig_inntekt_netto = beregning.skattepliktig_inntekt_netto
+    nytt_underskudd = beregning.nytt_underskudd
+    beregnet_skatt = beregning.beregnet_skatt
     andre_finansinntekter = r.finansposter.andre_finansinntekter
-    skattepliktig_inntekt_brutto = (
-        driftsresultat
-        + skattepliktig_utbytte
-        + andre_finansinntekter
-        - fin_kostnader
-    )
 
-    # Fradrag for fremførbart underskudd (kun hvis positiv inntekt)
-    if skattepliktig_inntekt_brutto > 0 and konfig.underskudd_til_fremfoering > 0:
-        fradrag_underskudd = min(
-            konfig.underskudd_til_fremfoering, skattepliktig_inntekt_brutto
-        )
-    else:
-        fradrag_underskudd = 0
-
-    skattepliktig_inntekt_netto = skattepliktig_inntekt_brutto - fradrag_underskudd
-
-    # Underskudd til fremføring neste år
-    if skattepliktig_inntekt_brutto < 0:
-        nytt_underskudd = konfig.underskudd_til_fremfoering + abs(
-            skattepliktig_inntekt_brutto
-        )
-    else:
-        nytt_underskudd = konfig.underskudd_til_fremfoering - fradrag_underskudd
-
-    # Beregnet skatt
-    if skattepliktig_inntekt_netto > 0:
-        beregnet_skatt = math.ceil(skattepliktig_inntekt_netto * SKATTESATS)
-    else:
-        beregnet_skatt = 0
+    # Skattekostnaden som faktisk er ført i regnskapet (rskl. § 6-1 nr. 19). Den, ikke
+    # beregningen, er det som sendes inn; avvik mellom de to varsles nedenfor.
+    skattekostnad = r.skattekostnad
 
     # --- Balansesjekk ---
     i_balanse = b.er_i_balanse()
@@ -270,8 +253,8 @@ def generer(regnskap: Aarsregnskap, konfig: SkattemeldingKonfig) -> str:
         f"    Andre finanskostnader        {_nok(r.finansposter.andre_finanskostnader)}",
         "",
         f"  RESULTAT FØR SKATT             {_nok(resultat_foer_skatt)}",
-        f"  Skattekostnad                  {_nok(-beregnet_skatt)}",
-        f"  ÅRSRESULTAT                    {_nok(resultat_foer_skatt - beregnet_skatt)}",
+        f"  Skattekostnad                  {_nok(-skattekostnad)}",
+        f"  ÅRSRESULTAT                    {_nok(r.aarsresultat)}",
         "",
         linje,
         "  SKATTEMELDING FOR AS",
@@ -354,6 +337,7 @@ def generer(regnskap: Aarsregnskap, konfig: SkattemeldingKonfig) -> str:
         "",
         "    Kortsiktig gjeld:",
         f"      Leverandørgjeld             {_nok(b.egenkapital_og_gjeld.kortsiktig_gjeld.leverandoergjeld)}",
+        f"      Betalbar skatt              {_nok(b.egenkapital_og_gjeld.kortsiktig_gjeld.betalbar_skatt)}",
         f"      Skyldige offentlige avgifter {_nok(b.egenkapital_og_gjeld.kortsiktig_gjeld.skyldige_offentlige_avgifter)}",
         f"      Annen kortsiktig gjeld      {_nok(b.egenkapital_og_gjeld.kortsiktig_gjeld.annen_kortsiktig_gjeld)}",
         f"    Sum kortsiktig gjeld          {_nok(b.egenkapital_og_gjeld.kortsiktig_gjeld.sum)}",
@@ -396,7 +380,7 @@ def generer(regnskap: Aarsregnskap, konfig: SkattemeldingKonfig) -> str:
         s = ak + ok + aek
         return f"  {label:<20}{_ekk(ak)}{_ekk(ok)}{_ekk(aek)}{_ekk(s)}"
 
-    aarsresultat = resultat_foer_skatt - beregnet_skatt
+    aarsresultat = r.aarsresultat
     ek_ub = b.egenkapital_og_gjeld.egenkapital
 
     linjer += [
@@ -435,12 +419,26 @@ def generer(regnskap: Aarsregnskap, konfig: SkattemeldingKonfig) -> str:
     else:
         linjer.append(f"  ADVARSEL: Balansen stemmer ikke! Differanse: {_nok(differanse)}")
 
-    if beregnet_skatt > 0:
+    # Kontroll av ført skattekostnad mot beregningen. Wenche fastsetter ikke tallet
+    # (beregningen modellerer ikke utsatt skatt eller andre permanente forskjeller enn
+    # fritaksmetoden), men et sprik er verdt å se før innsending.
+    avvik_skatt = round(skattekostnad) - round(beregnet_skatt)
+    if beregnet_skatt > 0 and round(skattekostnad) == 0:
         linjer += [
             "",
-            f"  NB: Beregnet skatt er {_nok(beregnet_skatt).strip()}. Husk å føre dette",
-            "  som «Skyldig skatt» (konto 2500) under kortsiktig gjeld i balansen,",
-            "  og kontroller at balansen fortsatt går opp.",
+            f"  NB: Beregnet skatt er {_nok(beregnet_skatt).strip()}, men det er ikke ført",
+            "  noen skattekostnad i resultatregnskapet. Regnskapsloven § 6-1 krever egen",
+            "  linje for skattekostnad før årsresultatet. Fyll inn «Skattekostnad» under",
+            "  resultatregnskapet, og «Betalbar skatt» (konto 2500) under kortsiktig gjeld",
+            "  hvis skatten ikke er betalt ved årsslutt.",
+        ]
+    elif avvik_skatt != 0 and (beregnet_skatt > 0 or round(skattekostnad) != 0):
+        linjer += [
+            "",
+            f"  NB: Ført skattekostnad er {_nok(skattekostnad).strip()}, mens Wenche beregner",
+            f"  {_nok(beregnet_skatt).strip()} ({_nok(avvik_skatt).strip()} i avvik). Kontroller tallet.",
+            "  Avvik er ikke nødvendigvis feil: beregningen dekker ikke utsatt skatt eller",
+            "  andre permanente forskjeller enn fritaksmetoden.",
         ]
 
     linjer += [

--- a/wenche/skattemelding_xml.py
+++ b/wenche/skattemelding_xml.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 from xml.etree.ElementTree import Element, SubElement, fromstring, tostring
 
 from wenche.models import Aarsregnskap, SkattemeldingKonfig
+from wenche.skatteberegning import beregn_skatt
 
 _NS = (
     "urn:no:skatteetaten:fastsetting:formueinntekt:"
@@ -243,7 +244,14 @@ def generer_skattemelding_fra_konfig(
     verdi_foer_rabatt, samlet_gjeld = beregn_formue_inputs(regnskap, konfig)
     # Årets underskudd som positiv kroner-magnitude. For et overskuddsår
     # (eller nullresultat) blir det 0 og underskuddsbaserte felter utelates.
-    aarets_underskudd = max(0, int(round(-regnskap.resultatregnskap.aarsresultat)))
+    #
+    # Grunnlaget er den skattepliktige inntekten, samme definisjon som
+    # næringsspesifikasjonens skattemessige resultat. Regnskapets resultat er ikke
+    # riktig grunnlag: et holdingselskap med fritatt utbytte og kostnader kan ha
+    # regnskapsmessig overskudd og skattemessig underskudd samtidig. Brukte vi resultat
+    # før skatt, ville et slikt selskap mistet underskuddet til fremføring.
+    beregning = beregn_skatt(regnskap.resultatregnskap, konfig)
+    aarets_underskudd = max(0, int(round(-beregning.skattepliktig_inntekt_brutto)))
     return generer_skattemelding_upersonlig(
         partsnummer=partsnummer,
         inntektsaar=regnskap.regnskapsaar,

--- a/wenche/web/backend/ruter_dokumenter.py
+++ b/wenche/web/backend/ruter_dokumenter.py
@@ -57,6 +57,22 @@ def dok_skattemelding(config: dict[str, Any] = Body(...)) -> dict:
     return {"filer": [_fil(navn, tekst.encode("utf-8"), "text/plain; charset=utf-8")]}
 
 
+@router.post("/skatteberegning")
+def dok_skatteberegning(config: dict[str, Any] = Body(...)) -> dict:
+    """Beregnet skatt fra tallene i skjemaet, som forslag til skattekostnad-feltet.
+
+    Beregner og returnerer, lagrer ingenting: brukeren avgjør selv om forslaget skal føres
+    (samme forhåndsfyll-prinsipp som SAF-T-importen). Gjenbruker skattemelding.beregn_skatt
+    så forslaget ikke kan drifte fra tallet visningen viser.
+    """
+    beregning, foert = sm.beregn_skatt_fra_config(config)
+    return {
+        "beregnet_skatt": round(beregning.beregnet_skatt),
+        "skattepliktig_inntekt": round(beregning.skattepliktig_inntekt_netto),
+        "foert_skattekostnad": round(foert),
+    }
+
+
 @router.post("/aarsregnskap")
 def dok_aarsregnskap(config: dict[str, Any] = Body(...)) -> dict:
     config = miljo.med_test_org(config)

--- a/wenche/web/frontend/src/Tall.tsx
+++ b/wenche/web/frontend/src/Tall.tsx
@@ -40,6 +40,7 @@ export default function Tall({
           visEksempel={env === "test"}
           initial={config ?? undefined}
           importerSaft={api.importerSaft}
+          beregnSkatt={(c) => api.dokument("skatteberegning", c)}
           saftMerknad="SAF-T-filen behandles lokalt på din egen maskin og lagres ikke."
           ekstraSeksjon={<NoterSeksjon noter={noter} setNoter={setNoter} />}
         />


### PR DESCRIPTION
## Bakgrunn

En bruker med to holdingselskaper rapporterte to feil i innsendingen. Begge er reelle, og den ene viste seg å ha en tredje feil bak seg.

## Endringer

**Skattekostnad som egen linje (rskl. § 6-1).** Modellen regnet resultat før skatt som årsresultat direkte, altså implisitt skattekostnad 0. Et passivt holdingselskap med renteinntekt har en reell skattekostnad, og årsresultatet ble rapportert for høyt til både Brønnøysund og Skatteetaten. Nytt felt `skattekostnad`, med `betalbar_skatt` som motpost i balansen.

**Riktig skattegrunnlag i næringsspesifikasjonen.** Skatteetaten utleder skattemessig resultat som årsresultat pluss permanente forskjeller, så hver forskjell må emitteres eksplisitt. Skattekostnaden tilbakeføres, og utbytte fritatt etter fritaksmetoden tilbakeføres med 3 %-sjablonen lagt til igjen. Uten dette oppgav næringsspesifikasjonen brutto utbytte som skattepliktig inntekt, altså en innsending som påsto et skattegrunnlag som ikke stemte med sin egen skattekostnad. Skatteberegningen er skilt ut i egen modul så de tre kallstedene deler én definisjon.

**Forlenget første regnskapsår (rskl. § 1-7).** Perioden var hardkodet til 1. januar til 31. desember. Kan nå oppgis med `regnskapsstart` og `regnskapsslutt`, med validering av 18-månedersgrensen. Enhetsregister-oppslaget beholder nå hele stiftelsesdatoen, som også retter at aksjonærregisteroppgaven oppgav 1. januar for alle selskap.

**SAF-T-importen** droppet skattekostnaden i det stille, slik at balansen ikke gikk opp etter import. Betalbar skatt flyttet fra skyldige offentlige avgifter til egen linje; summen av kortsiktig gjeld er uendret.

**Skjemaet** har fått feltene, og en knapp som foreslår skattekostnaden fra kjernens egen beregning. Forslaget føres aldri automatisk.

Alle nye felt er 0 eller tomme som standard, så et regnskap uten skattepliktig inntekt og med vanlig kalenderår gir innholdsmessig identisk innsending som før.

## Vurdert og avslått

**To separate PR-er.** Endringene er sammenvevd i samme funksjoner i fem filer. Å skille dem krevde patch-kirurgi som risikerte å committe noe annet enn det som faktisk er verifisert mot myndighetene. De er i stedet delt i commits som kan reverteres uavhengig.

**Å utsette fritaksmetoden til eget issue.** Den ble mer synlig av skattekostnad-linjen: brukeren får nå et skattetall som stod i motstrid til grunnlaget. Halv fiks var dårligere enn ingen.

## Test plan

- [x] 588 tester (var 505), hver commit verifisert grønn hver for seg i egen worktree
- [x] Skattemelding validert mot tt02 i fire varianter (renteinntekt, utbytte med og uten sjablonregel, skattemessig underskudd), hver med baseline for å skille nye avvik fra kjente. Alle `validertOK`
- [x] Fritatt utbytte: SKD beregner nå 30 000 der de før beregnet 1 000 000
- [x] Hvilende selskap som kontroll: fortsatt `validertOK` uten avvik
- [x] 14-måneders periode: `validertOK` uten avvik, inntektsår lik sluttåret
- [x] Årsregnskap sendt til Altinn tt02 i to varianter; BRGs egen PDF viser riktige linjer, beløp og periodedatoer
- [x] Orid-verdier og plassering verifisert mot Brønnøysunds skjema, koder mot Skatteetatens kodelister
- [x] Begge SPA-ene bygger, blanke tallfelt normaliseres som før